### PR TITLE
Add umd distribution

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: write
+  checks: write
+  pull-requests: write
 
 jobs:
   test:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: write
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-fsrs",
-  "version": "3.5.4",
+  "version": "3.5.5",
   "description": "ts-fsrs is a ES modules package based on TypeScript, used to implement the Free Spaced Repetition Scheduler (FSRS) algorithm. It helps developers apply FSRS to their flashcard applications, there by improving the user learning experience.",
   "main": "dist/index.cjs",
   "umd": "dist/index.umd.js",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.5.4",
   "description": "ts-fsrs is a ES modules package based on TypeScript, used to implement the Free Spaced Repetition Scheduler (FSRS) algorithm. It helps developers apply FSRS to their flashcard applications, there by improving the user learning experience.",
   "main": "dist/index.cjs",
+  "umd": "dist/index.umd.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "keywords": [

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -41,6 +41,28 @@ export default defineConfig([
             commonjs(),
         ],
         external: ["seedrandom"],
+    }, 
+    {
+        input: 'src/fsrs/index.ts',
+        output: {
+            file: 'dist/index.umd.js', 
+            format: 'umd',
+            name: 'FSRS',
+            sourcemap: true,
+            globals: {
+                seedrandom: 'seedrandom',
+            },
+        },
+        plugins: [
+            resolve(), 
+            esbuild({ 
+                target: 'es2017',
+                minify: true,
+                sourceMap: true,
+            }),
+            commonjs(),
+        ],
+        external: ["seedrandom"],
     },
     {
         input: 'src/fsrs/index.ts',

--- a/src/fsrs/default.ts
+++ b/src/fsrs/default.ts
@@ -9,7 +9,7 @@ export const default_w = [
 ];
 export const default_enable_fuzz = false;
 
-export const FSRSVersion: string = "3.5.4";
+export const FSRSVersion: string = "3.5.5";
 
 export const generatorParameters = (
   props?: Partial<FSRSParameters>,


### PR DESCRIPTION
I've been using FSRS in the browser. Running into some compilation issues requiring the package by itself, so I moved it to a umd distribution to require it outside of the build system.

One should be able to require this file with `jsdelivr` or `unpkg` as well. Not sure if it's acceptable for the repo but I needed it so thought I'd share