### PR TITLE
Chore/mark fields and methods as depreacted

### DIFF
--- a/__tests__/FSRS-5.test.ts
+++ b/__tests__/FSRS-5.test.ts
@@ -6,6 +6,7 @@ import {
   State,
   Grade,
   Grades,
+  date_diff,
 } from '../src/fsrs'
 
 describe('FSRS-5', () => {
@@ -43,7 +44,9 @@ describe('FSRS-5', () => {
         )
         expect(rollbackCard).toEqual(card)
         expect(scheduling_cards[check].log.elapsed_days).toEqual(
-          card.last_review ? now.diff(card.last_review as Date, 'days') : 0
+          card.last_review
+            ? date_diff(now, card.last_review as Date, 'days')
+            : 0
         )
         const _f = fsrs({ w })
         const next = _f.next(card, now, check)

--- a/__tests__/FSRS-6.test.ts
+++ b/__tests__/FSRS-6.test.ts
@@ -7,6 +7,7 @@ import {
   Grade,
   Grades,
   FSRSState,
+  date_diff,
 } from '../src/fsrs'
 
 describe('FSRS-6 ', () => {
@@ -44,7 +45,9 @@ describe('FSRS-6 ', () => {
         )
         expect(rollbackCard).toEqual(card)
         expect(scheduling_cards[check].log.elapsed_days).toEqual(
-          card.last_review ? now.diff(card.last_review as Date, 'days') : 0
+          card.last_review
+            ? date_diff(now, card.last_review as Date, 'days')
+            : 0
         )
         const _f = fsrs({ w })
         const next = _f.next(card, now, check)

--- a/__tests__/elapsed_days.test.ts
+++ b/__tests__/elapsed_days.test.ts
@@ -7,6 +7,7 @@ import {
   Rating,
   Grade,
   ReviewLog,
+  date_diff,
 } from '../src/fsrs'
 
 describe('elapsed_days', () => {
@@ -37,7 +38,7 @@ describe('elapsed_days', () => {
 
     currentLog = sc[grades[index]].log
     expect(currentLog.elapsed_days).toEqual(
-      secondDue.diff(card.last_review as Date, 'days')
+      date_diff(secondDue, card.last_review as Date, 'days')
     ) // 3
     expect(currentLog.elapsed_days).toEqual(3) // 0
     card = sc[grades[index]].card
@@ -54,7 +55,7 @@ describe('elapsed_days', () => {
 
     currentLog = sc[grades[index]].log
     expect(currentLog.elapsed_days).toEqual(
-      secondDue.diff(card.last_review as Date, 'days')
+      date_diff(secondDue, card.last_review as Date, 'days')
     ) // 0
     expect(currentLog.elapsed_days).toEqual(0) // 0
     // console.log(currentLog);
@@ -71,7 +72,7 @@ describe('elapsed_days', () => {
 
     currentLog = sc[grades[index]].log
     expect(currentLog.elapsed_days).toEqual(
-      secondDue.diff(card.last_review as Date, 'days')
+      date_diff(secondDue, card.last_review as Date, 'days')
     ) // 0
     expect(currentLog.elapsed_days).toEqual(0) // 0
     // console.log(currentLog);

--- a/__tests__/handler.test.ts
+++ b/__tests__/handler.test.ts
@@ -2,7 +2,7 @@ import {
   Card,
   createEmptyCard,
   date_scheduler,
-  fixState,
+  TypeConvert,
   fsrs,
   FSRS,
   Grades,
@@ -147,7 +147,9 @@ describe('afterHandler', () => {
   it('createEmptyCard[afterHandler]', () => {
     const emptyCardFormAfterHandler = createEmptyCard(now, cardAfterHandler)
     expect(emptyCardFormAfterHandler.state).toEqual('New')
-    expect(fixState(emptyCardFormAfterHandler.state)).toEqual(State.New)
+    expect(TypeConvert.state(emptyCardFormAfterHandler.state)).toEqual(
+      State.New
+    )
     expect(emptyCardFormAfterHandler.last_review).toEqual(null)
     expect(emptyCardFormAfterHandler.cid).toEqual('test001')
 
@@ -156,7 +158,9 @@ describe('afterHandler', () => {
       cardAfterHandler
     )
     expect(emptyCardFormAfterHandler2.state).toEqual('New')
-    expect(fixState(emptyCardFormAfterHandler2.state)).toEqual(State.New)
+    expect(TypeConvert.state(emptyCardFormAfterHandler2.state)).toEqual(
+      State.New
+    )
     expect(emptyCardFormAfterHandler2.last_review).toEqual(null)
     expect(emptyCardFormAfterHandler2.cid).toEqual('test001')
   })

--- a/__tests__/help.test.ts
+++ b/__tests__/help.test.ts
@@ -1,9 +1,7 @@
 import {
   date_diff,
   date_scheduler,
-  fixDate,
-  fixRating,
-  fixState,
+  TypeConvert,
   formatDate,
   Grades,
   Rating,
@@ -21,15 +19,9 @@ test('FSRS-Grades', () => {
 
 test('Date.prototype.format', () => {
   const now = new Date(2022, 11, 30, 12, 30, 0, 0)
-  const last_review = new Date(2022, 11, 29, 12, 30, 0, 0)
-  expect(now.format()).toEqual('2022-12-30 12:30:00')
   expect(formatDate(now)).toEqual('2022-12-30 12:30:00')
   expect(formatDate(now.getTime())).toEqual('2022-12-30 12:30:00')
   expect(formatDate(now.toUTCString())).toEqual('2022-12-30 12:30:00')
-  const TIMEUNITFORMAT_TEST = ['秒', '分', '时', '天', '月', '年']
-  expect(now.dueFormat(last_review)).toEqual('1')
-  expect(now.dueFormat(last_review, true)).toEqual('1day')
-  expect(now.dueFormat(last_review, true, TIMEUNITFORMAT_TEST)).toEqual('1天')
 })
 
 describe('date_scheduler', () => {
@@ -79,18 +71,18 @@ describe('date_diff', () => {
     const now = new Date(2022, 11, 30, 12, 30, 0, 0)
     const last_review = new Date(2022, 11, 29, 12, 30, 0, 0)
 
-    expect(() => date_diff(now, null as unknown as Date, 'days')).toThrowError(
+    expect(() => date_diff(now, null as unknown as Date, 'days')).toThrow(
+      'Invalid date'
+    )
+    expect(() => date_diff(now, null as unknown as Date, 'minutes')).toThrow(
       'Invalid date'
     )
     expect(() =>
-      date_diff(now, null as unknown as Date, 'minutes')
-    ).toThrowError('Invalid date')
-    expect(() =>
       date_diff(null as unknown as Date, last_review, 'days')
-    ).toThrowError('Invalid date')
+    ).toThrow('Invalid date')
     expect(() =>
       date_diff(null as unknown as Date, last_review, 'minutes')
-    ).toThrowError('Invalid date')
+    ).toThrow('Invalid date')
   })
 
   test('calculate difference in minutes', () => {
@@ -118,81 +110,85 @@ describe('date_diff', () => {
   })
 })
 
-describe('fixDate', () => {
+describe('TypeConvert.time', () => {
   test('throw error for invalid date value', () => {
     const input = 'invalid-date'
-    expect(() => fixDate(input)).toThrowError('Invalid date:[invalid-date]')
+    expect(() => TypeConvert.time(input)).toThrow('Invalid date:[invalid-date]')
   })
 
   test('throw error for unsupported value type', () => {
     const input = true
-    expect(() => fixDate(input)).toThrowError('Invalid date:[true]')
+    expect(() => TypeConvert.time(input)).toThrow('Invalid date:[true]')
   })
 
   test('throw error for undefined value', () => {
     const input = undefined
-    expect(() => fixDate(input)).toThrowError('Invalid date:[undefined]')
+    expect(() => TypeConvert.time(input)).toThrow('Invalid date:[undefined]')
   })
 
   test('throw error for null value', () => {
     const input = null
-    expect(() => fixDate(input)).toThrowError('Invalid date:[null]')
+    expect(() => TypeConvert.time(input)).toThrow('Invalid date:[null]')
   })
 })
 
-describe('fixState', () => {
+describe('TypeConvert.state', () => {
   test('fix state value', () => {
     const newState = 'New'
-    expect(fixState('new')).toEqual(State.New)
-    expect(fixState(newState)).toEqual(State.New)
+    expect(TypeConvert.state('new')).toEqual(State.New)
+    expect(TypeConvert.state(newState)).toEqual(State.New)
 
     const learning = 'Learning'
-    expect(fixState('learning')).toEqual(State.Learning)
-    expect(fixState(learning)).toEqual(State.Learning)
+    expect(TypeConvert.state('learning')).toEqual(State.Learning)
+    expect(TypeConvert.state(learning)).toEqual(State.Learning)
 
     const relearning = 'Relearning'
-    expect(fixState('relearning')).toEqual(State.Relearning)
-    expect(fixState(relearning)).toEqual(State.Relearning)
+    expect(TypeConvert.state('relearning')).toEqual(State.Relearning)
+    expect(TypeConvert.state(relearning)).toEqual(State.Relearning)
 
     const review = 'Review'
-    expect(fixState('review')).toEqual(State.Review)
-    expect(fixState(review)).toEqual(State.Review)
+    expect(TypeConvert.state('review')).toEqual(State.Review)
+    expect(TypeConvert.state(review)).toEqual(State.Review)
   })
 
   test('throw error for invalid state value', () => {
     const input = 'invalid-state'
-    expect(() => fixState(input)).toThrowError('Invalid state:[invalid-state]')
-    expect(() => fixState(null)).toThrowError('Invalid state:[null]')
-    expect(() => fixState(undefined)).toThrowError('Invalid state:[undefined]')
+    expect(() => TypeConvert.state(input)).toThrow(
+      'Invalid state:[invalid-state]'
+    )
+    expect(() => TypeConvert.state(null)).toThrow('Invalid state:[null]')
+    expect(() => TypeConvert.state(undefined)).toThrow(
+      'Invalid state:[undefined]'
+    )
   })
 })
 
-describe('fixRating', () => {
+describe('TypeConvert.rating', () => {
   test('fix Rating value', () => {
     const again = 'Again'
-    expect(fixRating('again')).toEqual(Rating.Again)
-    expect(fixRating(again)).toEqual(Rating.Again)
+    expect(TypeConvert.rating('again')).toEqual(Rating.Again)
+    expect(TypeConvert.rating(again)).toEqual(Rating.Again)
 
     const hard = 'Hard'
-    expect(fixRating('hard')).toEqual(Rating.Hard)
-    expect(fixRating(hard)).toEqual(Rating.Hard)
+    expect(TypeConvert.rating('hard')).toEqual(Rating.Hard)
+    expect(TypeConvert.rating(hard)).toEqual(Rating.Hard)
 
     const good = 'Good'
-    expect(fixRating('good')).toEqual(Rating.Good)
-    expect(fixRating(good)).toEqual(Rating.Good)
+    expect(TypeConvert.rating('good')).toEqual(Rating.Good)
+    expect(TypeConvert.rating(good)).toEqual(Rating.Good)
 
     const easy = 'Easy'
-    expect(fixRating('easy')).toEqual(Rating.Easy)
-    expect(fixRating(easy)).toEqual(Rating.Easy)
+    expect(TypeConvert.rating('easy')).toEqual(Rating.Easy)
+    expect(TypeConvert.rating(easy)).toEqual(Rating.Easy)
   })
 
   test('throw error for invalid rating value', () => {
     const input = 'invalid-rating'
-    expect(() => fixRating(input)).toThrowError(
+    expect(() => TypeConvert.rating(input)).toThrowError(
       'Invalid rating:[invalid-rating]'
     )
-    expect(() => fixRating(null)).toThrowError('Invalid rating:[null]')
-    expect(() => fixRating(undefined)).toThrowError(
+    expect(() => TypeConvert.rating(null)).toThrowError('Invalid rating:[null]')
+    expect(() => TypeConvert.rating(undefined)).toThrowError(
       'Invalid rating:[undefined]'
     )
   })

--- a/__tests__/reschedule.test.ts
+++ b/__tests__/reschedule.test.ts
@@ -460,7 +460,8 @@ describe('FSRS reschedule', () => {
           now: review_at,
         }
       )
-      const scheduled_days = reschedule_item!.card.due.diff(
+      const scheduled_days = date_diff(
+        reschedule_item!.card.due,
         cur_card.due,
         'days'
       )

--- a/__tests__/show_diff_message.test.ts
+++ b/__tests__/show_diff_message.test.ts
@@ -1,4 +1,4 @@
-import { fixDate, show_diff_message } from '../src/fsrs'
+import { show_diff_message } from '../src/fsrs'
 
 test('show_diff_message_bad_type', () => {
   const TIMEUNITFORMAT_TEST = ['秒', '分', '时', '天', '月', '年']
@@ -10,29 +10,17 @@ test('show_diff_message_bad_type', () => {
 
   const t5 = 0
   const t6 = 1000 * 60 * 60 * 24
-  // @ts-ignore
   expect(show_diff_message(t2, t1)).toBe('1')
-  // @ts-ignore
   expect(show_diff_message(t2, t1, true)).toEqual('1day')
-  expect(fixDate(t2).dueFormat(fixDate(t1), true, TIMEUNITFORMAT_TEST)).toEqual(
-    '1天'
-  )
+  expect(show_diff_message(t2, t1, true, TIMEUNITFORMAT_TEST)).toEqual('1天')
 
-  // @ts-ignore
   expect(show_diff_message(t4, t3)).toBe('1')
-  // @ts-ignore
   expect(show_diff_message(t4, t3, true)).toEqual('1day')
-  expect(fixDate(t4).dueFormat(fixDate(t3), true, TIMEUNITFORMAT_TEST)).toEqual(
-    '1天'
-  )
+  expect(show_diff_message(t4, t3, true, TIMEUNITFORMAT_TEST)).toEqual('1天')
 
-  // @ts-ignore
   expect(show_diff_message(t6, t5)).toBe('1')
-  // @ts-ignore
   expect(show_diff_message(t6, t5, true)).toEqual('1day')
-  expect(fixDate(t6).dueFormat(fixDate(t5), true, TIMEUNITFORMAT_TEST)).toEqual(
-    '1天'
-  )
+  expect(show_diff_message(t6, t5, true, TIMEUNITFORMAT_TEST)).toEqual('1天')
 })
 
 test('show_diff_message_min', () => {
@@ -43,14 +31,10 @@ test('show_diff_message_min', () => {
   const t3 = new Date(t1.getTime() + 1000 * 60 * 59)
   expect(show_diff_message(t2, t1)).toBe('1')
   expect(show_diff_message(t2, t1, true)).toEqual('1min')
-  expect(fixDate(t2).dueFormat(fixDate(t1), true, TIMEUNITFORMAT_TEST)).toEqual(
-    '1分'
-  )
+  expect(show_diff_message(t2, t1, true, TIMEUNITFORMAT_TEST)).toEqual('1分')
 
   expect(show_diff_message(t3, t1, true)).toEqual('59min')
-  expect(fixDate(t3).dueFormat(fixDate(t1), true, TIMEUNITFORMAT_TEST)).toEqual(
-    '59分'
-  )
+  expect(show_diff_message(t3, t1, true, TIMEUNITFORMAT_TEST)).toEqual('59分')
 })
 
 test('show_diff_message_hour', () => {
@@ -62,19 +46,15 @@ test('show_diff_message_hour', () => {
   expect(show_diff_message(t2, t1)).toBe('1')
 
   expect(show_diff_message(t2, t1, true)).toEqual('1hour')
-  expect(fixDate(t2).dueFormat(fixDate(t1), true, TIMEUNITFORMAT_TEST)).toEqual(
-    '1小时'
-  )
+  expect(show_diff_message(t2, t1, true, TIMEUNITFORMAT_TEST)).toEqual('1小时')
 
   expect(show_diff_message(t3, t1, true)).not.toBe('59hour')
-  expect(
-    fixDate(t3).dueFormat(fixDate(t1), true, TIMEUNITFORMAT_TEST)
-  ).not.toEqual('59小时')
+  expect(show_diff_message(t3, t1, true, TIMEUNITFORMAT_TEST)).not.toEqual(
+    '59小时'
+  )
 
   expect(show_diff_message(t3, t1, true)).toBe('2day')
-  expect(fixDate(t3).dueFormat(fixDate(t1), true, TIMEUNITFORMAT_TEST)).toEqual(
-    '2天'
-  )
+  expect(show_diff_message(t3, t1, true, TIMEUNITFORMAT_TEST)).toEqual('2天')
 })
 
 test('show_diff_message_day', () => {
@@ -86,21 +66,15 @@ test('show_diff_message_day', () => {
   const t4 = new Date(t1.getTime() + 1000 * 60 * 60 * 24 * 31)
   expect(show_diff_message(t2, t1)).toBe('1')
   expect(show_diff_message(t2, t1, true)).toEqual('1day')
-  expect(fixDate(t2).dueFormat(fixDate(t1), true, TIMEUNITFORMAT_TEST)).toEqual(
-    '1天'
-  )
+  expect(show_diff_message(t2, t1, true, TIMEUNITFORMAT_TEST)).toEqual('1天')
 
   expect(show_diff_message(t3, t1)).toBe('30')
   expect(show_diff_message(t3, t1, true)).toEqual('30day')
-  expect(fixDate(t3).dueFormat(fixDate(t1), true, TIMEUNITFORMAT_TEST)).toEqual(
-    '30天'
-  )
+  expect(show_diff_message(t3, t1, true, TIMEUNITFORMAT_TEST)).toEqual('30天')
 
   expect(show_diff_message(t4, t1)).not.toBe('31')
   expect(show_diff_message(t4, t1, true)).toEqual('1month')
-  expect(fixDate(t4).dueFormat(fixDate(t1), true, TIMEUNITFORMAT_TEST)).toEqual(
-    '1个月'
-  )
+  expect(show_diff_message(t4, t1, true, TIMEUNITFORMAT_TEST)).toEqual('1个月')
 })
 
 test('show_diff_message_month', () => {
@@ -112,21 +86,17 @@ test('show_diff_message_month', () => {
   const t4 = new Date(t1.getTime() + 1000 * 60 * 60 * 24 * 31 * 13)
   expect(show_diff_message(t2, t1)).toBe('1')
   expect(show_diff_message(t2, t1, true)).toEqual('1month')
-  expect(fixDate(t2).dueFormat(fixDate(t1), true, TIMEUNITFORMAT_TEST)).toEqual(
-    '1个月'
-  )
+  expect(show_diff_message(t2, t1, true, TIMEUNITFORMAT_TEST)).toEqual('1个月')
 
   expect(show_diff_message(t3, t1)).not.toBe('12')
   expect(show_diff_message(t3, t1, true)).not.toEqual('12month')
-  expect(
-    fixDate(t3).dueFormat(fixDate(t1), true, TIMEUNITFORMAT_TEST)
-  ).not.toEqual('12个月')
+  expect(show_diff_message(t3, t1, true, TIMEUNITFORMAT_TEST)).not.toEqual(
+    '12个月'
+  )
 
   expect(show_diff_message(t4, t1)).not.toBe('13')
   expect(show_diff_message(t4, t1, true)).toEqual('1year')
-  expect(fixDate(t4).dueFormat(fixDate(t1), true, TIMEUNITFORMAT_TEST)).toEqual(
-    '1年'
-  )
+  expect(show_diff_message(t4, t1, true, TIMEUNITFORMAT_TEST)).toEqual('1年')
 })
 
 test('show_diff_message_year', () => {
@@ -142,21 +112,15 @@ test('show_diff_message_year', () => {
   )
   expect(show_diff_message(t2, t1)).toBe('1')
   expect(show_diff_message(t2, t1, true)).toEqual('1year')
-  expect(fixDate(t2).dueFormat(fixDate(t1), true, TIMEUNITFORMAT_TEST)).toEqual(
-    '1年'
-  )
+  expect(show_diff_message(t2, t1, true, TIMEUNITFORMAT_TEST)).toEqual('1年')
 
   expect(show_diff_message(t3, t1)).toBe('1')
   expect(show_diff_message(t3, t1, true)).toEqual('1year')
-  expect(fixDate(t3).dueFormat(fixDate(t1), true, TIMEUNITFORMAT_TEST)).toEqual(
-    '1年'
-  )
+  expect(show_diff_message(t3, t1, true, TIMEUNITFORMAT_TEST)).toEqual('1年')
 
   expect(show_diff_message(t4, t1)).toBe('2')
   expect(show_diff_message(t4, t1, true)).toEqual('2year')
-  expect(fixDate(t4).dueFormat(fixDate(t1), true, TIMEUNITFORMAT_TEST)).toEqual(
-    '2年'
-  )
+  expect(show_diff_message(t4, t1, true, TIMEUNITFORMAT_TEST)).toEqual('2年')
 })
 
 test('wrong timeUnit length', () => {
@@ -165,12 +129,10 @@ test('wrong timeUnit length', () => {
   const t2 = new Date(t1.getTime() + 1000 * 60 * 60 * 24 * 31 * 13)
   expect(show_diff_message(t2, t1)).toBe('1')
   expect(show_diff_message(t2, t1, true)).toEqual('1year')
-  expect(
-    fixDate(t2).dueFormat(fixDate(t1), true, TIMEUNITFORMAT_TEST)
-  ).not.toEqual('1年')
-  expect(fixDate(t2).dueFormat(fixDate(t1), true, TIMEUNITFORMAT_TEST)).toEqual(
-    '1year'
+  expect(show_diff_message(t2, t1, true, TIMEUNITFORMAT_TEST)).not.toEqual(
+    '1年'
   )
+  expect(show_diff_message(t2, t1, true, TIMEUNITFORMAT_TEST)).toEqual('1year')
 })
 
 test('Date data real type is string/number', () => {
@@ -181,10 +143,8 @@ test('Date data real type is string/number', () => {
   ).toDateString()
   expect(show_diff_message(t2, t1.getTime())).toBe('1')
   expect(show_diff_message(t2, t1.toUTCString(), true)).toEqual('1year')
-  expect(
-    fixDate(t2).dueFormat(fixDate(t1), true, TIMEUNITFORMAT_TEST)
-  ).not.toEqual('1年')
-  expect(fixDate(t2).dueFormat(fixDate(t1), true, TIMEUNITFORMAT_TEST)).toEqual(
-    '1year'
+  expect(show_diff_message(t2, t1, true, TIMEUNITFORMAT_TEST)).not.toEqual(
+    '1年'
   )
+  expect(show_diff_message(t2, t1, true, TIMEUNITFORMAT_TEST)).toEqual('1year')
 })

--- a/src/fsrs/abstract_scheduler.ts
+++ b/src/fsrs/abstract_scheduler.ts
@@ -26,6 +26,7 @@ export abstract class AbstractScheduler implements IScheduler {
   protected next: Map<Grade, RecordLogItem> = new Map()
   protected algorithm: FSRSAlgorithm
   protected strategies: Map<StrategyMode, TStrategyHandler> | undefined
+  protected elapsed_days: number = 0 // init
 
   constructor(
     card: CardInput | Card,
@@ -54,6 +55,8 @@ export abstract class AbstractScheduler implements IScheduler {
       interval = dateDiffInDays(last_review, this.review_time)
     }
     this.current.last_review = this.review_time
+    this.elapsed_days = interval
+    // pending removal in v6.0.0
     this.current.elapsed_days = interval
     this.current.reps += 1
 
@@ -118,7 +121,7 @@ export abstract class AbstractScheduler implements IScheduler {
       due: last_review || due,
       stability: this.current.stability,
       difficulty: this.current.difficulty,
-      elapsed_days: this.current.elapsed_days,
+      elapsed_days: this.elapsed_days,
       last_elapsed_days: elapsed_days,
       scheduled_days: this.current.scheduled_days,
       learning_steps: this.current.learning_steps,

--- a/src/fsrs/fsrs.ts
+++ b/src/fsrs/fsrs.ts
@@ -28,6 +28,7 @@ import {
   type TSchedulerStrategy,
   type TStrategyHandler,
 } from './strategies/types'
+import { date_diff } from './help'
 
 export class FSRS extends FSRSAlgorithm {
   private strategyHandler = new Map<StrategyMode, TStrategyHandler>()
@@ -258,7 +259,7 @@ export class FSRS extends FSRSAlgorithm {
     now = now ? TypeConvert.time(now) : new Date()
     const t =
       processedCard.state !== State.New
-        ? Math.max(now.diff(processedCard.last_review as Date, 'days'), 0)
+        ? Math.max(date_diff(now, processedCard.last_review as Date, 'days'), 0)
         : 0
     const r =
       processedCard.state !== State.New
@@ -407,7 +408,7 @@ export class FSRS extends FSRSAlgorithm {
     const scheduled_days =
       processedCard.state === State.New
         ? 0
-        : now.diff(processedCard.last_review as Date, 'days')
+        : date_diff(now, processedCard.due as Date, 'days')
     const forget_log: ReviewLog = {
       rating: Rating.Manual,
       state: processedCard.state,

--- a/src/fsrs/help.ts
+++ b/src/fsrs/help.ts
@@ -137,6 +137,7 @@ export function show_diff_message(
 /**
  *
  * @deprecated Use TypeConvert.time instead
+ * @deprecated This function will be removed in version 6.0.0.
  */
 export function fixDate(value: unknown) {
   return TypeConvert.time(value)
@@ -144,6 +145,7 @@ export function fixDate(value: unknown) {
 
 /**
  * @deprecated Use TypeConvert.state instead
+ * @deprecated This function will be removed in version 6.0.0.
  */
 export function fixState(value: unknown): State {
   return TypeConvert.state(value)
@@ -151,6 +153,7 @@ export function fixState(value: unknown): State {
 
 /**
  * @deprecated Use TypeConvert.rating instead
+ * @deprecated This function will be removed in version 6.0.0.
  */
 export function fixRating(value: unknown): Rating {
   return TypeConvert.rating(value)

--- a/src/fsrs/help.ts
+++ b/src/fsrs/help.ts
@@ -5,12 +5,25 @@ import { TypeConvert } from './convert'
 
 declare global {
   export interface Date {
+    /**
+     * @deprecated This method will be removed in version 6.0.0.
+     *
+     */
     scheduler(t: int, isDay?: boolean): Date
-
+    /**
+     * @deprecated This method will be removed in version 6.0.0.
+     *
+     */
     diff(pre: Date, unit: unit): int
-
+    /**
+     * @deprecated This method will be removed in version 6.0.0.
+     *
+     */
     format(): string
-
+    /**
+     * @deprecated This method will be removed in version 6.0.0.
+     *
+     */
     dueFormat(last_review: Date, unit?: boolean, timeUnit?: string[]): string
   }
 }

--- a/src/fsrs/impl/basic_scheduler.ts
+++ b/src/fsrs/impl/basic_scheduler.ts
@@ -105,7 +105,7 @@ export default class BasicScheduler extends AbstractScheduler {
         nextCard.learning_steps = 0
         const interval = this.algorithm.next_interval(
           nextCard.stability,
-          this.current.elapsed_days
+          this.elapsed_days
         )
         nextCard.scheduled_days = interval
         nextCard.due = date_scheduler(this.review_time, interval as int, true)
@@ -154,7 +154,7 @@ export default class BasicScheduler extends AbstractScheduler {
     if (exist) {
       return exist
     }
-    const interval = this.current.elapsed_days
+    const interval = this.elapsed_days
     const { difficulty, stability } = this.last
     const retrievability = this.algorithm.forgetting_curve(interval, stability)
     const next_again = TypeConvert.card(this.current)

--- a/src/fsrs/impl/basic_scheduler.ts
+++ b/src/fsrs/impl/basic_scheduler.ts
@@ -1,7 +1,7 @@
 import { AbstractScheduler } from '../abstract_scheduler'
 import { TypeConvert } from '../convert'
 import { S_MIN } from '../constant'
-import { clamp } from '../help'
+import { clamp, date_scheduler } from '../help'
 import {
   type Card,
   CardInput,
@@ -86,7 +86,8 @@ export default class BasicScheduler extends AbstractScheduler {
       nextCard.learning_steps = next_steps
       nextCard.scheduled_days = 0
       nextCard.state = to_state
-      nextCard.due = this.review_time.scheduler(
+      nextCard.due = date_scheduler(
+        this.review_time,
         Math.round(scheduled_minutes) as int,
         false /** true:days false: minute */
       )
@@ -94,7 +95,8 @@ export default class BasicScheduler extends AbstractScheduler {
       nextCard.state = State.Review
       if (scheduled_minutes >= 1440) {
         nextCard.learning_steps = next_steps
-        nextCard.due = this.review_time.scheduler(
+        nextCard.due = date_scheduler(
+          this.review_time,
           Math.round(scheduled_minutes) as int,
           false /** true:days false: minute */
         )
@@ -106,7 +108,7 @@ export default class BasicScheduler extends AbstractScheduler {
           this.current.elapsed_days
         )
         nextCard.scheduled_days = interval
-        nextCard.due = this.review_time.scheduler(interval as int, true)
+        nextCard.due = date_scheduler(this.review_time, interval as int, true)
       }
     }
   }
@@ -279,12 +281,12 @@ export default class BasicScheduler extends AbstractScheduler {
     ) as int
 
     next_hard.scheduled_days = hard_interval
-    next_hard.due = this.review_time.scheduler(hard_interval, true)
+    next_hard.due = date_scheduler(this.review_time, hard_interval, true)
     next_good.scheduled_days = good_interval
-    next_good.due = this.review_time.scheduler(good_interval, true)
+    next_good.due = date_scheduler(this.review_time, good_interval, true)
 
     next_easy.scheduled_days = easy_interval
-    next_easy.due = this.review_time.scheduler(easy_interval, true)
+    next_easy.due = date_scheduler(this.review_time, easy_interval, true)
   }
 
   /**

--- a/src/fsrs/impl/long_term_scheduler.ts
+++ b/src/fsrs/impl/long_term_scheduler.ts
@@ -1,7 +1,7 @@
 import { AbstractScheduler } from '../abstract_scheduler'
 import { TypeConvert } from '../convert'
 import { S_MIN } from '../constant'
-import { clamp } from '../help'
+import { clamp, date_scheduler } from '../help'
 import {
   type Card,
   type Grade,
@@ -181,16 +181,16 @@ export default class LongTermScheduler extends AbstractScheduler {
     easy_interval = Math.max(easy_interval, good_interval + 1) as int
 
     next_again.scheduled_days = again_interval
-    next_again.due = this.review_time.scheduler(again_interval, true)
+    next_again.due = date_scheduler(this.review_time, again_interval, true)
 
     next_hard.scheduled_days = hard_interval
-    next_hard.due = this.review_time.scheduler(hard_interval, true)
+    next_hard.due = date_scheduler(this.review_time, hard_interval, true)
 
     next_good.scheduled_days = good_interval
-    next_good.due = this.review_time.scheduler(good_interval, true)
+    next_good.due = date_scheduler(this.review_time, good_interval, true)
 
     next_easy.scheduled_days = easy_interval
-    next_easy.due = this.review_time.scheduler(easy_interval, true)
+    next_easy.due = date_scheduler(this.review_time, easy_interval, true)
   }
 
   /**

--- a/src/fsrs/impl/long_term_scheduler.ts
+++ b/src/fsrs/impl/long_term_scheduler.ts
@@ -19,6 +19,7 @@ export default class LongTermScheduler extends AbstractScheduler {
     }
 
     this.current.scheduled_days = 0
+    // pending removal in v6.0.0
     this.current.elapsed_days = 0
 
     const next_again = TypeConvert.card(this.current)
@@ -72,7 +73,7 @@ export default class LongTermScheduler extends AbstractScheduler {
     if (exist) {
       return exist
     }
-    const interval = this.current.elapsed_days
+    const interval = this.elapsed_days
     const { difficulty, stability } = this.last
     const retrievability = this.algorithm.forgetting_curve(interval, stability)
     const next_again = TypeConvert.card(this.current)

--- a/src/fsrs/models.ts
+++ b/src/fsrs/models.ts
@@ -26,7 +26,13 @@ export interface ReviewLog {
   due: Date // Date of the last scheduling
   stability: number // Memory stability during the review
   difficulty: number // Difficulty of the card during the review
+  /**
+   * @deprecated This field will be removed in version 6.0.0
+   */
   elapsed_days: number // Number of days elapsed since the last review
+  /**
+   * @deprecated This field will be removed in version 6.0.0
+   */
   last_elapsed_days: number // Number of days between the last two reviews
   scheduled_days: number // Number of days until the next review
   learning_steps: number // Keeps track of the current step during the (re)learning stages
@@ -45,6 +51,9 @@ export interface Card {
   due: Date // Due date
   stability: number // Stability
   difficulty: number // Difficulty level
+  /**
+   * @deprecated This field will be removed in version 6.0.0
+   */
   elapsed_days: number // Number of days elapsed
   scheduled_days: number // Number of days scheduled
   learning_steps: number // Keeps track of the current step during the (re)learning stages

--- a/src/fsrs/reschedule.ts
+++ b/src/fsrs/reschedule.ts
@@ -1,6 +1,7 @@
 import { TypeConvert } from './convert'
 import { createEmptyCard } from './default'
 import type { FSRS } from './fsrs'
+import { date_diff } from './help'
 import {
   type Card,
   type CardInput,
@@ -83,7 +84,7 @@ export class Reschedule {
       if (typeof due === 'undefined') {
         throw new Error('reschedule: due is required for manual rating')
       }
-      const scheduled_days = due.diff(reviewed as Date, 'days')
+      const scheduled_days = date_diff(due, reviewed, 'days')
       log = {
         rating: Rating.Manual,
         state: <State>card.state,
@@ -129,7 +130,7 @@ export class Reschedule {
         // ref: abstract_scheduler.ts#init
         let interval = 0
         if (cur_card.state !== State.New && cur_card.last_review) {
-          interval = review.review.diff(cur_card.last_review as Date, 'days')
+          interval = date_diff(review.review, cur_card.last_review, 'days')
         }
         item = this.handleManualRating(
           cur_card,
@@ -164,8 +165,9 @@ export class Reschedule {
     if (cur_card.due.getTime() === reschedule_card.due.getTime()) {
       return null
     }
-    cur_card.scheduled_days = reschedule_card.due.diff(
-      cur_card.due as Date,
+    cur_card.scheduled_days = date_diff(
+      reschedule_card.due,
+      cur_card.due,
       'days'
     )
     return this.handleManualRating(


### PR DESCRIPTION
There are some methods that are currently preventing me from publishing the package to JSR, so I need to mark them for now and plan to remove them in version 6.0.0.
> Publishing to JSR will allow ts-fsrs to support Deno.

This change will reduce the unit test coverage to 99%.