### PR TITLE
Test/update algorithm test

### DIFF
--- a/__tests__/FSRSV4.test.ts
+++ b/__tests__/FSRSV4.test.ts
@@ -1,88 +1,12 @@
 import {
   fsrs,
   Rating,
-  generatorParameters,
   FSRS,
   createEmptyCard,
   State,
   Grade,
-  Grades, default_request_retention, default_maximum_interval, default_enable_fuzz, default_w,
+  Grades,
 } from "../src/fsrs";
-import { FSRSAlgorithm } from "../src/fsrs/algorithm";
-import { get_fuzz_range } from "../src/fsrs";
-
-describe("initial FSRS V4", () => {
-  const params = generatorParameters();
-  const f: FSRS = fsrs(params);
-  it("initial stability ", () => {
-    Grades.forEach((grade) => {
-      const s = f.init_stability(grade);
-      expect(s).toEqual(params.w[grade - 1]);
-    });
-  });
-  it("again s0(1) ", () => {
-    expect(f.init_stability(Rating.Again)).toEqual(params.w[0]);
-  });
-  it("initial s0(4) ", () => {
-    expect(f.init_stability(Rating.Easy)).toEqual(params.w[3]);
-  });
-
-  it("initial difficulty ", () => {
-    Grades.forEach((grade) => {
-      const s = f.init_difficulty(grade);
-      expect(s).toEqual(params.w[4] - (grade - 3) * params.w[5]);
-    });
-  });
-  it("good D0(3) ", () => {
-    expect(f.init_difficulty(Rating.Good)).toEqual(params.w[4]);
-  });
-
-  it("retrievability t=s ", () => {
-    expect(Number(f.forgetting_curve(5, 5).toFixed(2))).toEqual(0.9);
-  });
-
-  it("default params",()=>{
-    const expected_w = [
-      0.5701, 1.4436, 4.1386, 10.9355, 5.1443, 1.2006, 0.8627, 0.0362, 1.629,
-      0.1342, 1.0166, 2.1174, 0.0839, 0.3204, 1.4676, 0.219, 2.8237,
-    ];
-    expect(default_request_retention).toEqual(0.9);
-    expect(default_maximum_interval).toEqual(36500);
-    expect(default_enable_fuzz).toEqual(false)
-    expect(default_w).toEqual(expected_w);
-    expect(default_w.length).toBe(expected_w.length);
-  })
-});
-
-describe("FSRS apply_fuzz", () => {
-  test("return original interval when fuzzing is disabled", () => {
-    const ivl = 3.2;
-    const enable_fuzz = false;
-    const algorithm = new FSRS({ enable_fuzz: enable_fuzz });
-    expect(algorithm.apply_fuzz(ivl, 0)).toBe(3);
-  });
-
-  test("return original interval when ivl is less than 2.5", () => {
-    const ivl = 2.3;
-    const enable_fuzz = true;
-    const algorithm = new FSRS({ enable_fuzz: enable_fuzz });
-    expect(algorithm.apply_fuzz(ivl, 0)).toBe(2);
-  });
-
-  test("return original interval when ivl is less than 2.5", () => {
-    const ivl = 2.5;
-    const enable_fuzz = true;
-    const algorithm = new FSRSAlgorithm({ enable_fuzz: enable_fuzz });
-    const { min_ivl, max_ivl } = get_fuzz_range(
-      ivl,
-      0,
-      default_maximum_interval,
-    );
-    const fuzzedInterval = algorithm.apply_fuzz(ivl, 0);
-    expect(fuzzedInterval).toBeGreaterThanOrEqual(min_ivl);
-    expect(fuzzedInterval).toBeLessThanOrEqual(max_ivl);
-  });
-});
 
 // Ref: https://github.com/open-spaced-repetition/py-fsrs/blob/ecd68e453611eb808c7367c7a5312d7cadeedf5c/tests/test_fsrs.py#L1
 describe("FSRS V4 AC by py-fsrs", () => {
@@ -166,7 +90,7 @@ describe("FSRS V4 AC by py-fsrs", () => {
       states.push(first_card.state);
     }
     expect(stability).toEqual([1.14, 1.01, 5.44, 14.67]);
-    expect(difficulty).toEqual([8.4348, 6.8686, 5.3024, 3.7361999999999993]);
+    expect(difficulty).toEqual([8.4348, 6.8686, 5.3024, 3.7362]);
     expect(reps).toEqual([1, 1, 1, 1]);
     expect(lapses).toEqual([0, 0, 0, 0]);
     expect(elapsed_days).toEqual([0, 0, 0, 0]);

--- a/__tests__/algorithm.test.ts
+++ b/__tests__/algorithm.test.ts
@@ -1,9 +1,238 @@
-import { fsrs, FSRS, generatorParameters, get_fuzz_range } from "../src/fsrs";
+import {
+  default_maximum_interval,
+  fsrs,
+  FSRS,
+  FSRSAlgorithm,
+  generatorParameters,
+  get_fuzz_range,
+  Grades,
+  Rating,
+} from "../src/fsrs";
+import Decimal from "decimal.js";
+
+const DECAY: number = -0.5;
+const FACTOR: number = 19 / 81;
+
+describe("FACTOR[DECAY = -0.5]", () => {
+  it("FACTOR", () => {
+    expect(19 / 81).toEqual(new Decimal(19).div(81).toNumber());
+    expect(FACTOR).toEqual(new Decimal(19).div(81).toNumber());
+    expect(FACTOR).toEqual(
+      new Decimal(0.9).pow(new Decimal(1).div(DECAY)).sub(1).toNumber(),
+    );
+    expect(new Decimal(19).div(81).toNumber()).toEqual(
+      new Decimal(0.9).pow(new Decimal(1).div(DECAY)).sub(1).toNumber(),
+    );
+  });
+});
+
+describe("forgetting_curve", () => {
+  const params = generatorParameters();
+  //w=[
+  //   0.5701, 1.4436, 4.1386, 10.9355, 5.1443, 1.2006, 0.8627, 0.0362, 1.629,
+  //   0.1342, 1.0166, 2.1174, 0.0839, 0.3204, 1.4676, 0.219, 2.8237,
+  // ];
+  const algorithm: FSRSAlgorithm = new FSRSAlgorithm(params);
+
+  function forgetting_curve(elapsed_days: number, stability: number): number {
+    return +new Decimal(
+      new Decimal(1)
+        .add(new Decimal(FACTOR).mul(elapsed_days).div(stability))
+        .pow(DECAY),
+    ).toFixed(8);
+  }
+
+  const delta_t = [0, 1, 2, 3, 4, 5];
+  const s = [1.0, 2.0, 3.0, 4.0, 4.0, 2.0];
+  const collection: number[] = [];
+  const expected: number[] = [];
+  it("retrievability", () => {
+    for (let i = 0; i < delta_t.length; i++) {
+      collection.push(algorithm.forgetting_curve(delta_t[i], s[i]));
+      expected.push(forgetting_curve(delta_t[i], s[i]));
+    }
+    expect(collection).toEqual(expected);
+    expect(collection).toEqual([
+      1.0, 0.946059, 0.9299294, 0.92216794, 0.9, 0.79394596,
+    ]);
+  });
+});
+
+describe("init_ds", () => {
+  const params = generatorParameters();
+  //w=[
+  //   0.5701, 1.4436, 4.1386, 10.9355, 5.1443, 1.2006, 0.8627, 0.0362, 1.629,
+  //   0.1342, 1.0166, 2.1174, 0.0839, 0.3204, 1.4676, 0.219, 2.8237,
+  // ];
+  const algorithm: FSRSAlgorithm = new FSRSAlgorithm(params);
+  it("initial stability ", () => {
+    const collection: number[] = [];
+    Grades.forEach((grade) => {
+      const s = algorithm.init_stability(grade);
+      collection.push(s);
+    });
+    expect(collection).toEqual([
+      params.w[0],
+      params.w[1],
+      params.w[2],
+      params.w[3],
+    ]);
+  });
+  it("initial difficulty ", () => {
+    const collection: number[] = [];
+    const expected: number[] = [];
+    Grades.forEach((grade) => {
+      const d = algorithm.init_difficulty(grade);
+      collection.push(d);
+      expected.push(
+        new Decimal(params.w[4])
+          .sub(new Decimal(grade - 3).mul(new Decimal(params.w[5])))
+          .toNumber(),
+      );
+    });
+    expect(collection).toEqual(expected);
+    // again: w[4]-w[5]*(-2)
+    // hard: w[4]-w[5]*(-1)
+    // good: w[4]-w[5]*(0)
+    // easy: w[4]-w[5]*(1)
+  });
+});
+
+describe("next_ds", () => {
+  const params = generatorParameters();
+  //w=[
+  //   0.5701, 1.4436, 4.1386, 10.9355, 5.1443, 1.2006, 0.8627, 0.0362, 1.629,
+  //   0.1342, 1.0166, 2.1174, 0.0839, 0.3204, 1.4676, 0.219, 2.8237,
+  // ];
+  const algorithm: FSRSAlgorithm = new FSRSAlgorithm(params);
+  it("next_difficulty", () => {
+    function next_d(d: number, g: number) {
+      function mean_reversion(init: number, current: number): number {
+        const f1 = new Decimal(params.w[7]).mul(init);
+        const f2 = new Decimal(1).sub(new Decimal(params.w[7])).mul(current);
+        return f1.add(f2).toNumber();
+      }
+
+      function constrain_difficulty(difficulty: number): number {
+        return Math.min(Math.max(+new Decimal(difficulty).toFixed(8), 1), 10);
+      }
+
+      const next_d = new Decimal(d)
+        .sub(new Decimal(params.w[6]).mul(new Decimal(g - 3)))
+        .toNumber();
+      return constrain_difficulty(mean_reversion(params.w[4], next_d));
+    }
+
+    const collection: number[] = [];
+    const expected: number[] = [];
+    Grades.forEach((grade) => {
+      const d = algorithm.next_difficulty(5.0, grade);
+      const expected_d = next_d(5.0, grade);
+      collection.push(d);
+      expected.push(expected_d);
+    });
+    expect(collection).toEqual([6.66816418, 5.83669392, 5.00522366, 4.1737534]);
+    expect(collection).toEqual(expected);
+  });
+
+  it("next_stability", () => {
+    function next_forget_stability(d: number, s: number, r: number): number {
+      return +new Decimal(params.w[11])
+        .mul(new Decimal(d).pow(-params.w[12]))
+        .mul(new Decimal(s + 1).pow(params.w[13]).sub(1))
+        .mul(new Decimal(Math.exp((1 - r) * params.w[14])))
+        .toFixed(8);
+    }
+
+    function next_recall_stability(
+      d: number,
+      s: number,
+      r: number,
+      g: number,
+    ): number {
+      const hard_penalty = Rating.Hard === g ? params.w[15] : 1;
+      const easy_bound = Rating.Easy === g ? params.w[16] : 1;
+      return +new Decimal(s)
+        .mul(
+          new Decimal(1).add(
+            new Decimal(params.w[8])
+              .exp()
+              .mul(new Decimal(11).sub(d))
+              .mul(new Decimal(s).pow(-params.w[9]))
+              .mul(
+                new Decimal(params.w[10])
+                  .mul(new Decimal(1).sub(r))
+                  .exp()
+                  .sub(1),
+              )
+              .mul(hard_penalty)
+              .mul(easy_bound),
+          ),
+        )
+        .toFixed(8);
+    }
+
+    function next_s(d: number, s: number, r: number, g: number) {
+      if (g < 1 || g > 4) {
+        throw new Error("Invalid grade");
+      } else if (g === Rating.Again) {
+        return next_forget_stability(d, s, r);
+      } else {
+        return next_recall_stability(d, s, r, g);
+      }
+    }
+
+    const s_recall_collection: number[] = [];
+    const s_fail_collection: number[] = [];
+    const next_s_collection: number[] = [];
+    const expected_s_recall: number[] = [];
+    const expected_s_fail: number[] = [];
+    const expected_next_s: number[] = [];
+
+    const s = [5, 5, 5, 5];
+    const d = [1, 2, 3, 4];
+    const r = [0.9, 0.8, 0.7, 0.6];
+    Grades.forEach((grade, index) => {
+      const s_recall = algorithm.next_recall_stability(
+        d[index],
+        s[index],
+        r[index],
+        grade,
+      );
+      const s_fail = algorithm.next_forget_stability(
+        d[index],
+        s[index],
+        r[index],
+      );
+      s_recall_collection.push(s_recall);
+      s_fail_collection.push(s_fail);
+      expected_s_fail.push(next_forget_stability(d[index], s[index], r[index]));
+      expected_s_recall.push(
+        next_recall_stability(d[index], s[index], r[index], grade),
+      );
+      if (grade === Rating.Again) {
+        next_s_collection.push(s_fail);
+      } else {
+        next_s_collection.push(s_recall);
+      }
+      expected_next_s.push(next_s(d[index], s[index], r[index], grade));
+    });
+    expect(s_recall_collection).toEqual([
+      26.98093855, 14.12848781, 63.60068241, 208.72742276,
+    ]);
+    expect(s_recall_collection).toEqual(expected_s_recall);
+    expect(s_fail_collection).toEqual([
+      1.9016012, 2.0777825, 2.3257503, 2.62916465,
+    ]);
+    expect(s_fail_collection).toEqual(expected_s_fail);
+    expect(next_s_collection).toEqual([
+      1.9016012, 14.12848781, 63.60068241, 208.72742276,
+    ]);
+    expect(next_s_collection).toEqual(expected_next_s);
+  });
+});
 
 describe("next_interval", () => {
-  const DECAY: number = -0.5;
-  const FACTOR: number = Math.pow(0.9, 1 / DECAY) - 1;
-
   it("next_ivl", () => {
     const desired_retentions: number[] = Array.from(
       { length: 10 },
@@ -29,11 +258,42 @@ describe("next_interval", () => {
     const t_fuzz = 98;
     const next_ivl_fuzz = f.next_interval(s, t_fuzz, true);
     const { min_ivl, max_ivl } = get_fuzz_range(
-      s * intervalModifier,
+      Math.round(s * intervalModifier),
       t_fuzz,
       params.maximum_interval,
     );
     expect(next_ivl_fuzz).toBeGreaterThanOrEqual(min_ivl);
-    expect(next_ivl_fuzz).toBeLessThanOrEqual(params.maximum_interval);
+    expect(max_ivl).toBe(params.maximum_interval);
+    expect(next_ivl_fuzz).toBeLessThanOrEqual(max_ivl);
+  });
+});
+
+describe("FSRS apply_fuzz", () => {
+  test("return original interval when fuzzing is disabled", () => {
+    const ivl = 3.2;
+    const enable_fuzz = false;
+    const algorithm = new FSRS({ enable_fuzz: enable_fuzz });
+    expect(algorithm.apply_fuzz(ivl, 0)).toBe(3);
+  });
+
+  test("return original interval when ivl is less than 2.5", () => {
+    const ivl = 2.3;
+    const enable_fuzz = true;
+    const algorithm = new FSRS({ enable_fuzz: enable_fuzz });
+    expect(algorithm.apply_fuzz(ivl, 0)).toBe(2);
+  });
+
+  test("return original interval when ivl is less than 2.5", () => {
+    const ivl = 2.5;
+    const enable_fuzz = true;
+    const algorithm = new FSRSAlgorithm({ enable_fuzz: enable_fuzz });
+    const { min_ivl, max_ivl } = get_fuzz_range(
+      Math.round(2.5),
+      0,
+      default_maximum_interval,
+    );
+    const fuzzedInterval = algorithm.apply_fuzz(ivl, 0);
+    expect(fuzzedInterval).toBeGreaterThanOrEqual(min_ivl);
+    expect(fuzzedInterval).toBeLessThanOrEqual(max_ivl);
   });
 });

--- a/__tests__/default.test.ts
+++ b/__tests__/default.test.ts
@@ -1,0 +1,52 @@
+import {
+  createEmptyCard,
+  default_enable_fuzz,
+  default_maximum_interval,
+  default_request_retention,
+  default_w,
+  generatorParameters,
+} from "../src/fsrs";
+
+describe("default params", () => {
+  const expected_w = [
+    0.5701, 1.4436, 4.1386, 10.9355, 5.1443, 1.2006, 0.8627, 0.0362, 1.629,
+    0.1342, 1.0166, 2.1174, 0.0839, 0.3204, 1.4676, 0.219, 2.8237,
+  ];
+  expect(default_request_retention).toEqual(0.9);
+  expect(default_maximum_interval).toEqual(36500);
+  expect(default_enable_fuzz).toEqual(false);
+  expect(default_w.length).toBe(expected_w.length);
+  expect(default_w).toEqual(expected_w);
+
+  const params = generatorParameters();
+  it("default_request_retention", () => {
+    expect(params.request_retention).toEqual(default_request_retention);
+  });
+  it("default_maximum_interval", () => {
+    expect(params.maximum_interval).toEqual(default_maximum_interval);
+  });
+  it("default_w ", () => {
+    expect(params.w).toEqual(expected_w);
+  });
+  it("default_enable_fuzz ", () => {
+    expect(params.enable_fuzz).toEqual(default_enable_fuzz);
+  });
+});
+
+describe("default Card", () => {
+  it("empty card", () => {
+    const time = [new Date(), new Date("2023-10-3 00:00:00")];
+    for(const now of time){
+      const card = createEmptyCard(now);
+      expect(card.due).toEqual(now);
+      expect(card.stability).toEqual(0);
+      expect(card.difficulty).toEqual(0);
+      expect(card.elapsed_days).toEqual(0);
+      expect(card.scheduled_days).toEqual(0);
+      expect(card.reps).toEqual(0);
+      expect(card.lapses).toEqual(0);
+      expect(card.state).toEqual(0);
+    }
+  });
+  
+});

--- a/__tests__/forget.test.ts
+++ b/__tests__/forget.test.ts
@@ -1,5 +1,5 @@
 import { createEmptyCard, fsrs, FSRS, Rating } from "../src/fsrs";
-import { Grade } from "../src/fsrs/models";
+import { Grade } from "../src/fsrs";
 
 describe("FSRS forget", () => {
   const f: FSRS = fsrs({
@@ -34,7 +34,7 @@ describe("FSRS forget", () => {
         last_review: scheduling_cards[grade].card.last_review,
       });
       expect(forgetCard.log.rating).toEqual(Rating.Manual);
-      expect(() => f.rollback(forgetCard.card, forgetCard.log)).toThrowError(
+      expect(() => f.rollback(forgetCard.card, forgetCard.log)).toThrow(
         "Cannot rollback a manual rating",
       );
     }
@@ -48,7 +48,7 @@ describe("FSRS forget", () => {
         last_review: scheduling_cards[grade].card.last_review,
       });
       expect(forgetCard.log.rating).toEqual(Rating.Manual);
-      expect(() => f.rollback(forgetCard.card, forgetCard.log)).toThrowError(
+      expect(() => f.rollback(forgetCard.card, forgetCard.log)).toThrow(
         "Cannot rollback a manual rating",
       );
     }

--- a/__tests__/models.test.ts
+++ b/__tests__/models.test.ts
@@ -3,8 +3,6 @@ import {
   RatingType,
   State,
   StateType,
-  generatorParameters,
-  createEmptyCard,
 } from "../src/fsrs";
 
 describe("State", () => {
@@ -72,53 +70,5 @@ describe("Rating", () => {
     expect(Rating[Rating.Easy]).toEqual("Easy");
     expect((4 as Rating).valueOf()).toEqual(4);
     expect(Rating["Easy" as RatingType]).toEqual(4);
-  });
-});
-
-describe("default FSRSParameters", () => {
-  // const env = envParams;
-  const params = generatorParameters();
-  const w_v4 = [
-    0.5701, 1.4436, 4.1386, 10.9355, 5.1443, 1.2006, 0.8627, 0.0362, 1.629,
-    0.1342, 1.0166, 2.1174, 0.0839, 0.3204, 1.4676, 0.219, 2.8237,
-  ];
-  it("default_request_retention", () => {
-    expect(0.9).toEqual(params.request_retention);
-  });
-  it("default_maximum_interval", () => {
-    expect(36500).toEqual(params.maximum_interval);
-  });
-  it("default_w ", () => {
-    expect(w_v4).toEqual(params.w);
-  });
-  it("default_enable_fuzz ", () => {
-    expect(false).toEqual(params.enable_fuzz);
-  });
-});
-
-describe("default Card", () => {
-  it("empty card", () => {
-    const now = new Date();
-    const card = createEmptyCard(now);
-    expect(card.due).toEqual(now);
-    expect(card.stability).toEqual(0);
-    expect(card.difficulty).toEqual(0);
-    expect(card.elapsed_days).toEqual(0);
-    expect(card.scheduled_days).toEqual(0);
-    expect(card.reps).toEqual(0);
-    expect(card.lapses).toEqual(0);
-    expect(card.state).toEqual(0);
-  });
-  it("empty card", () => {
-    const now = new Date("2023-10-3 00:00:00");
-    const card = createEmptyCard();
-    expect(card.due).not.toEqual(now);
-    expect(card.stability).toEqual(0);
-    expect(card.difficulty).toEqual(0);
-    expect(card.elapsed_days).toEqual(0);
-    expect(card.scheduled_days).toEqual(0);
-    expect(card.reps).toEqual(0);
-    expect(card.lapses).toEqual(0);
-    expect(card.state).toEqual(0);
   });
 });

--- a/__tests__/reschedule.test.ts
+++ b/__tests__/reschedule.test.ts
@@ -6,13 +6,13 @@ import {
   default_request_retention,
   fsrs,
   FSRS,
+  get_fuzz_range,
   State,
 } from "../src/fsrs";
-import { get_fuzz_range } from "../src/fsrs";
 
 describe("FSRS reschedule", () => {
   const DECAY: number = -0.5;
-  const FACTOR: number = Math.pow(0.9, 1 / DECAY) - 1;
+  const FACTOR: number = 19 / 81;
   const request_retentions = [default_request_retention, 0.95, 0.85, 0.8];
 
   type CardType = Card & {
@@ -79,7 +79,7 @@ describe("FSRS reschedule", () => {
         expect(reschedule_cards[0].cid).toBeGreaterThanOrEqual(1);
 
         const { min_ivl, max_ivl } = get_fuzz_range(
-          reviewCard.stability * intervalModifier,
+          Math.round(reviewCard.stability * intervalModifier),
           reviewCard.elapsed_days,
           default_maximum_interval,
         );
@@ -108,12 +108,14 @@ describe("FSRS reschedule", () => {
       });
       if (rescheduleCard) {
         // next_ivl !== scheduled_days
-        expect(rescheduleCard.cid).toBeGreaterThanOrEqual(1);
+        expect(rescheduleCard.cid).toEqual(1);
         const { min_ivl, max_ivl } = get_fuzz_range(
-          reviewCard.stability * intervalModifier,
+          Math.round(reviewCard.stability * intervalModifier),
           reviewCard.elapsed_days,
           default_maximum_interval,
         );
+        // reviewCard.stability * intervalModifier = 115.73208467290684 = ivl = 116
+        // max_ivl=124 expected = 124
 
         expect(rescheduleCard.scheduled_days).toBeGreaterThanOrEqual(min_ivl);
         expect(rescheduleCard.scheduled_days).toBeLessThanOrEqual(max_ivl);

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@types/seedrandom": "^3.0.8",
     "@typescript-eslint/eslint-plugin": "^6.11.0",
     "@typescript-eslint/parser": "^6.11.0",
+    "decimal.js": "^10.4.3",
     "eslint": "^8.53.0",
     "eslint-config-prettier": "^9.0.0",
     "jest": "^29.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,9 @@ devDependencies:
   '@typescript-eslint/parser':
     specifier: ^6.11.0
     version: 6.15.0(eslint@8.56.0)(typescript@5.3.3)
+  decimal.js:
+    specifier: ^10.4.3
+    version: 10.4.3
   eslint:
     specifier: ^8.53.0
     version: 8.56.0
@@ -1744,6 +1747,10 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
+    dev: true
+
+  /decimal.js@10.4.3:
+    resolution: {integrity: sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==}
     dev: true
 
   /dedent@1.5.1:


### PR DESCRIPTION
use decimal.js to test decimal precision.

Due to the implementation of the IEEE754 standard for the number type in JavaScript, there are precision issues. 
For example, 0.1 + 0.2 !== 0.3. 
When `w[4] = 5.1443` , `w[5] = 1.2006`:
- init_difficulty(Rating.Easy) = `3.9437000000000006` , expected : `3.9437`
- init_difficulty(Rating.Again) = `7.5455000000000005`, expected : `7.5455`
- Math.pow(0.9, 1 / -0.5) - 1 =`0.23456790123456783`, expected : `0.2345679012345679`