### PR TITLE
Doc/Improve Examples

### DIFF
--- a/src/fsrs/default.ts
+++ b/src/fsrs/default.ts
@@ -71,11 +71,11 @@ export const generatorParameters = (
  * @param now Current time
  * @param afterHandler Convert the result to another type. (Optional)
  * @example
- * ```
+ * ```typescript
  * const card: Card = createEmptyCard(new Date());
  * ```
  * @example
- * ```
+ * ```typescript
  * interface CardUnChecked
  *   extends Omit<Card, "due" | "last_review" | "state"> {
  *   cid: string;

--- a/src/fsrs/fsrs.ts
+++ b/src/fsrs/fsrs.ts
@@ -103,13 +103,13 @@ export class FSRS extends FSRSAlgorithm {
    * @param now Current time or scheduled time
    * @param afterHandler Convert the result to another type. (Optional)
    * @example
-   * ```
+   * ```typescript
    * const card: Card = createEmptyCard(new Date());
    * const f = fsrs();
    * const recordLog = f.repeat(card, new Date());
    * ```
    * @example
-   * ```
+   * ```typescript
    * interface RevLogUnchecked
    *   extends Omit<ReviewLog, "due" | "review" | "state" | "rating"> {
    *   cid: string;
@@ -176,13 +176,13 @@ export class FSRS extends FSRSAlgorithm {
    * @param grade Rating of the review (Again, Hard, Good, Easy)
    * @param afterHandler Convert the result to another type. (Optional)
    * @example
-   * ```
+   * ```typescript
    * const card: Card = createEmptyCard(new Date());
    * const f = fsrs();
    * const recordLogItem = f.next(card, new Date(), Rating.Again);
    * ```
    * @example
-   * ```
+   * ```typescript
    * interface RevLogUnchecked
    *   extends Omit<ReviewLog, "due" | "review" | "state" | "rating"> {
    *   cid: string;
@@ -275,7 +275,7 @@ export class FSRS extends FSRSAlgorithm {
    * @param log last review log
    * @param afterHandler Convert the result to another type. (Optional)
    * @example
-   * ```
+   * ```typescript
    * const now = new Date();
    * const f = fsrs();
    * const emptyCardFormAfterHandler = createEmptyCard(now);
@@ -285,7 +285,7 @@ export class FSRS extends FSRSAlgorithm {
    * ```
    *
    * @example
-   * ```
+   * ```typescript
    * const now = new Date();
    * const f = fsrs();
    * const emptyCardFormAfterHandler = createEmptyCard(now, cardAfterHandler);  //see method: createEmptyCard
@@ -351,7 +351,7 @@ export class FSRS extends FSRSAlgorithm {
    * @param reset_count Should the review count information(reps,lapses) be reset. (Optional)
    * @param afterHandler Convert the result to another type. (Optional)
    * @example
-   * ```
+   * ```typescript
    * const now = new Date();
    * const f = fsrs();
    * const emptyCard = createEmptyCard(now);
@@ -361,7 +361,7 @@ export class FSRS extends FSRSAlgorithm {
    * ```
    *
    * @example
-   * ```
+   * ```typescript
    * interface RepeatRecordLog {
    *   card: CardUnChecked; //see method: createEmptyCard
    *   log: RevLogUnchecked; //see method: fsrs.repeat()
@@ -446,9 +446,9 @@ export class FSRS extends FSRSAlgorithm {
    * @param {Array<FSRSHistory>} reviews - The array of FSRSHistory objects representing the reviews.
    * @param {Partial<RescheduleOptions<T>>} options - The optional reschedule options.
    * @returns {IReschedule<T>} - The rescheduled collections and reschedule item.
-   * 
+   *
    * @example
-   * ```
+   * ```typescript
     const f = fsrs()
         const grades: Grade[] = [Rating.Good, Rating.Good, Rating.Good, Rating.Good]
         const reviews_at = [

--- a/src/fsrs/fsrs.ts
+++ b/src/fsrs/fsrs.ts
@@ -449,31 +449,31 @@ export class FSRS extends FSRSAlgorithm {
    *
    * @example
    * ```typescript
-    const f = fsrs()
-        const grades: Grade[] = [Rating.Good, Rating.Good, Rating.Good, Rating.Good]
-        const reviews_at = [
-          new Date(2024, 8, 13),
-          new Date(2024, 8, 13),
-          new Date(2024, 8, 17),
-          new Date(2024, 8, 28),
-        ]
-
-        const reviews: FSRSHistory[] = []
-        for (let i = 0; i < grades.length; i++) {
-          reviews.push({
-            rating: grades[i],
-            review: reviews_at[i],
-          })
-        }
-
-        const results_short = scheduler.reschedule(
-          createEmptyCard(),
-          reviews,
-          {
-            skipManual: false,
-          }
-        )
-        console.log(results_short)
+   * const f = fsrs()
+   * const grades: Grade[] = [Rating.Good, Rating.Good, Rating.Good, Rating.Good]
+   * const reviews_at = [
+   *   new Date(2024, 8, 13),
+   *   new Date(2024, 8, 13),
+   *   new Date(2024, 8, 17),
+   *   new Date(2024, 8, 28),
+   * ]
+   *
+   * const reviews: FSRSHistory[] = []
+   * for (let i = 0; i < grades.length; i++) {
+   *   reviews.push({
+   *     rating: grades[i],
+   *     review: reviews_at[i],
+   *   })
+   * }
+   *
+   * const results_short = scheduler.reschedule(
+   *   createEmptyCard(),
+   *   reviews,
+   *   {
+   *     skipManual: false,
+   *   }
+   * )
+   * console.log(results_short)
    * ```
    */
   reschedule<T = RecordLogItem>(


### PR DESCRIPTION
* Add syntax highlighting on hover
* Fix indentation of an example

<details>

<summary>Results in the following patch in `/dist`</summary>

```patch
Subject: [PATCH]
---
Index: dist/src/fsrs/default.d.ts
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/dist/src/fsrs/default.d.ts b/dist/src/fsrs/default.d.ts
--- a/dist/src/fsrs/default.d.ts	(revision 2d4695a937b13375134151229cf7bf7c547f37e9)
+++ b/dist/src/fsrs/default.d.ts	(date 1743042538131)
@@ -14,11 +14,11 @@
  * @param now Current time
  * @param afterHandler Convert the result to another type. (Optional)
  * @example
- * ```
+ * ```typescript
  * const card: Card = createEmptyCard(new Date());
  * ```
  * @example
- * ```
+ * ```typescript
  * interface CardUnChecked
  *   extends Omit<Card, "due" | "last_review" | "state"> {
  *   cid: string;
Index: dist/src/fsrs/fsrs.d.ts
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/dist/src/fsrs/fsrs.d.ts b/dist/src/fsrs/fsrs.d.ts
--- a/dist/src/fsrs/fsrs.d.ts	(revision 2d4695a937b13375134151229cf7bf7c547f37e9)
+++ b/dist/src/fsrs/fsrs.d.ts	(date 1743042538145)
@@ -16,13 +16,13 @@
      * @param now Current time or scheduled time
      * @param afterHandler Convert the result to another type. (Optional)
      * @example
-     * ```
+     * ```typescript
      * const card: Card = createEmptyCard(new Date());
      * const f = fsrs();
      * const recordLog = f.repeat(card, new Date());
      * ```
      * @example
-     * ```
+     * ```typescript
      * interface RevLogUnchecked
      *   extends Omit<ReviewLog, "due" | "review" | "state" | "rating"> {
      *   cid: string;
@@ -76,13 +76,13 @@
      * @param grade Rating of the review (Again, Hard, Good, Easy)
      * @param afterHandler Convert the result to another type. (Optional)
      * @example
-     * ```
+     * ```typescript
      * const card: Card = createEmptyCard(new Date());
      * const f = fsrs();
      * const recordLogItem = f.next(card, new Date(), Rating.Again);
      * ```
      * @example
-     * ```
+     * ```typescript
      * interface RevLogUnchecked
      *   extends Omit<ReviewLog, "due" | "review" | "state" | "rating"> {
      *   cid: string;
@@ -138,7 +138,7 @@
      * @param log last review log
      * @param afterHandler Convert the result to another type. (Optional)
      * @example
-     * ```
+     * ```typescript
      * const now = new Date();
      * const f = fsrs();
      * const emptyCardFormAfterHandler = createEmptyCard(now);
@@ -148,7 +148,7 @@
      * ```
      *
      * @example
-     * ```
+     * ```typescript
      * const now = new Date();
      * const f = fsrs();
      * const emptyCardFormAfterHandler = createEmptyCard(now, cardAfterHandler);  //see method: createEmptyCard
@@ -165,7 +165,7 @@
      * @param reset_count Should the review count information(reps,lapses) be reset. (Optional)
      * @param afterHandler Convert the result to another type. (Optional)
      * @example
-     * ```
+     * ```typescript
      * const now = new Date();
      * const f = fsrs();
      * const emptyCard = createEmptyCard(now);
@@ -175,7 +175,7 @@
      * ```
      *
      * @example
-     * ```
+     * ```typescript
      * interface RepeatRecordLog {
      *   card: CardUnChecked; //see method: createEmptyCard
      *   log: RevLogUnchecked; //see method: fsrs.repeat()
@@ -220,32 +220,32 @@
      * @returns {IReschedule<T>} - The rescheduled collections and reschedule item.
      *
      * @example
-     * ```
-      const f = fsrs()
-          const grades: Grade[] = [Rating.Good, Rating.Good, Rating.Good, Rating.Good]
-          const reviews_at = [
-            new Date(2024, 8, 13),
-            new Date(2024, 8, 13),
-            new Date(2024, 8, 17),
-            new Date(2024, 8, 28),
-          ]
-  
-          const reviews: FSRSHistory[] = []
-          for (let i = 0; i < grades.length; i++) {
-            reviews.push({
-              rating: grades[i],
-              review: reviews_at[i],
-            })
-          }
-  
-          const results_short = scheduler.reschedule(
-            createEmptyCard(),
-            reviews,
-            {
-              skipManual: false,
-            }
-          )
-          console.log(results_short)
+     * ```typescript
+     * const f = fsrs()
+     * const grades: Grade[] = [Rating.Good, Rating.Good, Rating.Good, Rating.Good]
+     * const reviews_at = [
+     *   new Date(2024, 8, 13),
+     *   new Date(2024, 8, 13),
+     *   new Date(2024, 8, 17),
+     *   new Date(2024, 8, 28),
+     * ]
+     *
+     * const reviews: FSRSHistory[] = []
+     * for (let i = 0; i < grades.length; i++) {
+     *   reviews.push({
+     *     rating: grades[i],
+     *     review: reviews_at[i],
+     *   })
+     * }
+     *
+     * const results_short = scheduler.reschedule(
+     *   createEmptyCard(),
+     *   reviews,
+     *   {
+     *     skipManual: false,
+     *   }
+     * )
+     * console.log(results_short)
      * ```
      */
     reschedule<T = RecordLogItem>(current_card: CardInput | Card, reviews?: FSRSHistory[], options?: Partial<RescheduleOptions<T>>): IReschedule<T>;
```

</details>