### PR TITLE
fix(tsconfig): scope `vitest/globals` to `__tests__` only

### DIFF
--- a/packages/binding/__tests__/tsconfig.json
+++ b/packages/binding/__tests__/tsconfig.json
@@ -8,7 +8,8 @@
     "paths": {
       "@open-spaced-repetition/binding": ["../dist/index.d.ts"],
       "@open-spaced-repetition/binding/*": ["../dist/*"]
-    }
+    },
+    "types": ["vitest/globals", "node"]
   },
   "include": ["."],
   "exclude": ["lib"]

--- a/packages/binding/tsconfig.json
+++ b/packages/binding/tsconfig.json
@@ -11,7 +11,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "noEmitHelpers": true,
-    "types": ["vitest/globals", "node"]
+    "types": ["node"]
   },
   "include": ["."],
   "exclude": ["node_modules", "benchmark", "__test__", ".cargo"]

--- a/packages/fsrs/__tests__/tsconfig.json
+++ b/packages/fsrs/__tests__/tsconfig.json
@@ -4,7 +4,8 @@
     "paths": {
       "ts-fsrs": ["../src/index.ts"],
       "ts-fsrs/*": ["../src/*"]
-    }
+    },
+    "types": ["vitest/globals", "node"]
   },
   "include": ["."],
   "exclude": []

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -101,7 +101,7 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": false /* Skip type checking all .d.ts files. */,
-    "types": ["vitest/globals", "node"]
+    "types": ["node"]
   },
   "include": ["."],
   "exclude": ["node_modules", "target", ".cargo", "packages/binding/**"],


### PR DESCRIPTION
Make `vitest/globals` apply only to the `__tests__` directory.