### PR TITLE
Permit mock date objects that convert to Date values

### DIFF
--- a/__tests__/help.test.ts
+++ b/__tests__/help.test.ts
@@ -131,6 +131,29 @@ describe('TypeConvert.time', () => {
     const input = null
     expect(() => TypeConvert.time(input)).toThrow('Invalid date:[null]')
   })
+
+  test('accepts mock date objects', () => {
+    const input = { toString: () => '2025-08-12T00:00:00Z' }
+    const expected = new Date('2025-08-12T00:00:00Z')
+    expect(TypeConvert.time(input)).toEqual(expected)
+  })
+
+  test('accepts string objects', () => {
+    const input = new String('2025-08-12T00:00:00Z')
+    const expected = new Date('2025-08-12T00:00:00Z')
+    expect(TypeConvert.time(input)).toEqual(expected)
+  })
+
+  test('accepts number objects', () => {
+    const input = new Number(1.755e12)
+    const expected = new Date(1.755e12)
+    expect(TypeConvert.time(input)).toEqual(expected)
+  })
+
+  test('throws error for invalid mock date objects', () => {
+    const input = {}
+    expect(() => TypeConvert.time(input)).toThrow('[object Object]')
+  })
 })
 
 describe('TypeConvert.state', () => {

--- a/src/fsrs/convert.ts
+++ b/src/fsrs/convert.ts
@@ -47,8 +47,13 @@ export class TypeConvert {
     throw new Error(`Invalid state:[${value}]`)
   }
   static time(value: unknown): Date {
-    if (typeof value === 'object' && value instanceof Date) {
-      return value
+    const date = new Date(value as string)
+    if (
+      typeof value === 'object' &&
+      value !== null &&
+      !Number.isNaN(Date.parse(value as unknown as string) || +date)
+    ) {
+      return date
     } else if (typeof value === 'string') {
       const timestamp = Date.parse(value)
       if (!Number.isNaN(timestamp)) {


### PR DESCRIPTION
Convert to Date any object which both parses and produces a valid Date object if passed into the Date constructor.

This prevents errors for users with browser plugins which manipulates or mocks the global Date object.