### PR TITLE
Chore/update CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: ${{ matrix.node }}
           cache: 'pnpm'
 
       - name: Get pnpm store directory

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,14 +46,20 @@ jobs:
     runs-on: ${{matrix.platform}}
 
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Node.js
-        uses: actions/setup-node@v2
-        with:
-          node-version: 16
-      - uses: pnpm/action-setup@v2.2.2
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
         with:
           version: 8.7.1
+          run_install: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 16
+          cache: 'pnpm'
 
       - name: Get pnpm store directory
         shell: bash

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,19 +16,22 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v2
-        with:
-          node-version: 16
-
-      - uses: pnpm/action-setup@v2.2.2
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
         with:
           version: 8.7.1
+          run_install: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 16
+          cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
 
       - name: Build docs
         run: pnpm run docs

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -20,14 +20,20 @@ jobs:
       packages: write # allow GITHUB_TOKEN to publish packages
       id-token: write
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Node.js
-        uses: actions/setup-node@v2
-        with:
-          node-version: 16
-      - uses: pnpm/action-setup@v2.2.2
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
         with:
           version: 8.7.1
+          run_install: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 16
+          cache: 'pnpm'
 
       - name: Get pnpm store directory
         shell: bash


### PR DESCRIPTION
`pnpm/action-setup@v2` is no longer working and needs to be updated to `v4`.

- https://github.com/pnpm/action-setup/issues/135

- https://github.com/pnpm/action-setup
> ## :warning: Upgrade from v2
> The v2 version of this action has stopped working with newer Node.js versions. Please, upgrade to the latest version to fix any issues.