### PR TITLE
Feat/remove seedrandom

### DIFF
--- a/__tests__/alea.test.ts
+++ b/__tests__/alea.test.ts
@@ -1,0 +1,90 @@
+// Import the Alea generator and additional required elements
+import { alea } from '../src/fsrs/alea' // Adjust the import path according to your project structure
+
+describe('Alea PRNG Tests', () => {
+  it('make sure two seeded values are the same', () => {
+    const prng1 = alea(1)
+    const prng2 = alea(3)
+    const prng3 = alea(1)
+
+    const a = prng1.state()
+    const b = prng2.state()
+    const c = prng3.state()
+
+    expect(a).toEqual(c)
+    expect(a).not.toEqual(b)
+  })
+
+  it('Known values test', () => {
+    const seed = 12345
+    const generator = alea(seed)
+    const results = Array.from({ length: 3 }, () => generator())
+    expect(results).toEqual([
+      0.27138191112317145, 0.19615925149992108, 0.6810678059700876,
+    ])
+  })
+
+  it('should generate an int32', () => {
+    const generator = alea('int32test')
+    const int32 = generator.int32()
+    expect(int32).toBeLessThanOrEqual(0xffffffff)
+    expect(int32).toBeGreaterThanOrEqual(0)
+  })
+
+  it('Uint32 test', () => {
+    const seed = 12345
+    const generator = alea(seed)
+    const results = Array.from({ length: 3 }, () => generator.int32())
+    expect(results).toEqual([1165576433, 842497570, -1369803343])
+  })
+
+  it('should generate a double', () => {
+    const generator = alea('doubletest')
+    const double = generator.double()
+    expect(double).toBeGreaterThanOrEqual(0)
+    expect(double).toBeLessThan(1)
+  })
+
+  it('Fract53 test', () => {
+    const seed = 12345
+    const generator = alea(seed)
+    const results = Array.from({ length: 3 }, () => generator.double())
+    expect(results).toEqual([
+      0.27138191116884325, 0.6810678062004586, 0.3407802057882554,
+    ])
+  })
+
+  it('Import with Alea.importState()', () => {
+    const prng1 = alea(Math.random())
+
+    // generate a few numbers
+    prng1()
+    prng1()
+    prng1()
+
+    const e = prng1.state()
+
+    const prng4 = alea().importState(e)
+    expect(prng4.state()).toEqual(prng1.state())
+    for (let i = 0; i < 10000; i++) {
+      const a = prng1()
+      const b = prng4()
+      expect(a).toEqual(b)
+      expect(a).toBeGreaterThanOrEqual(0)
+      expect(a).toBeLessThan(1)
+      expect(b).toBeLessThan(1)
+    }
+  })
+  it('should have reproducible state', () => {
+    const generator = alea('statetest')
+    const state1 = generator.state()
+    const next1 = generator()
+    const state2 = generator.state()
+    const next2 = generator()
+
+    expect(state1.s0).not.toEqual(state2.s0)
+    expect(state1.s1).not.toEqual(state2.s1)
+    expect(state1.s2).not.toEqual(state2.s2)
+    expect(next1).not.toEqual(next2)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -23,9 +23,6 @@
     "docs": "typedoc",
     "clean": "rimraf ./dist ./docs"
   },
-  "dependencies": {
-    "seedrandom": "^3.0.5"
-  },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^26.0.1",
     "@rollup/plugin-node-resolve": "^15.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      seedrandom:
-        specifier: ^3.0.5
-        version: 3.0.5
     devDependencies:
       '@rollup/plugin-commonjs':
         specifier: ^26.0.1
@@ -28,11 +24,11 @@ importers:
         specifier: ^3.0.8
         version: 3.0.8
       '@typescript-eslint/eslint-plugin':
-        specifier: ^7.16.0
-        version: 7.16.0(@typescript-eslint/parser@7.16.0(eslint@9.6.0)(typescript@5.5.3))(eslint@9.6.0)(typescript@5.5.3)
+        specifier: ^8.0.0
+        version: 8.0.0(@typescript-eslint/parser@8.0.0(eslint@9.6.0)(typescript@5.5.3))(eslint@9.6.0)(typescript@5.5.3)
       '@typescript-eslint/parser':
-        specifier: ^7.16.0
-        version: 7.16.0(eslint@9.6.0)(typescript@5.5.3)
+        specifier: ^8.0.0
+        version: 8.0.0(eslint@9.6.0)(typescript@5.5.3)
       decimal.js:
         specifier: ^10.4.3
         version: 10.4.3
@@ -728,63 +724,62 @@ packages:
   '@types/yargs@17.0.32':
     resolution: {integrity: sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==}
 
-  '@typescript-eslint/eslint-plugin@7.16.0':
-    resolution: {integrity: sha512-py1miT6iQpJcs1BiJjm54AMzeuMPBSPuKPlnT8HlfudbcS5rYeX5jajpLf3mrdRh9dA/Ec2FVUY0ifeVNDIhZw==}
-    engines: {node: ^18.18.0 || >=20.0.0}
+  '@typescript-eslint/eslint-plugin@8.0.0':
+    resolution: {integrity: sha512-STIZdwEQRXAHvNUS6ILDf5z3u95Gc8jzywunxSNqX00OooIemaaNIA0vEgynJlycL5AjabYLLrIyHd4iazyvtg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^7.0.0
-      eslint: ^8.56.0
+      '@typescript-eslint/parser': ^8.0.0 || ^8.0.0-alpha.0
+      eslint: ^8.57.0 || ^9.0.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@typescript-eslint/parser@7.16.0':
-    resolution: {integrity: sha512-ar9E+k7CU8rWi2e5ErzQiC93KKEFAXA2Kky0scAlPcxYblLt8+XZuHUZwlyfXILyQa95P6lQg+eZgh/dDs3+Vw==}
-    engines: {node: ^18.18.0 || >=20.0.0}
+  '@typescript-eslint/parser@8.0.0':
+    resolution: {integrity: sha512-pS1hdZ+vnrpDIxuFXYQpLTILglTjSYJ9MbetZctrUawogUsPdz31DIIRZ9+rab0LhYNTsk88w4fIzVheiTbWOQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.56.0
+      eslint: ^8.57.0 || ^9.0.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@typescript-eslint/scope-manager@7.16.0':
-    resolution: {integrity: sha512-8gVv3kW6n01Q6TrI1cmTZ9YMFi3ucDT7i7aI5lEikk2ebk1AEjrwX8MDTdaX5D7fPXMBLvnsaa0IFTAu+jcfOw==}
-    engines: {node: ^18.18.0 || >=20.0.0}
+  '@typescript-eslint/scope-manager@8.0.0':
+    resolution: {integrity: sha512-V0aa9Csx/ZWWv2IPgTfY7T4agYwJyILESu/PVqFtTFz9RIS823mAze+NbnBI8xiwdX3iqeQbcTYlvB04G9wyQw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/type-utils@7.16.0':
-    resolution: {integrity: sha512-j0fuUswUjDHfqV/UdW6mLtOQQseORqfdmoBNDFOqs9rvNVR2e+cmu6zJu/Ku4SDuqiJko6YnhwcL8x45r8Oqxg==}
-    engines: {node: ^18.18.0 || >=20.0.0}
-    peerDependencies:
-      eslint: ^8.56.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@typescript-eslint/types@7.16.0':
-    resolution: {integrity: sha512-fecuH15Y+TzlUutvUl9Cc2XJxqdLr7+93SQIbcZfd4XRGGKoxyljK27b+kxKamjRkU7FYC6RrbSCg0ALcZn/xw==}
-    engines: {node: ^18.18.0 || >=20.0.0}
-
-  '@typescript-eslint/typescript-estree@7.16.0':
-    resolution: {integrity: sha512-a5NTvk51ZndFuOLCh5OaJBELYc2O3Zqxfl3Js78VFE1zE46J2AaVuW+rEbVkQznjkmlzWsUI15BG5tQMixzZLw==}
-    engines: {node: ^18.18.0 || >=20.0.0}
+  '@typescript-eslint/type-utils@8.0.0':
+    resolution: {integrity: sha512-mJAFP2mZLTBwAn5WI4PMakpywfWFH5nQZezUQdSKV23Pqo6o9iShQg1hP2+0hJJXP2LnZkWPphdIq4juYYwCeg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@typescript-eslint/utils@7.16.0':
-    resolution: {integrity: sha512-PqP4kP3hb4r7Jav+NiRCntlVzhxBNWq6ZQ+zQwII1y/G/1gdIPeYDCKr2+dH6049yJQsWZiHU6RlwvIFBXXGNA==}
-    engines: {node: ^18.18.0 || >=20.0.0}
-    peerDependencies:
-      eslint: ^8.56.0
+  '@typescript-eslint/types@8.0.0':
+    resolution: {integrity: sha512-wgdSGs9BTMWQ7ooeHtu5quddKKs5Z5dS+fHLbrQI+ID0XWJLODGMHRfhwImiHoeO2S5Wir2yXuadJN6/l4JRxw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/visitor-keys@7.16.0':
-    resolution: {integrity: sha512-rMo01uPy9C7XxG7AFsxa8zLnWXTF8N3PYclekWSrurvhwiw1eW88mrKiAYe6s53AUY57nTRz8dJsuuXdkAhzCg==}
-    engines: {node: ^18.18.0 || >=20.0.0}
+  '@typescript-eslint/typescript-estree@8.0.0':
+    resolution: {integrity: sha512-5b97WpKMX+Y43YKi4zVcCVLtK5F98dFls3Oxui8LbnmRsseKenbbDinmvxrWegKDMmlkIq/XHuyy0UGLtpCDKg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@typescript-eslint/utils@8.0.0':
+    resolution: {integrity: sha512-k/oS/A/3QeGLRvOWCg6/9rATJL5rec7/5s1YmdS0ZU6LHveJyGFwBvLhSRBv6i9xaj7etmosp+l+ViN1I9Aj/Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+
+  '@typescript-eslint/visitor-keys@8.0.0':
+    resolution: {integrity: sha512-oN0K4nkHuOyF3PVMyETbpP5zp6wfyOvm7tWhTMfoqxSSsPmJIh6JNASuZDlODE8eE+0EB9uar+6+vxr9DBTYOA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -1852,9 +1847,6 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
-  seedrandom@3.0.5:
-    resolution: {integrity: sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==}
-
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -2808,14 +2800,14 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@7.16.0(@typescript-eslint/parser@7.16.0(eslint@9.6.0)(typescript@5.5.3))(eslint@9.6.0)(typescript@5.5.3)':
+  '@typescript-eslint/eslint-plugin@8.0.0(@typescript-eslint/parser@8.0.0(eslint@9.6.0)(typescript@5.5.3))(eslint@9.6.0)(typescript@5.5.3)':
     dependencies:
       '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 7.16.0(eslint@9.6.0)(typescript@5.5.3)
-      '@typescript-eslint/scope-manager': 7.16.0
-      '@typescript-eslint/type-utils': 7.16.0(eslint@9.6.0)(typescript@5.5.3)
-      '@typescript-eslint/utils': 7.16.0(eslint@9.6.0)(typescript@5.5.3)
-      '@typescript-eslint/visitor-keys': 7.16.0
+      '@typescript-eslint/parser': 8.0.0(eslint@9.6.0)(typescript@5.5.3)
+      '@typescript-eslint/scope-manager': 8.0.0
+      '@typescript-eslint/type-utils': 8.0.0(eslint@9.6.0)(typescript@5.5.3)
+      '@typescript-eslint/utils': 8.0.0(eslint@9.6.0)(typescript@5.5.3)
+      '@typescript-eslint/visitor-keys': 8.0.0
       eslint: 9.6.0
       graphemer: 1.4.0
       ignore: 5.3.1
@@ -2826,12 +2818,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@7.16.0(eslint@9.6.0)(typescript@5.5.3)':
+  '@typescript-eslint/parser@8.0.0(eslint@9.6.0)(typescript@5.5.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 7.16.0
-      '@typescript-eslint/types': 7.16.0
-      '@typescript-eslint/typescript-estree': 7.16.0(typescript@5.5.3)
-      '@typescript-eslint/visitor-keys': 7.16.0
+      '@typescript-eslint/scope-manager': 8.0.0
+      '@typescript-eslint/types': 8.0.0
+      '@typescript-eslint/typescript-estree': 8.0.0(typescript@5.5.3)
+      '@typescript-eslint/visitor-keys': 8.0.0
       debug: 4.3.4
       eslint: 9.6.0
     optionalDependencies:
@@ -2839,29 +2831,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@7.16.0':
+  '@typescript-eslint/scope-manager@8.0.0':
     dependencies:
-      '@typescript-eslint/types': 7.16.0
-      '@typescript-eslint/visitor-keys': 7.16.0
+      '@typescript-eslint/types': 8.0.0
+      '@typescript-eslint/visitor-keys': 8.0.0
 
-  '@typescript-eslint/type-utils@7.16.0(eslint@9.6.0)(typescript@5.5.3)':
+  '@typescript-eslint/type-utils@8.0.0(eslint@9.6.0)(typescript@5.5.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 7.16.0(typescript@5.5.3)
-      '@typescript-eslint/utils': 7.16.0(eslint@9.6.0)(typescript@5.5.3)
+      '@typescript-eslint/typescript-estree': 8.0.0(typescript@5.5.3)
+      '@typescript-eslint/utils': 8.0.0(eslint@9.6.0)(typescript@5.5.3)
       debug: 4.3.4
-      eslint: 9.6.0
       ts-api-utils: 1.3.0(typescript@5.5.3)
     optionalDependencies:
       typescript: 5.5.3
     transitivePeerDependencies:
+      - eslint
       - supports-color
 
-  '@typescript-eslint/types@7.16.0': {}
+  '@typescript-eslint/types@8.0.0': {}
 
-  '@typescript-eslint/typescript-estree@7.16.0(typescript@5.5.3)':
+  '@typescript-eslint/typescript-estree@8.0.0(typescript@5.5.3)':
     dependencies:
-      '@typescript-eslint/types': 7.16.0
-      '@typescript-eslint/visitor-keys': 7.16.0
+      '@typescript-eslint/types': 8.0.0
+      '@typescript-eslint/visitor-keys': 8.0.0
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
@@ -2873,20 +2865,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@7.16.0(eslint@9.6.0)(typescript@5.5.3)':
+  '@typescript-eslint/utils@8.0.0(eslint@9.6.0)(typescript@5.5.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@9.6.0)
-      '@typescript-eslint/scope-manager': 7.16.0
-      '@typescript-eslint/types': 7.16.0
-      '@typescript-eslint/typescript-estree': 7.16.0(typescript@5.5.3)
+      '@typescript-eslint/scope-manager': 8.0.0
+      '@typescript-eslint/types': 8.0.0
+      '@typescript-eslint/typescript-estree': 8.0.0(typescript@5.5.3)
       eslint: 9.6.0
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@typescript-eslint/visitor-keys@7.16.0':
+  '@typescript-eslint/visitor-keys@8.0.0':
     dependencies:
-      '@typescript-eslint/types': 7.16.0
+      '@typescript-eslint/types': 8.0.0
       eslint-visitor-keys: 3.4.3
 
   acorn-jsx@5.3.2(acorn@8.12.1):
@@ -3390,7 +3382,7 @@ snapshots:
       array-union: 2.1.0
       dir-glob: 3.0.1
       fast-glob: 3.3.2
-      ignore: 5.3.0
+      ignore: 5.3.1
       merge2: 1.4.1
       slash: 3.0.0
 
@@ -4148,8 +4140,6 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
-
-  seedrandom@3.0.5: {}
 
   semver@6.3.1: {}
 

--- a/src/fsrs/alea.ts
+++ b/src/fsrs/alea.ts
@@ -1,0 +1,113 @@
+// https://github.com/davidbau/seedrandom/blob/released/lib/alea.js
+// A port of an algorithm by Johannes Baagøe <baagoe@baagoe.com>, 2010
+// http://baagoe.com/en/RandomMusings/javascript/
+// https://github.com/nquinlan/better-random-numbers-for-javascript-mirror
+// Original work is under MIT license -
+
+// Copyright (C) 2010 by Johannes Baagøe <baagoe@baagoe.org>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+type State = {
+  c: number
+  s0: number
+  s1: number
+  s2: number
+}
+
+class Alea {
+  private c: number
+  private s0: number
+  private s1: number
+  private s2: number
+
+  constructor(seed?: number | string) {
+    const mash = Mash()
+    this.c = 1
+    this.s0 = mash(' ')
+    this.s1 = mash(' ')
+    this.s2 = mash(' ')
+    if (seed == null) seed = +new Date()
+    this.s0 -= mash(seed)
+    if (this.s0 < 0) this.s0 += 1
+    this.s1 -= mash(seed)
+    if (this.s1 < 0) this.s1 += 1
+    this.s2 -= mash(seed)
+    if (this.s2 < 0) this.s2 += 1
+  }
+
+  next(): number {
+    const t = 2091639 * this.s0 + this.c * 2.3283064365386963e-10 // 2^-32
+    this.s0 = this.s1
+    this.s1 = this.s2
+    this.s2 = t - (this.c = t | 0)
+    return this.s2
+  }
+
+  set state(state: State) {
+    this.c = state.c
+    this.s0 = state.s0
+    this.s1 = state.s1
+    this.s2 = state.s2
+  }
+
+  get state(): State {
+    return {
+      c: this.c,
+      s0: this.s0,
+      s1: this.s1,
+      s2: this.s2,
+    }
+  }
+}
+
+function Mash() {
+  let n = 0xefc8249d
+  return function mash(data: string | number): number {
+    data = String(data)
+    for (let i = 0; i < data.length; i++) {
+      n += data.charCodeAt(i)
+      let h = 0.02519603282416938 * n
+      n = h >>> 0
+      h -= n
+      h *= n
+      n = h >>> 0
+      h -= n
+      n += h * 0x100000000 // 2^32
+    }
+    return (n >>> 0) * 2.3283064365386963e-10 // 2^-32
+  }
+}
+
+function alea(seed?: number | string) {
+  const xg = new Alea(seed)
+  const prng = () => xg.next()
+
+  prng.int32 = () => (xg.next() * 0x100000000) | 0
+  prng.double = () =>
+    prng() + ((prng() * 0x200000) | 0) * 1.1102230246251565e-16 // 2^-53
+  prng.state = () => xg.state
+  prng.importState = (state: State) => {
+    xg.state = state
+    return prng
+  }
+  return prng
+}
+
+export { alea }

--- a/src/fsrs/algorithm.ts
+++ b/src/fsrs/algorithm.ts
@@ -1,8 +1,8 @@
-import pseudorandom from 'seedrandom'
 import { generatorParameters } from './default'
 import { FSRSParameters, Grade, Rating } from './models'
 import type { int } from './types'
 import { get_fuzz_range } from './help'
+import { alea } from './alea'
 
 /**
  * @default DECAY = -0.5
@@ -136,7 +136,7 @@ export class FSRSAlgorithm {
    **/
   apply_fuzz(ivl: number, elapsed_days: number, enable_fuzz?: boolean): int {
     if (!enable_fuzz || ivl < 2.5) return Math.round(ivl) as int
-    const generator = pseudorandom(this.seed)
+    const generator = alea(this.seed)
     const fuzz_factor = generator()
     const { min_ivl, max_ivl } = get_fuzz_range(
       ivl,


### PR DESCRIPTION
The dependency on seedrandom is planned to be removed to reduce the package size. Instead, the similar Alea PRNG algorithm will be used. For implementation, refer to https://github.com/davidbau/seedrandom/blob/released/lib/alea.js.

use seedrandom: 10.36KB ( gzip: 3.83KB)
![1242bd9ea9a058079111f6bb5d37334](https://github.com/user-attachments/assets/f9e48d93-c2aa-4ad4-802e-355edd40ce53)

use alea: 2.32KB (gzip: 0.971KB)
![86deff86cdb0ca4c115858bfcbbc901](https://github.com/user-attachments/assets/7e913901-926a-4da7-a1c7-2c2277c558fe)
