### PR TITLE
Feat/use `Reflect` to set the `FSRSParamters`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-fsrs",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "ts-fsrs is a versatile package based on TypeScript that supports ES modules, CommonJS, and UMD. It implements the Free Spaced Repetition Scheduler (FSRS) algorithm, enabling developers to integrate FSRS into their flashcard applications to enhance the user learning experience.",
   "main": "dist/index.cjs",
   "umd": "dist/index.umd.js",

--- a/src/fsrs/algorithm.ts
+++ b/src/fsrs/algorithm.ts
@@ -72,7 +72,7 @@ export class FSRSAlgorithm {
   }
 
   protected params_handler_proxy(): ProxyHandler<FSRSParameters> {
-    const _this: FSRSAlgorithm = this satisfies FSRSAlgorithm
+    const _this = this satisfies FSRSAlgorithm
     return {
       set: function (
         target: FSRSParameters,

--- a/src/fsrs/algorithm.ts
+++ b/src/fsrs/algorithm.ts
@@ -72,17 +72,19 @@ export class FSRSAlgorithm {
   }
 
   protected params_handler_proxy(): ProxyHandler<FSRSParameters> {
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
-    const _this: FSRSAlgorithm = this
+    const _this: FSRSAlgorithm = this satisfies FSRSAlgorithm
     return {
-      set: function (target, prop, value) {
+      set: function (
+        target: FSRSParameters,
+        prop: keyof FSRSParameters,
+        value: FSRSParameters[keyof FSRSParameters]
+      ) {
         if (prop === 'request_retention' && Number.isFinite(value)) {
           _this.intervalModifier = _this.calculate_interval_modifier(
             Number(value)
           )
         }
-        // @ts-ignore
-        target[prop] = value
+        Reflect.set(target, prop, value)
         return true
       },
     }
@@ -97,7 +99,6 @@ export class FSRSAlgorithm {
       }
     }
   }
-
 
   /**
    * The formula used is :

--- a/src/fsrs/default.ts
+++ b/src/fsrs/default.ts
@@ -11,7 +11,7 @@ export const default_w = [
 export const default_enable_fuzz = false
 export const defualt_enable_short_term = true
 
-export const FSRSVersion: string = 'v4.0.0 using FSRS V5.0'
+export const FSRSVersion: string = 'v4.0.1 using FSRS V5.0'
 
 export const generatorParameters = (
   props?: Partial<FSRSParameters>

--- a/src/fsrs/fsrs.ts
+++ b/src/fsrs/fsrs.ts
@@ -28,7 +28,7 @@ export class FSRS extends FSRSAlgorithm {
   }
 
   protected override params_handler_proxy(): ProxyHandler<FSRSParameters> {
-    const _this: FSRS = this satisfies FSRS
+    const _this = this satisfies FSRS
     return {
       set: function (
         target: FSRSParameters,

--- a/src/fsrs/fsrs.ts
+++ b/src/fsrs/fsrs.ts
@@ -30,7 +30,11 @@ export class FSRS extends FSRSAlgorithm {
   protected override params_handler_proxy(): ProxyHandler<FSRSParameters> {
     const _this: FSRS = this satisfies FSRS
     return {
-      set: function (target, prop, value) {
+      set: function (
+        target: FSRSParameters,
+        prop: keyof FSRSParameters,
+        value: FSRSParameters[keyof FSRSParameters]
+      ) {
         if (prop === 'request_retention' && Number.isFinite(value)) {
           _this.intervalModifier = _this.calculate_interval_modifier(
             Number(value)
@@ -38,8 +42,7 @@ export class FSRS extends FSRSAlgorithm {
         } else if (prop === 'enable_short_term') {
           _this.Schduler = value === true ? BasicScheduler : LongTermScheduler
         }
-        // @ts-ignore
-        target[prop] = value
+        Reflect.set(target, prop, value)
         return true
       },
     }


### PR DESCRIPTION
I plan to use the Reflect method to set parameter values, avoiding the use of ts-ignore. The reason for using the proxy pattern is because the request_retention and enable_short_term parameters require special assignment of some variables when they are changed. @AlexErrant , do you have a better approach?