### PR TITLE
Feat/Export the forgetting curve function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-fsrs",
-  "version": "4.6.1",
+  "version": "4.7.0",
   "description": "ts-fsrs is a versatile package based on TypeScript that supports ES modules, CommonJS, and UMD. It implements the Free Spaced Repetition Scheduler (FSRS) algorithm, enabling developers to integrate FSRS into their flashcard applications to enhance the user learning experience.",
   "main": "dist/index.cjs",
   "umd": "dist/index.umd.js",

--- a/src/fsrs/algorithm.ts
+++ b/src/fsrs/algorithm.ts
@@ -17,6 +17,20 @@ export const DECAY: number = -0.5
 export const FACTOR: number = 19 / 81
 
 /**
+ * The formula used is :
+ * $$R(t,S) = (1 + \text{FACTOR} \times \frac{t}{9 \cdot S})^{\text{DECAY}}$$
+ * @param {number} elapsed_days t days since the last review
+ * @param {number} stability Stability (interval when R=90%)
+ * @return {number} r Retrievability (probability of recall)
+ */
+export function forgetting_curve(
+  elapsed_days: number,
+  stability: number
+): number {
+  return +Math.pow(1 + (FACTOR * elapsed_days) / stability, DECAY).toFixed(8)
+}
+
+/**
  * @see https://github.com/open-spaced-repetition/fsrs4anki/wiki/The-Algorithm#fsrs-45
  */
 export class FSRSAlgorithm {
@@ -265,16 +279,7 @@ export class FSRSAlgorithm {
     ).toFixed(8)
   }
 
-  /**
-   * The formula used is :
-   * $$R(t,S) = (1 + \text{FACTOR} \times \frac{t}{9 \cdot S})^{\text{DECAY}}$$
-   * @param {number} elapsed_days t days since the last review
-   * @param {number} stability Stability (interval when R=90%)
-   * @return {number} r Retrievability (probability of recall)
-   */
-  forgetting_curve(elapsed_days: number, stability: number): number {
-    return +Math.pow(1 + (FACTOR * elapsed_days) / stability, DECAY).toFixed(8)
-  }
+  forgetting_curve = forgetting_curve
 
   /**
    * Calculates the next state of memory based on the current state, time elapsed, and grade.


### PR DESCRIPTION
I use `FSRS.prototype.forgetting_curve` as a workaround:

https://github.com/Luc-Mcgrady/Anki-Search-Stats-Extended/blob/578a95d372da3d54afbe89280d11fd43e72e5607/src/ts/CardDataPies.ts#L36

But this can be counter-intuitive:

https://github.com/Luc-Mcgrady/Anki-Search-Stats-Extended/pull/31#discussion_r1965675970

Also you need to run `lint::fix` :smile: (No idea how the CI doesn't notice that) 