### PR TITLE
Feat/reschedule

### DIFF
--- a/__tests__/FSRSV4.test.ts
+++ b/__tests__/FSRSV4.test.ts
@@ -9,6 +9,7 @@ import {
   Grades, default_request_retention, default_maximum_interval, default_enable_fuzz, default_w,
 } from "../src/fsrs";
 import { FSRSAlgorithm } from "../src/fsrs/algorithm";
+import { get_fuzz_range } from "../src/fsrs";
 
 describe("initial FSRS V4", () => {
   const params = generatorParameters();
@@ -55,26 +56,29 @@ describe("initial FSRS V4", () => {
 
 describe("FSRS apply_fuzz", () => {
   test("return original interval when fuzzing is disabled", () => {
-    const ivl = 3.0;
+    const ivl = 3.2;
     const enable_fuzz = false;
     const algorithm = new FSRS({ enable_fuzz: enable_fuzz });
-    expect(algorithm.apply_fuzz(ivl)).toBe(3);
+    expect(algorithm.apply_fuzz(ivl, 0)).toBe(3);
   });
 
   test("return original interval when ivl is less than 2.5", () => {
-    const ivl = 2.0;
+    const ivl = 2.3;
     const enable_fuzz = true;
     const algorithm = new FSRS({ enable_fuzz: enable_fuzz });
-    expect(algorithm.apply_fuzz(ivl)).toBe(2);
+    expect(algorithm.apply_fuzz(ivl, 0)).toBe(2);
   });
 
   test("return original interval when ivl is less than 2.5", () => {
     const ivl = 2.5;
     const enable_fuzz = true;
     const algorithm = new FSRSAlgorithm({ enable_fuzz: enable_fuzz });
-    const min_ivl = Math.max(2, Math.round(ivl * 0.95 - 1));
-    const max_ivl = Math.round(ivl * 1.05 + 1);
-    const fuzzedInterval = algorithm.apply_fuzz(ivl);
+    const { min_ivl, max_ivl } = get_fuzz_range(
+      ivl,
+      0,
+      default_maximum_interval,
+    );
+    const fuzzedInterval = algorithm.apply_fuzz(ivl, 0);
     expect(fuzzedInterval).toBeGreaterThanOrEqual(min_ivl);
     expect(fuzzedInterval).toBeLessThanOrEqual(max_ivl);
   });

--- a/__tests__/reschedule.test.ts
+++ b/__tests__/reschedule.test.ts
@@ -1,0 +1,125 @@
+import {
+  Card,
+  createEmptyCard,
+  date_scheduler,
+  fsrs,
+  FSRS,
+  State,
+} from "../src/fsrs";
+
+describe("FSRS reschedule", () => {
+  const f: FSRS = fsrs({
+    enable_fuzz: false,
+  });
+
+  type CardType = Card & {
+    cid: number;
+  };
+
+  function cardHandler(card: Card) {
+    (card as CardType)["cid"] = 1;
+    return card as CardType;
+  }
+
+  const newCard = createEmptyCard(undefined, cardHandler);
+  const learningCard: CardType = {
+    cid: 1,
+    due: new Date(),
+    stability: 0.6,
+    difficulty: 5.87,
+    elapsed_days: 0,
+    scheduled_days: 0,
+    reps: 1,
+    lapses: 0,
+    state: State.Learning,
+    last_review: new Date("2024-03-08 05:00:00"),
+  };
+  const reviewCard: CardType = {
+    cid: 1,
+    due: new Date("2024-03-17 04:43:02"),
+    stability: 48.26139059062234,
+    difficulty: 5.67,
+    elapsed_days: 18,
+    scheduled_days: 51,
+    reps: 8,
+    lapses: 1,
+    state: State.Review,
+    last_review: new Date("2024-01-26 04:43:02"),
+  };
+  const relearningCard: CardType = {
+    cid: 1,
+    due: new Date("2024-02-15 08:43:05"),
+    stability: 0.27,
+    difficulty: 10,
+    elapsed_days: 2,
+    scheduled_days: 0,
+    reps: 42,
+    lapses: 8,
+    state: State.Relearning,
+    last_review: new Date("2024-02-15 08:38:05"),
+  };
+
+  function dateHandler(date: Date) {
+    return date.getTime();
+  }
+
+  const cards = [newCard, learningCard, reviewCard, relearningCard];
+  it("reschedule", () => {
+    const reschedule_cards = f.reschedule(cards);
+    if (reschedule_cards.length > 0) {
+      // next_ivl !== scheduled_days
+      expect(reschedule_cards[0].cid).toBeGreaterThanOrEqual(1);
+      const min_ivl = Math.max(2, Math.round(reviewCard.stability * 0.95 - 1));
+      const max_ivl = Math.round(reviewCard.stability * 1.05 + 1);
+      expect(reschedule_cards[0].scheduled_days).toBeGreaterThanOrEqual(
+        min_ivl,
+      );
+      expect(reschedule_cards[0].scheduled_days).toBeLessThanOrEqual(max_ivl);
+      expect(reschedule_cards[0].due).toEqual(
+        date_scheduler(
+          reviewCard.last_review!,
+          reschedule_cards[0].scheduled_days,
+          true,
+        ),
+      );
+    }
+  });
+
+  it("reschedule[dateHandler]", () => {
+    const [rescheduleCard] = f.reschedule([reviewCard], {
+      dateHandler,
+    });
+    if (rescheduleCard) {
+      // next_ivl !== scheduled_days
+      expect(rescheduleCard.cid).toBeGreaterThanOrEqual(1);
+      const min_ivl = Math.max(2, Math.round(reviewCard.stability * 0.95 - 1));
+      const max_ivl = Math.round(reviewCard.stability * 1.05 + 1);
+      expect(rescheduleCard.scheduled_days).toBeGreaterThanOrEqual(min_ivl);
+      expect(rescheduleCard.scheduled_days).toBeLessThanOrEqual(max_ivl);
+      expect(rescheduleCard.due as unknown as number).toEqual(
+        date_scheduler(
+          reviewCard.last_review!,
+          rescheduleCard.scheduled_days,
+          true,
+        ).getTime(),
+      );
+      expect(typeof rescheduleCard.due).toEqual("number");
+    }
+  });
+
+  it("reschedule[next_ivl === scheduled_days]", () => {
+    const reschedule_cards = f.reschedule([{
+      cid: 1,
+      due: new Date("2024-03-13 04:43:02"),
+      stability: 48.26139059062234,
+      difficulty: 5.67,
+      elapsed_days: 18,
+      scheduled_days: 48,
+      reps: 8,
+      lapses: 1,
+      state: State.Review,
+      last_review: new Date("2024-01-26 04:43:02"),
+    }], { enable_fuzz: false });
+    expect(reschedule_cards.length).toEqual(0);
+  });
+});

--- a/__tests__/reschedule.test.ts
+++ b/__tests__/reschedule.test.ts
@@ -2,15 +2,16 @@ import {
   Card,
   createEmptyCard,
   date_scheduler,
+  default_request_retention,
   fsrs,
   FSRS,
   State,
 } from "../src/fsrs";
 
 describe("FSRS reschedule", () => {
-  const f: FSRS = fsrs({
-    enable_fuzz: false,
-  });
+  const DECAY: number = -0.5;
+  const FACTOR: number = Math.pow(0.9, 1 / DECAY) - 1;
+  const request_retentions = [default_request_retention, 0.95, 0.85, 0.8];
 
   type CardType = Card & {
     cid: number;
@@ -65,61 +66,88 @@ describe("FSRS reschedule", () => {
 
   const cards = [newCard, learningCard, reviewCard, relearningCard];
   it("reschedule", () => {
-    const reschedule_cards = f.reschedule(cards);
-    if (reschedule_cards.length > 0) {
-      // next_ivl !== scheduled_days
-      expect(reschedule_cards[0].cid).toBeGreaterThanOrEqual(1);
-      const min_ivl = Math.max(2, Math.round(reviewCard.stability * 0.95 - 1));
-      const max_ivl = Math.round(reviewCard.stability * 1.05 + 1);
-      expect(reschedule_cards[0].scheduled_days).toBeGreaterThanOrEqual(
-        min_ivl,
-      );
-      expect(reschedule_cards[0].scheduled_days).toBeLessThanOrEqual(max_ivl);
-      expect(reschedule_cards[0].due).toEqual(
-        date_scheduler(
-          reviewCard.last_review!,
-          reschedule_cards[0].scheduled_days,
-          true,
-        ),
-      );
+    for (const requestRetention of request_retentions) {
+      const f: FSRS = fsrs({ request_retention: requestRetention });
+      const intervalModifier =
+        (Math.pow(requestRetention, 1 / DECAY) - 1) / FACTOR;
+      const reschedule_cards = f.reschedule(cards);
+      if (reschedule_cards.length > 0) {
+        // next_ivl !== scheduled_days
+        expect(reschedule_cards.length).toBeGreaterThanOrEqual(1);
+        expect(reschedule_cards[0].cid).toBeGreaterThanOrEqual(1);
+        const min_ivl = Math.max(
+          2,
+          Math.round(reviewCard.stability * intervalModifier * 0.95 - 1),
+        );
+        const max_ivl = Math.round(
+          reviewCard.stability * intervalModifier * 1.05 + 1,
+        );
+        expect(reschedule_cards[0].scheduled_days).toBeGreaterThanOrEqual(
+          min_ivl,
+        );
+        expect(reschedule_cards[0].scheduled_days).toBeLessThanOrEqual(max_ivl);
+        expect(reschedule_cards[0].due).toEqual(
+          date_scheduler(
+            reviewCard.last_review!,
+            reschedule_cards[0].scheduled_days,
+            true,
+          ),
+        );
+      }
     }
   });
 
   it("reschedule[dateHandler]", () => {
-    const [rescheduleCard] = f.reschedule([reviewCard], {
-      dateHandler,
-    });
-    if (rescheduleCard) {
-      // next_ivl !== scheduled_days
-      expect(rescheduleCard.cid).toBeGreaterThanOrEqual(1);
-      const min_ivl = Math.max(2, Math.round(reviewCard.stability * 0.95 - 1));
-      const max_ivl = Math.round(reviewCard.stability * 1.05 + 1);
-      expect(rescheduleCard.scheduled_days).toBeGreaterThanOrEqual(min_ivl);
-      expect(rescheduleCard.scheduled_days).toBeLessThanOrEqual(max_ivl);
-      expect(rescheduleCard.due as unknown as number).toEqual(
-        date_scheduler(
-          reviewCard.last_review!,
-          rescheduleCard.scheduled_days,
-          true,
-        ).getTime(),
-      );
-      expect(typeof rescheduleCard.due).toEqual("number");
+    for (const requestRetention of request_retentions) {
+      const f: FSRS = fsrs({ request_retention: requestRetention });
+      const intervalModifier =
+        (Math.pow(requestRetention, 1 / DECAY) - 1) / FACTOR;
+      const [rescheduleCard] = f.reschedule([reviewCard], {
+        dateHandler,
+      });
+      if (rescheduleCard) {
+        // next_ivl !== scheduled_days
+        expect(rescheduleCard.cid).toBeGreaterThanOrEqual(1);
+        const min_ivl = Math.max(
+          2,
+          Math.round(reviewCard.stability * intervalModifier * 0.95 - 1),
+        );
+        const max_ivl = Math.round(
+          reviewCard.stability * intervalModifier * 1.05 + 1,
+        );
+        expect(rescheduleCard.scheduled_days).toBeGreaterThanOrEqual(min_ivl);
+        expect(rescheduleCard.scheduled_days).toBeLessThanOrEqual(max_ivl);
+        expect(rescheduleCard.due as unknown as number).toEqual(
+          date_scheduler(
+            reviewCard.last_review!,
+            rescheduleCard.scheduled_days,
+            true,
+          ).getTime(),
+        );
+        expect(typeof rescheduleCard.due).toEqual("number");
+      }
     }
   });
 
   it("reschedule[next_ivl === scheduled_days]", () => {
-    const reschedule_cards = f.reschedule([{
-      cid: 1,
-      due: new Date("2024-03-13 04:43:02"),
-      stability: 48.26139059062234,
-      difficulty: 5.67,
-      elapsed_days: 18,
-      scheduled_days: 48,
-      reps: 8,
-      lapses: 1,
-      state: State.Review,
-      last_review: new Date("2024-01-26 04:43:02"),
-    }], { enable_fuzz: false });
+    const f: FSRS = fsrs();
+    const reschedule_cards = f.reschedule(
+      [
+        {
+          cid: 1,
+          due: new Date("2024-03-13 04:43:02"),
+          stability: 48.26139059062234,
+          difficulty: 5.67,
+          elapsed_days: 18,
+          scheduled_days: 48,
+          reps: 8,
+          lapses: 1,
+          state: State.Review,
+          last_review: new Date("2024-01-26 04:43:02"),
+        },
+      ],
+      { enable_fuzz: false },
+    );
     expect(reschedule_cards.length).toEqual(0);
   });
 });

--- a/__tests__/reschedule.test.ts
+++ b/__tests__/reschedule.test.ts
@@ -2,11 +2,13 @@ import {
   Card,
   createEmptyCard,
   date_scheduler,
+  default_maximum_interval,
   default_request_retention,
   fsrs,
   FSRS,
   State,
 } from "../src/fsrs";
+import { get_fuzz_range } from "../src/fsrs";
 
 describe("FSRS reschedule", () => {
   const DECAY: number = -0.5;
@@ -75,12 +77,11 @@ describe("FSRS reschedule", () => {
         // next_ivl !== scheduled_days
         expect(reschedule_cards.length).toBeGreaterThanOrEqual(1);
         expect(reschedule_cards[0].cid).toBeGreaterThanOrEqual(1);
-        const min_ivl = Math.max(
-          2,
-          Math.round(reviewCard.stability * intervalModifier * 0.95 - 1),
-        );
-        const max_ivl = Math.round(
-          reviewCard.stability * intervalModifier * 1.05 + 1,
+
+        const { min_ivl, max_ivl } = get_fuzz_range(
+          reviewCard.stability * intervalModifier,
+          reviewCard.elapsed_days,
+          default_maximum_interval,
         );
         expect(reschedule_cards[0].scheduled_days).toBeGreaterThanOrEqual(
           min_ivl,
@@ -108,13 +109,12 @@ describe("FSRS reschedule", () => {
       if (rescheduleCard) {
         // next_ivl !== scheduled_days
         expect(rescheduleCard.cid).toBeGreaterThanOrEqual(1);
-        const min_ivl = Math.max(
-          2,
-          Math.round(reviewCard.stability * intervalModifier * 0.95 - 1),
+        const { min_ivl, max_ivl } = get_fuzz_range(
+          reviewCard.stability * intervalModifier,
+          reviewCard.elapsed_days,
+          default_maximum_interval,
         );
-        const max_ivl = Math.round(
-          reviewCard.stability * intervalModifier * 1.05 + 1,
-        );
+
         expect(rescheduleCard.scheduled_days).toBeGreaterThanOrEqual(min_ivl);
         expect(rescheduleCard.scheduled_days).toBeLessThanOrEqual(max_ivl);
         expect(rescheduleCard.due as unknown as number).toEqual(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-fsrs",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "description": "ts-fsrs is a ES modules package based on TypeScript, used to implement the Free Spaced Repetition Scheduler (FSRS) algorithm. It helps developers apply FSRS to their flashcard applications, there by improving the user learning experience.",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/src/fsrs/algorithm.ts
+++ b/src/fsrs/algorithm.ts
@@ -102,10 +102,11 @@ export class FSRSAlgorithm {
   /**
    * If fuzzing is disabled or ivl is less than 2.5, it returns the original interval.
    * @param {number} ivl - The interval to be fuzzed.
+   * @param {number} enable_fuzz - This adds a small random delay to the new interval time to prevent cards from sticking together and always being reviewed on the same day.
    * @return {number} - The fuzzed interval.
    **/
-  apply_fuzz(ivl: number): number {
-    if (!this.param.enable_fuzz || ivl < 2.5) return ivl;
+  apply_fuzz(ivl: number, enable_fuzz?: boolean): number {
+    if (!enable_fuzz || ivl < 2.5) return ivl;
     const generator = pseudorandom(this.seed);
     const fuzz_factor = generator();
     ivl = Math.round(ivl);
@@ -119,9 +120,10 @@ export class FSRSAlgorithm {
    *   constructor(param: Partial<FSRSParameters>)
    *   this.intervalModifier = 9 * (1 / this.param.request_retention - 1);
    *   @param {number} s - Stability (interval when R=90%)
+   *   @param {number} enable_fuzz - This adds a small random delay to the new interval time to prevent cards from sticking together and always being reviewed on the same day.
    */
-  next_interval(s: number): int {
-    const newInterval = this.apply_fuzz(s * this.intervalModifier);
+  next_interval(s: number, enable_fuzz: boolean = this.param.enable_fuzz): int {
+    const newInterval = this.apply_fuzz(s * this.intervalModifier, enable_fuzz);
     return Math.min(
       Math.max(Math.round(newInterval), 1),
       this.param.maximum_interval,

--- a/src/fsrs/algorithm.ts
+++ b/src/fsrs/algorithm.ts
@@ -3,6 +3,7 @@ import { generatorParameters } from "./default";
 import {SchedulingCard} from './scheduler'
 import {FSRSParameters, Grade, Rating} from "./models";
 import type { int } from "./type";
+import { get_fuzz_range } from "./help";
 
 // Ref: https://github.com/open-spaced-repetition/fsrs4anki/wiki/The-Algorithm#fsrs-v4
 export class FSRSAlgorithm {
@@ -102,17 +103,20 @@ export class FSRSAlgorithm {
   /**
    * If fuzzing is disabled or ivl is less than 2.5, it returns the original interval.
    * @param {number} ivl - The interval to be fuzzed.
+   * @param {number} elapsed_days t days since the last review
    * @param {number} enable_fuzz - This adds a small random delay to the new interval time to prevent cards from sticking together and always being reviewed on the same day.
    * @return {number} - The fuzzed interval.
    **/
-  apply_fuzz(ivl: number, enable_fuzz?: boolean): number {
-    if (!enable_fuzz || ivl < 2.5) return ivl;
+  apply_fuzz(ivl: number, elapsed_days: number, enable_fuzz?: boolean): int {
+    if (!enable_fuzz || ivl < 2.5) return Math.round(ivl) as int;
     const generator = pseudorandom(this.seed);
     const fuzz_factor = generator();
-    ivl = Math.round(ivl);
-    const min_ivl = Math.max(2, Math.round(ivl * 0.95 - 1));
-    const max_ivl = Math.round(ivl * 1.05 + 1);
-    return Math.floor(fuzz_factor * (max_ivl - min_ivl + 1) + min_ivl);
+    const { min_ivl, max_ivl } = get_fuzz_range(
+      ivl,
+      elapsed_days,
+      this.param.maximum_interval,
+    );
+    return Math.floor(fuzz_factor * (max_ivl - min_ivl + 1) + min_ivl) as int;
   }
 
   /**
@@ -120,14 +124,19 @@ export class FSRSAlgorithm {
    *   constructor(param: Partial<FSRSParameters>)
    *   this.intervalModifier = 9 * (1 / this.param.request_retention - 1);
    *   @param {number} s - Stability (interval when R=90%)
+   *   @param {number} elapsed_days t days since the last review
    *   @param {number} enable_fuzz - This adds a small random delay to the new interval time to prevent cards from sticking together and always being reviewed on the same day.
    */
-  next_interval(s: number, enable_fuzz: boolean = this.param.enable_fuzz): int {
-    const newInterval = this.apply_fuzz(s * this.intervalModifier, enable_fuzz);
-    return Math.min(
-      Math.max(Math.round(newInterval), 1),
-      this.param.maximum_interval,
+  next_interval(
+    s: number,
+    elapsed_days: number,
+    enable_fuzz: boolean = this.param.enable_fuzz,
+  ): int {
+    const newInterval = Math.max(
+      1,
+      Math.round(s * this.intervalModifier),
     ) as int;
+    return this.apply_fuzz(newInterval, elapsed_days, enable_fuzz);
   }
 
   /**

--- a/src/fsrs/default.ts
+++ b/src/fsrs/default.ts
@@ -9,7 +9,7 @@ export const default_w = [
 ];
 export const default_enable_fuzz = false;
 
-export const FSRSVersion: string = "3.4.1";
+export const FSRSVersion: string = "3.5.0";
 
 export const generatorParameters = (
   props?: Partial<FSRSParameters>,

--- a/src/fsrs/fsrs.ts
+++ b/src/fsrs/fsrs.ts
@@ -343,6 +343,32 @@ export class FSRS extends FSRSAlgorithm {
     }
   }
 
+  /**
+   *
+   * @param cards scheduled card collection
+   * @param options Reschedule options,fuzz is enabled by default.If the type of due is not Date, please implement dataHandler.
+   * @example
+   * ```typescript
+   * type CardType = Card & {
+   *     cid: number;
+   * };
+   * const reviewCard: CardType = {
+   *     cid: 1,
+   *     due: new Date("2024-03-17 04:43:02"),
+   *     stability: 48.26139059062234,
+   *     difficulty: 5.67,
+   *     elapsed_days: 18,
+   *     scheduled_days: 51,
+   *     reps: 8,
+   *     lapses: 1,
+   *     state: State.Review,
+   *     last_review: new Date("2024-01-26 04:43:02"),
+   * };
+   * const f = fsrs();
+   * const reschedule_cards = f.reschedule([reviewCard]);
+   * ```
+   *
+   */
   reschedule<T extends CardInput | Card>(
     cards: Array<T>,
     options: RescheduleOptions = {},

--- a/src/fsrs/fsrs.ts
+++ b/src/fsrs/fsrs.ts
@@ -119,16 +119,16 @@ export class FSRS extends FSRSAlgorithm {
         s.again.due = now.scheduler(1 as int);
         s.hard.due = now.scheduler(5 as int);
         s.good.due = now.scheduler(10 as int);
-        easy_interval = this.next_interval(s.easy.stability);
+        easy_interval = this.next_interval(s.easy.stability,processedCard.elapsed_days);
         s.easy.scheduled_days = easy_interval;
         s.easy.due = now.scheduler(easy_interval, true);
         break;
       case State.Learning:
       case State.Relearning:
         hard_interval = 0;
-        good_interval = this.next_interval(s.good.stability);
+        good_interval = this.next_interval(s.good.stability,processedCard.elapsed_days);
         easy_interval = Math.max(
-          this.next_interval(s.easy.stability),
+          this.next_interval(s.easy.stability,processedCard.elapsed_days),
           good_interval + 1,
         );
         s.schedule(now, hard_interval, good_interval, easy_interval);
@@ -139,12 +139,12 @@ export class FSRS extends FSRSAlgorithm {
         const last_s = processedCard.stability;
         const retrievability = this.forgetting_curve(interval, last_s);
         this.next_ds(s, last_d, last_s, retrievability);
-        hard_interval = this.next_interval(s.hard.stability);
-        good_interval = this.next_interval(s.good.stability);
+        hard_interval = this.next_interval(s.hard.stability,processedCard.elapsed_days);
+        good_interval = this.next_interval(s.good.stability,processedCard.elapsed_days);
         hard_interval = Math.min(hard_interval, good_interval);
         good_interval = Math.max(good_interval, hard_interval + 1);
         easy_interval = Math.max(
-          this.next_interval(s.easy.stability),
+          this.next_interval(s.easy.stability,processedCard.elapsed_days),
           good_interval + 1,
         );
         s.schedule(now, hard_interval, good_interval, easy_interval);
@@ -353,6 +353,7 @@ export class FSRS extends FSRSAlgorithm {
       const scheduled_days = Math.floor(card.scheduled_days) as int;
       const next_ivl = this.next_interval(
         +card.stability.toFixed(2),
+        Math.round(card.elapsed_days),
         options.enable_fuzz ?? true,
       );
       if (next_ivl === scheduled_days || next_ivl === 0) continue;

--- a/src/fsrs/fsrs.ts
+++ b/src/fsrs/fsrs.ts
@@ -113,38 +113,38 @@ export class FSRS extends FSRSAlgorithm {
     );
     this.seed = String(now.getTime()) + String(processedCard.reps);
     let easy_interval, good_interval, hard_interval;
+    const interval = processedCard.elapsed_days;
     switch (processedCard.state) {
       case State.New:
         this.init_ds(s);
         s.again.due = now.scheduler(1 as int);
         s.hard.due = now.scheduler(5 as int);
         s.good.due = now.scheduler(10 as int);
-        easy_interval = this.next_interval(s.easy.stability,processedCard.elapsed_days);
+        easy_interval = this.next_interval(s.easy.stability, interval);
         s.easy.scheduled_days = easy_interval;
         s.easy.due = now.scheduler(easy_interval, true);
         break;
       case State.Learning:
       case State.Relearning:
         hard_interval = 0;
-        good_interval = this.next_interval(s.good.stability,processedCard.elapsed_days);
+        good_interval = this.next_interval(s.good.stability, interval);
         easy_interval = Math.max(
-          this.next_interval(s.easy.stability,processedCard.elapsed_days),
+          this.next_interval(s.easy.stability, interval),
           good_interval + 1,
         );
         s.schedule(now, hard_interval, good_interval, easy_interval);
         break;
       case State.Review: {
-        const interval = processedCard.elapsed_days;
         const last_d = processedCard.difficulty;
         const last_s = processedCard.stability;
         const retrievability = this.forgetting_curve(interval, last_s);
         this.next_ds(s, last_d, last_s, retrievability);
-        hard_interval = this.next_interval(s.hard.stability,processedCard.elapsed_days);
-        good_interval = this.next_interval(s.good.stability,processedCard.elapsed_days);
+        hard_interval = this.next_interval(s.hard.stability, interval);
+        good_interval = this.next_interval(s.good.stability, interval);
         hard_interval = Math.min(hard_interval, good_interval);
         good_interval = Math.max(good_interval, hard_interval + 1);
         easy_interval = Math.max(
-          this.next_interval(s.easy.stability,processedCard.elapsed_days),
+          this.next_interval(s.easy.stability, interval),
           good_interval + 1,
         );
         s.schedule(now, hard_interval, good_interval, easy_interval);

--- a/src/fsrs/help.ts
+++ b/src/fsrs/help.ts
@@ -160,3 +160,41 @@ export function fixRating(value: unknown): Rating {
 
 
 export const Grades: Grade[] = [Rating.Again, Rating.Hard, Rating.Good, Rating.Easy];
+
+const FUZZ_RANGES = [
+  {
+    start: 2.5,
+    end: 7.0,
+    factor: 0.15,
+  },
+  {
+    start: 7.0,
+    end: 20.0,
+    factor: 0.1,
+  },
+  {
+    start: 20.0,
+    end: Infinity,
+    factor: 0.05,
+  },
+] as const;
+
+export function get_fuzz_range(
+  interval: number,
+  elapsed_days: number,
+  maximum_interval: number,
+) {
+  let delta = 1.0;
+  for (const range of FUZZ_RANGES) {
+    delta +=
+      range.factor * Math.max(Math.min(interval, range.end) - range.start, 0.0);
+  }
+  interval = Math.min(interval, maximum_interval);
+  let min_ivl = Math.max(2, Math.round(interval - delta));
+  const max_ivl = Math.min(Math.round(interval + delta), maximum_interval);
+  if (interval > elapsed_days) {
+    min_ivl = Math.max(min_ivl, elapsed_days + 1);
+  }
+  min_ivl = Math.min(min_ivl, max_ivl);
+  return { min_ivl, max_ivl };
+}

--- a/src/fsrs/index.ts
+++ b/src/fsrs/index.ts
@@ -1,25 +1,10 @@
-export { SchedulingCard } from "./scheduler";
-export {
-  default_request_retention,
-  default_maximum_interval,
-  default_w,
-  default_enable_fuzz,
-  FSRSVersion,
-  generatorParameters,
-  createEmptyCard
-} from "./default";
-export {
-  date_scheduler,
-  date_diff,
-  formatDate,
-  show_diff_message,
-  fixState,
-  fixDate,
-  fixRating,
-  Grades
-} from "./help";
+export * from "./scheduler";
+export * from "./default";
+export * from "./help";
+export * from "./algorithm"
+export * from "./fsrs";
 
-export type { int, double } from "./type";
+export type * from "./type";
 export type {
   FSRSParameters,
   Card,
@@ -34,4 +19,3 @@ export type {
   DateInput
 } from "./models";
 export { State, Rating } from "./models";
-export { FSRS,fsrs } from "./fsrs";

--- a/src/fsrs/models.ts
+++ b/src/fsrs/models.ts
@@ -75,3 +75,8 @@ export interface FSRSParameters {
   w: number[];
   enable_fuzz: boolean;
 }
+
+export type RescheduleOptions = {
+  enable_fuzz?: boolean;
+  dateHandler?: (date: Date) => DateInput;
+};


### PR DESCRIPTION
增加重排功能，根据`Card`当前的`stability`、`last_review `和期望的`request_retentions`来进行重排。
`f. reschedule`方法：
- 会根据传入的类型来决定返回的类型，并允许用户传入`options.dateHandler`来解决日期类型转换问题
- 排除卡片状态为`State.New`、`State.Learning`、`State.Relearning`数据
- 默认启用`enable_fuzz`来进行重排，允许用户传入`options.enable_fuzz=false`来关闭抖动
- 仅返回需要重排的卡片集合

@L-M-Sherlock 叶大，麻烦看看这样设计有没有问题？
目前期望该方法能够在变更`enable_fuzz`后对没开启前的卡片进行重排产生一定的随机延迟间隔。