### PR TITLE
Example/add switch short-term example

### DIFF
--- a/example/example.html
+++ b/example/example.html
@@ -9,7 +9,11 @@
     <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
     <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio,line-clamp"></script>
     <script type="module">
+        // production
         import * as tsFsrs from 'https://cdn.jsdelivr.net/npm/ts-fsrs@latest/+esm';
+        // development,please use this: pnpm run build
+        // import * as tsFsrs from '../dist/index.mjs';
+        
         window.tsfsrs = tsFsrs
     </script>
     <title>TS-FSRS example</title>

--- a/example/example.html
+++ b/example/example.html
@@ -11,9 +11,12 @@
     <script type="module">
         // production
         import * as tsFsrs from 'https://cdn.jsdelivr.net/npm/ts-fsrs@latest/+esm';
-        // development,please use this: pnpm run build
+        // development
+        // Please start with this command: `pnpm run build`
+        // you need install `Live Server` in vscode:
+        // https://marketplace.visualstudio.com/items?itemName=ritwickdey.LiveServer
         // import * as tsFsrs from '../dist/index.mjs';
-        
+
         window.tsfsrs = tsFsrs
     </script>
     <title>TS-FSRS example</title>

--- a/example/exampleComponent.jsx
+++ b/example/exampleComponent.jsx
@@ -241,6 +241,30 @@ const ParamsComponent = ({ f, setF }) => {
         prevent cards from sticking together and always being reviewed on the
         same day.
       </div>
+
+      <div className="flex py-4">
+        <label htmlFor="enable_short-term" className="pr-4">
+        enable_short-term:
+        </label>
+        <input
+          name="enable_short-term"
+          type="checkbox"
+          className="toggle toggle-info mt-1"
+          aria-label="enable short-term"
+          defaultChecked={f.parameters.enable_short_term}
+          onChange={(e) => handleChange("enable_short_term", e.target.checked)}
+        />
+      </div>
+      <div className="label text-xs">
+        When disabled, this allow user to skip the short-term schedule.
+      </div>
+      <hr className="pt-4"/>
+      <div>
+        <div>current apply parameters:</div>
+        <div>{Object.keys(f.parameters).map(key=><p key={key}>
+          {`${key} : ${JSON.stringify(f.parameters[key])}`}
+        </p>)}</div>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
Add the `enable_short_term` parameter and display the currently applied parameters.
![image](https://github.com/user-attachments/assets/1c5e30b9-4e70-4375-bdfd-a9934b52e925)
