### PR TITLE
Fix/export the `FSRSHistory` and `FSRSReview` typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-fsrs",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "description": "ts-fsrs is a versatile package based on TypeScript that supports ES modules, CommonJS, and UMD. It implements the Free Spaced Repetition Scheduler (FSRS) algorithm, enabling developers to integrate FSRS into their flashcard applications to enhance the user learning experience.",
   "main": "dist/index.cjs",
   "umd": "dist/index.umd.js",

--- a/src/fsrs/default.ts
+++ b/src/fsrs/default.ts
@@ -11,7 +11,7 @@ export const default_w = [
 export const default_enable_fuzz = false
 export const default_enable_short_term = true
 
-export const FSRSVersion: string = 'v4.4.2 using FSRS V5.0'
+export const FSRSVersion: string = 'v4.4.3 using FSRS V5.0'
 
 export const generatorParameters = (
   props?: Partial<FSRSParameters>

--- a/src/fsrs/index.ts
+++ b/src/fsrs/index.ts
@@ -16,6 +16,8 @@ export type {
   CardInput,
   ReviewLogInput,
   DateInput,
+  FSRSReview,
+  FSRSHistory,
 } from './models'
 export { State, Rating } from './models'
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d2437f85-f8f7-4de9-9d31-2e2510a91224)
