### PR TITLE
perf(fsrs): implement caching for decay and factor in FSRSAlgorithm

### DIFF
--- a/.changeset/cache-decay-factor.md
+++ b/.changeset/cache-decay-factor.md
@@ -1,0 +1,10 @@
+---
+"ts-fsrs": patch
+---
+
+perf: cache decay/factor in FSRSAlgorithm to avoid redundant computation in forgetting_curve
+
+- Replace bound `forgetting_curve` function with an instance method that uses cached `decay`/`factor` values
+- Cache is updated automatically when `w` parameters change via proxy handler
+- Add benchmark suite for `next_state` and `forgetting_curve` in `packages/fsrs/bench/`
+- Add `forgetting_curve.test.ts` covering cache consistency, concurrent mutations, and multi-instance independence

--- a/packages/fsrs/__tests__/algorithm.test.ts
+++ b/packages/fsrs/__tests__/algorithm.test.ts
@@ -20,9 +20,9 @@ import {
 } from 'ts-fsrs'
 
 const _computeDecayFactor = (decay: number) => {
-  const DECAY = -decay
+  const DECAY = decay
   const FACTOR = +new Decimal(0.9)
-    .pow(new Decimal(1).div(DECAY))
+    .pow(new Decimal(1).div(-DECAY))
     .sub(1)
     .toFixed(8)
   return { DECAY, FACTOR }
@@ -91,7 +91,7 @@ describe('forgetting_curve', () => {
     return +new Decimal(
       new Decimal(1)
         .add(new Decimal(FACTOR).mul(elapsed_days).div(stability))
-        .pow(DECAY)
+        .pow(-DECAY)
     ).toFixed(8)
   }
   // https://github.com/open-spaced-repetition/fsrs-rs/blob/3e2f0b423fed194d238cdcb55c1baccd0eca63f0/src/pre_training.rs#L289-L296
@@ -363,7 +363,7 @@ describe('next_interval', () => {
     const params = generatorParameters({ maximum_interval: 365 })
     const { decay, factor } = computeDecayFactor(params.w)
     const intervalModifier =
-      (Math.pow(params.request_retention, 1 / decay) - 1) / factor
+      (Math.pow(params.request_retention, 1 / -decay) - 1) / factor
     let f: FSRS = fsrs(params)
 
     const s = 737.47

--- a/packages/fsrs/__tests__/algorithm.test.ts
+++ b/packages/fsrs/__tests__/algorithm.test.ts
@@ -20,9 +20,9 @@ import {
 } from 'ts-fsrs'
 
 const _computeDecayFactor = (decay: number) => {
-  const DECAY = decay
+  const DECAY = -decay
   const FACTOR = +new Decimal(0.9)
-    .pow(new Decimal(1).div(-DECAY))
+    .pow(new Decimal(1).div(DECAY))
     .sub(1)
     .toFixed(8)
   return { DECAY, FACTOR }
@@ -91,7 +91,7 @@ describe('forgetting_curve', () => {
     return +new Decimal(
       new Decimal(1)
         .add(new Decimal(FACTOR).mul(elapsed_days).div(stability))
-        .pow(-DECAY)
+        .pow(DECAY)
     ).toFixed(8)
   }
   // https://github.com/open-spaced-repetition/fsrs-rs/blob/3e2f0b423fed194d238cdcb55c1baccd0eca63f0/src/pre_training.rs#L289-L296
@@ -363,7 +363,7 @@ describe('next_interval', () => {
     const params = generatorParameters({ maximum_interval: 365 })
     const { decay, factor } = computeDecayFactor(params.w)
     const intervalModifier =
-      (Math.pow(params.request_retention, 1 / -decay) - 1) / factor
+      (Math.pow(params.request_retention, 1 / decay) - 1) / factor
     let f: FSRS = fsrs(params)
 
     const s = 737.47

--- a/packages/fsrs/__tests__/forgetting_curve.test.ts
+++ b/packages/fsrs/__tests__/forgetting_curve.test.ts
@@ -290,10 +290,10 @@ describe('forgetting_curve cache consistency', () => {
       const algorithm = new FSRSAlgorithm(defaultParams)
       const { decay, factor } = computeDecayFactor(default_w)
 
-      // Verify via forgetting_curve formula: R = (1 + factor * t / s) ^ decay
+      // Verify via forgetting_curve formula: R = (1 + factor * t / s) ^ -decay
       const t = 5
       const s = 30.0
-      const expected = +Math.pow(1 + (factor * t) / s, decay).toFixed(8)
+      const expected = +Math.pow(1 + (factor * t) / s, -decay).toFixed(8)
       // roundTo(x, 8) may differ slightly from toFixed(8), so use toBeCloseTo
       expect(algorithm.forgetting_curve(t, s)).toBeCloseTo(expected, 8)
     })
@@ -308,7 +308,7 @@ describe('forgetting_curve cache consistency', () => {
       const { decay, factor } = computeDecayFactor(new_w)
       const t = 10
       const s = 50.0
-      const expected = +Math.pow(1 + (factor * t) / s, decay).toFixed(8)
+      const expected = +Math.pow(1 + (factor * t) / s, -decay).toFixed(8)
       expect(algorithm.forgetting_curve(t, s)).toBeCloseTo(expected, 8)
     })
   })

--- a/packages/fsrs/__tests__/forgetting_curve.test.ts
+++ b/packages/fsrs/__tests__/forgetting_curve.test.ts
@@ -290,10 +290,10 @@ describe('forgetting_curve cache consistency', () => {
       const algorithm = new FSRSAlgorithm(defaultParams)
       const { decay, factor } = computeDecayFactor(default_w)
 
-      // Verify via forgetting_curve formula: R = (1 + factor * t / s) ^ -decay
+      // Verify via forgetting_curve formula: R = (1 + factor * t / s) ^ decay
       const t = 5
       const s = 30.0
-      const expected = +Math.pow(1 + (factor * t) / s, -decay).toFixed(8)
+      const expected = +Math.pow(1 + (factor * t) / s, decay).toFixed(8)
       // roundTo(x, 8) may differ slightly from toFixed(8), so use toBeCloseTo
       expect(algorithm.forgetting_curve(t, s)).toBeCloseTo(expected, 8)
     })
@@ -308,7 +308,7 @@ describe('forgetting_curve cache consistency', () => {
       const { decay, factor } = computeDecayFactor(new_w)
       const t = 10
       const s = 50.0
-      const expected = +Math.pow(1 + (factor * t) / s, -decay).toFixed(8)
+      const expected = +Math.pow(1 + (factor * t) / s, decay).toFixed(8)
       expect(algorithm.forgetting_curve(t, s)).toBeCloseTo(expected, 8)
     })
   })

--- a/packages/fsrs/__tests__/forgetting_curve.test.ts
+++ b/packages/fsrs/__tests__/forgetting_curve.test.ts
@@ -4,8 +4,8 @@ import {
   FSRS5_DEFAULT_DECAY,
   FSRS6_DEFAULT_DECAY,
   FSRSAlgorithm,
-  fsrs,
   forgetting_curve,
+  fsrs,
   generatorParameters,
 } from 'ts-fsrs'
 
@@ -22,14 +22,11 @@ describe('forgetting_curve cache consistency', () => {
       { t: 90, s: 365.0 },
     ]
 
-    it.each(testCases)(
-      'forgetting_curve(t=$t, s=$s)',
-      ({ t, s }) => {
-        const instanceResult = algorithm.forgetting_curve(t, s)
-        const standaloneResult = forgetting_curve(default_w, t, s)
-        expect(instanceResult).toBe(standaloneResult)
-      }
-    )
+    it.each(testCases)('forgetting_curve(t=$t, s=$s)', ({ t, s }) => {
+      const instanceResult = algorithm.forgetting_curve(t, s)
+      const standaloneResult = forgetting_curve(default_w, t, s)
+      expect(instanceResult).toBe(standaloneResult)
+    })
   })
 
   describe('cache updates correctly when w changes via parameters setter', () => {
@@ -92,6 +89,60 @@ describe('forgetting_curve cache consistency', () => {
 
       expect(after).not.toBe(before)
       expect(after).toBe(expected)
+    })
+  })
+
+  describe('cache updates on in-place w element mutation', () => {
+    it('fsrs: parameters.w[20] = newValue', () => {
+      const f = fsrs({})
+      const before = f.forgetting_curve(5, 30.0)
+
+      ;(f.parameters.w as number[])[20] = FSRS5_DEFAULT_DECAY
+      const after = f.forgetting_curve(5, 30.0)
+      const expected = forgetting_curve(FSRS5_DEFAULT_DECAY, 5, 30.0)
+
+      expect(after).not.toBe(before)
+      expect(after).toBe(expected)
+    })
+
+    it('FSRSAlgorithm: parameters.w[20] = newValue', () => {
+      const algo = new FSRSAlgorithm({})
+      const before = algo.forgetting_curve(5, 30.0)
+
+      ;(algo.parameters.w as number[])[20] = FSRS5_DEFAULT_DECAY
+      const after = algo.forgetting_curve(5, 30.0)
+      const expected = forgetting_curve(FSRS5_DEFAULT_DECAY, 5, 30.0)
+
+      expect(after).not.toBe(before)
+      expect(after).toBe(expected)
+    })
+
+    it('non-numeric property on w does not trigger cache update', () => {
+      const f = fsrs({})
+      const before = f.forgetting_curve(5, 30.0)
+
+      // Pushing an extra element triggers 'set' with numeric index AND 'length',
+      // but only the numeric index should call updateDecayFactor.
+      // Here we verify that after push + restoring length, the cache stays correct.
+      const w = f.parameters.w as number[]
+      const originalLength = w.length
+      w.push(0)
+      w.length = originalLength
+      // decay value (w[20]) was not changed, so forgetting_curve should return the same
+      expect(f.forgetting_curve(5, 30.0)).toBe(before)
+    })
+
+    it('in-place then full assignment round-trip', () => {
+      const f = fsrs({})
+      const original = f.forgetting_curve(5, 30.0)
+
+      // In-place mutation
+      ;(f.parameters.w as number[])[20] = FSRS5_DEFAULT_DECAY
+      expect(f.forgetting_curve(5, 30.0)).not.toBe(original)
+
+      // Full assignment back to default
+      f.parameters.w = default_w
+      expect(f.forgetting_curve(5, 30.0)).toBe(original)
     })
   })
 
@@ -242,9 +293,7 @@ describe('forgetting_curve cache consistency', () => {
       // Verify via forgetting_curve formula: R = (1 + factor * t / s) ^ decay
       const t = 5
       const s = 30.0
-      const expected = +(
-        Math.pow(1 + (factor * t) / s, decay)
-      ).toFixed(8)
+      const expected = +Math.pow(1 + (factor * t) / s, decay).toFixed(8)
       // roundTo(x, 8) may differ slightly from toFixed(8), so use toBeCloseTo
       expect(algorithm.forgetting_curve(t, s)).toBeCloseTo(expected, 8)
     })
@@ -259,9 +308,7 @@ describe('forgetting_curve cache consistency', () => {
       const { decay, factor } = computeDecayFactor(new_w)
       const t = 10
       const s = 50.0
-      const expected = +(
-        Math.pow(1 + (factor * t) / s, decay)
-      ).toFixed(8)
+      const expected = +Math.pow(1 + (factor * t) / s, decay).toFixed(8)
       expect(algorithm.forgetting_curve(t, s)).toBeCloseTo(expected, 8)
     })
   })

--- a/packages/fsrs/__tests__/forgetting_curve.test.ts
+++ b/packages/fsrs/__tests__/forgetting_curve.test.ts
@@ -1,0 +1,268 @@
+import {
+  computeDecayFactor,
+  default_w,
+  FSRS5_DEFAULT_DECAY,
+  FSRS6_DEFAULT_DECAY,
+  FSRSAlgorithm,
+  fsrs,
+  forgetting_curve,
+  generatorParameters,
+} from 'ts-fsrs'
+
+describe('forgetting_curve cache consistency', () => {
+  const defaultParams = generatorParameters()
+
+  describe('instance method matches standalone function after construction', () => {
+    const algorithm = new FSRSAlgorithm(defaultParams)
+    const testCases = [
+      { t: 0, s: 1.0 },
+      { t: 1, s: 1.2931 },
+      { t: 5, s: 30.0 },
+      { t: 30, s: 180.0 },
+      { t: 90, s: 365.0 },
+    ]
+
+    it.each(testCases)(
+      'forgetting_curve(t=$t, s=$s)',
+      ({ t, s }) => {
+        const instanceResult = algorithm.forgetting_curve(t, s)
+        const standaloneResult = forgetting_curve(default_w, t, s)
+        expect(instanceResult).toBe(standaloneResult)
+      }
+    )
+  })
+
+  describe('cache updates correctly when w changes via parameters setter', () => {
+    it('FSRSAlgorithm.parameters = { w: new_w }', () => {
+      const algorithm = new FSRSAlgorithm(defaultParams)
+      const before = algorithm.forgetting_curve(5, 30.0)
+
+      // Change w[20] to FSRS5 decay (0.5)
+      const new_w = [...default_w]
+      new_w[20] = FSRS5_DEFAULT_DECAY
+      algorithm.parameters = { w: new_w }
+
+      const after = algorithm.forgetting_curve(5, 30.0)
+      const expected = forgetting_curve(FSRS5_DEFAULT_DECAY, 5, 30.0)
+
+      expect(after).not.toBe(before)
+      expect(after).toBe(expected)
+    })
+
+    it('FSRSAlgorithm.parameters.w = new_w', () => {
+      const algorithm = new FSRSAlgorithm(defaultParams)
+      const before = algorithm.forgetting_curve(5, 30.0)
+
+      const new_w = [...default_w]
+      new_w[20] = FSRS5_DEFAULT_DECAY
+      algorithm.parameters.w = new_w
+
+      const after = algorithm.forgetting_curve(5, 30.0)
+      const expected = forgetting_curve(FSRS5_DEFAULT_DECAY, 5, 30.0)
+
+      expect(after).not.toBe(before)
+      expect(after).toBe(expected)
+    })
+
+    it('fsrs instance: parameters = { w: new_w }', () => {
+      const f = fsrs({})
+      const before = f.forgetting_curve(5, 30.0)
+
+      const new_w = [...default_w]
+      new_w[20] = FSRS5_DEFAULT_DECAY
+      f.parameters = { w: new_w }
+
+      const after = f.forgetting_curve(5, 30.0)
+      const expected = forgetting_curve(FSRS5_DEFAULT_DECAY, 5, 30.0)
+
+      expect(after).not.toBe(before)
+      expect(after).toBe(expected)
+    })
+
+    it('fsrs instance: parameters.w = new_w', () => {
+      const f = fsrs({})
+      const before = f.forgetting_curve(10, 31.722975)
+
+      const new_w = [...default_w]
+      new_w[20] = FSRS5_DEFAULT_DECAY
+      f.parameters.w = new_w
+
+      const after = f.forgetting_curve(10, 31.722975)
+      const expected = forgetting_curve(FSRS5_DEFAULT_DECAY, 10, 31.722975)
+
+      expect(after).not.toBe(before)
+      expect(after).toBe(expected)
+    })
+  })
+
+  describe('cache resets correctly when w reverts to default', () => {
+    it('round-trip: default -> custom -> default', () => {
+      const f = fsrs({})
+      const original = f.forgetting_curve(5, 30.0)
+
+      // Change to custom
+      const new_w = [...default_w]
+      new_w[20] = FSRS5_DEFAULT_DECAY
+      f.parameters.w = new_w
+      expect(f.forgetting_curve(5, 30.0)).not.toBe(original)
+
+      // Revert to default
+      f.parameters.w = default_w
+      expect(f.forgetting_curve(5, 30.0)).toBe(original)
+    })
+  })
+
+  describe('multiple instances with different w are independent', () => {
+    it('two FSRSAlgorithm instances do not interfere', () => {
+      const a = new FSRSAlgorithm({ w: default_w })
+
+      const custom_w = [...default_w]
+      custom_w[20] = FSRS5_DEFAULT_DECAY
+      const b = new FSRSAlgorithm({ w: custom_w })
+
+      const resultA = a.forgetting_curve(5, 30.0)
+      const resultB = b.forgetting_curve(5, 30.0)
+
+      expect(resultA).not.toBe(resultB)
+      expect(resultA).toBe(forgetting_curve(FSRS6_DEFAULT_DECAY, 5, 30.0))
+      expect(resultB).toBe(forgetting_curve(FSRS5_DEFAULT_DECAY, 5, 30.0))
+    })
+
+    it('interleaved calls remain correct', () => {
+      const a = fsrs({})
+      const custom_w = [...default_w]
+      custom_w[20] = FSRS5_DEFAULT_DECAY
+      const b = fsrs({ w: custom_w })
+
+      for (let t = 1; t <= 10; t++) {
+        const ra = a.forgetting_curve(t, 30.0)
+        const rb = b.forgetting_curve(t, 30.0)
+        expect(ra).toBe(forgetting_curve(default_w, t, 30.0))
+        expect(rb).toBe(forgetting_curve(FSRS5_DEFAULT_DECAY, t, 30.0))
+        expect(ra).not.toBe(rb)
+      }
+    })
+  })
+
+  describe('concurrent w mutations across instances', () => {
+    it('Promise.all: multiple instances update w simultaneously', async () => {
+      const decays = [0.15, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
+      const instances = decays.map((decay) => {
+        const w = [...default_w]
+        w[20] = decay
+        return fsrs({ w })
+      })
+
+      const results = await Promise.all(
+        instances.map(async (f, i) => {
+          // Yield to event loop to interleave execution
+          await Promise.resolve()
+          const r = f.forgetting_curve(5, 30.0)
+          const expected = forgetting_curve(decays[i], 5, 30.0)
+          return { actual: r, expected, decay: decays[i] }
+        })
+      )
+
+      for (const { actual, expected } of results) {
+        expect(actual).toBe(expected)
+      }
+    })
+
+    it('Promise.all: w changes during concurrent reads', async () => {
+      const f = fsrs({})
+
+      const tasks = Array.from({ length: 20 }, async (_, i) => {
+        await Promise.resolve()
+        if (i === 10) {
+          // Mid-way through, change w
+          const new_w = [...default_w]
+          new_w[20] = FSRS5_DEFAULT_DECAY
+          f.parameters.w = new_w
+        }
+        // After mutation, result must match current w state
+        const r = f.forgetting_curve(5, 30.0)
+        const currentDecay = f.parameters.w[20]
+        const expected = forgetting_curve(currentDecay, 5, 30.0)
+        return { actual: r, expected }
+      })
+
+      const results = await Promise.all(tasks)
+      for (const { actual, expected } of results) {
+        expect(actual).toBe(expected)
+      }
+    })
+
+    it('rapid sequential w mutations stay consistent', () => {
+      const f = fsrs({})
+      const decays = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
+
+      for (const decay of decays) {
+        const new_w = [...default_w]
+        new_w[20] = decay
+        f.parameters.w = new_w
+
+        const result = f.forgetting_curve(5, 30.0)
+        const expected = forgetting_curve(decay, 5, 30.0)
+        expect(result).toBe(expected)
+      }
+    })
+
+    it('interleaved w mutations on two instances', () => {
+      const a = fsrs({})
+      const b = fsrs({})
+
+      const decaysA = [0.15, 0.3, 0.5, 0.7]
+      const decaysB = [0.2, 0.4, 0.6, 0.8]
+
+      for (let i = 0; i < decaysA.length; i++) {
+        const wA = [...default_w]
+        wA[20] = decaysA[i]
+        a.parameters.w = wA
+
+        const wB = [...default_w]
+        wB[20] = decaysB[i]
+        b.parameters.w = wB
+
+        // Each instance must reflect its own w, not the other's
+        expect(a.forgetting_curve(5, 30.0)).toBe(
+          forgetting_curve(decaysA[i], 5, 30.0)
+        )
+        expect(b.forgetting_curve(5, 30.0)).toBe(
+          forgetting_curve(decaysB[i], 5, 30.0)
+        )
+      }
+    })
+  })
+
+  describe('computeDecayFactor consistency', () => {
+    it('instance cache matches computeDecayFactor output', () => {
+      const algorithm = new FSRSAlgorithm(defaultParams)
+      const { decay, factor } = computeDecayFactor(default_w)
+
+      // Verify via forgetting_curve formula: R = (1 + factor * t / s) ^ decay
+      const t = 5
+      const s = 30.0
+      const expected = +(
+        Math.pow(1 + (factor * t) / s, decay)
+      ).toFixed(8)
+      // roundTo(x, 8) may differ slightly from toFixed(8), so use toBeCloseTo
+      expect(algorithm.forgetting_curve(t, s)).toBeCloseTo(expected, 8)
+    })
+
+    it('after w change, cache matches new computeDecayFactor', () => {
+      const algorithm = new FSRSAlgorithm(defaultParams)
+
+      const new_w = [...default_w]
+      new_w[20] = 0.3
+      algorithm.parameters.w = new_w
+
+      const { decay, factor } = computeDecayFactor(new_w)
+      const t = 10
+      const s = 50.0
+      const expected = +(
+        Math.pow(1 + (factor * t) / s, decay)
+      ).toFixed(8)
+      expect(algorithm.forgetting_curve(t, s)).toBeCloseTo(expected, 8)
+    })
+  })
+})

--- a/packages/fsrs/bench/next_state.bench.ts
+++ b/packages/fsrs/bench/next_state.bench.ts
@@ -1,0 +1,165 @@
+import { bench, describe } from 'vitest'
+import {
+  FSRSAlgorithm,
+  forgetting_curve,
+  computeDecayFactor,
+} from '../src/algorithm'
+import { default_w } from '../src/constant'
+import { Rating, type FSRSState } from '../src/models'
+import { fsrs } from '../src/fsrs'
+
+// Weights from real-world Anki FSRS training output (19 params, auto-migrated to 21)
+const weights = [
+  0.40255, 1.18385, 3.173, 15.69105, 7.1949, 0.5345, 1.4604, 0.0046,
+  1.54575, 0.1192, 1.01925, 1.9395, 0.11, 0.29605, 2.2698, 0.2315, 2.9898,
+  0.51655, 0.6621,
+]
+
+const algorithm = new FSRSAlgorithm({})
+const algorithmCustom = new FSRSAlgorithm({ w: weights })
+const FSRS_A = fsrs({ w: weights })
+const FSRS_B = fsrs({}) // default weights
+
+// Pre-computed states for benchmarking
+const newState: FSRSState | null = null
+const learningState: FSRSState = { difficulty: 5.0, stability: 1.2931 }
+const reviewState: FSRSState = { difficulty: 6.5, stability: 30.0 }
+const matureState: FSRSState = { difficulty: 4.2, stability: 180.0 }
+
+// --- forgetting_curve benchmarks ---
+
+describe('forgetting_curve - standalone function', () => {
+  bench('with decay number (default_w[20])', () => {
+    forgetting_curve(default_w[20], 5, 30.0)
+  })
+  bench('with params array (default_w)', () => {
+    forgetting_curve(default_w, 5, 30.0)
+  })
+  bench('with custom weights array', () => {
+    forgetting_curve(weights, 5, 30.0)
+  })
+})
+
+describe('forgetting_curve - instance method (cached)', () => {
+  bench('default params: t=5, s=30', () => {
+    algorithm.forgetting_curve(5, 30.0)
+  })
+  bench('custom weights: t=5, s=30', () => {
+    algorithmCustom.forgetting_curve(5, 30.0)
+  })
+  bench('fsrs instance: t=10, s=31.72', () => {
+    FSRS_A.forgetting_curve(10, 31.722975)
+  })
+  bench('t=1, s=1.29', () => {
+    algorithm.forgetting_curve(1, 1.2931)
+  })
+  bench('t=30, s=180', () => {
+    algorithm.forgetting_curve(30, 180.0)
+  })
+  bench('t=90, s=365', () => {
+    algorithm.forgetting_curve(90, 365.0)
+  })
+})
+
+describe('forgetting_curve - multi-instance interleaved', () => {
+  bench('alternate between two FSRS instances (100 calls)', () => {
+    for (let i = 0; i < 100; i++) {
+      if (i % 2 === 0) {
+        FSRS_A.forgetting_curve(i + 1, 31.722975)
+      } else {
+        FSRS_B.forgetting_curve(i + 1, 50.0)
+      }
+    }
+  })
+})
+
+describe('computeDecayFactor', () => {
+  bench('from decay number', () => {
+    computeDecayFactor(default_w[20])
+  })
+  bench('from params array', () => {
+    computeDecayFactor(default_w)
+  })
+})
+
+// --- next_state benchmarks ---
+
+describe('next_state - new card (null state)', () => {
+  bench('grade Again', () => {
+    algorithm.next_state(newState, 0, Rating.Again)
+  })
+  bench('grade Hard', () => {
+    algorithm.next_state(newState, 0, Rating.Hard)
+  })
+  bench('grade Good', () => {
+    algorithm.next_state(newState, 0, Rating.Good)
+  })
+  bench('grade Easy', () => {
+    algorithm.next_state(newState, 0, Rating.Easy)
+  })
+})
+
+describe('next_state - learning (short-term, t=0)', () => {
+  bench('grade Again', () => {
+    algorithm.next_state(learningState, 0, Rating.Again)
+  })
+  bench('grade Hard', () => {
+    algorithm.next_state(learningState, 0, Rating.Hard)
+  })
+  bench('grade Good', () => {
+    algorithm.next_state(learningState, 0, Rating.Good)
+  })
+  bench('grade Easy', () => {
+    algorithm.next_state(learningState, 0, Rating.Easy)
+  })
+})
+
+describe('next_state - review (t=5)', () => {
+  bench('grade Again', () => {
+    algorithm.next_state(reviewState, 5, Rating.Again)
+  })
+  bench('grade Hard', () => {
+    algorithm.next_state(reviewState, 5, Rating.Hard)
+  })
+  bench('grade Good', () => {
+    algorithm.next_state(reviewState, 5, Rating.Good)
+  })
+  bench('grade Easy', () => {
+    algorithm.next_state(reviewState, 5, Rating.Easy)
+  })
+})
+
+describe('next_state - mature card (t=30)', () => {
+  bench('grade Again', () => {
+    algorithm.next_state(matureState, 30, Rating.Again)
+  })
+  bench('grade Hard', () => {
+    algorithm.next_state(matureState, 30, Rating.Hard)
+  })
+  bench('grade Good', () => {
+    algorithm.next_state(matureState, 30, Rating.Good)
+  })
+  bench('grade Easy', () => {
+    algorithm.next_state(matureState, 30, Rating.Easy)
+  })
+})
+
+describe('next_state - with pre-computed retrievability', () => {
+  bench('grade Good with r=0.9', () => {
+    algorithm.next_state(reviewState, 5, Rating.Good, 0.9)
+  })
+  bench('grade Again with r=0.7', () => {
+    algorithm.next_state(reviewState, 5, Rating.Again, 0.7)
+  })
+})
+
+describe('next_state - batch simulation (100 reviews)', () => {
+  bench('simulate 100 sequential reviews', () => {
+    let state: FSRSState | null = null
+    for (let i = 0; i < 100; i++) {
+      const grade = (i % 4) + 1 // cycle through 1-4
+      const t = state === null ? 0 : Math.max(1, Math.floor(state.stability))
+      state = algorithm.next_state(state, t, grade)
+    }
+  })
+})

--- a/packages/fsrs/package.json
+++ b/packages/fsrs/package.json
@@ -20,6 +20,7 @@
     "check": "biome check ./src",
     "check:fix": "biome check --write ./src",
     "dev": "rollup -c rollup.config.ts --configPlugin esbuild -w",
+    "bench": "vitest bench --config=vitest.config.ts",
     "test": "vitest run --config=vitest.config.ts --passWithNoTests",
     "test:coverage": "vitest run --config=vitest.config.ts --passWithNoTests --coverage",
     "test::publish": "yalc publish",

--- a/packages/fsrs/src/algorithm.ts
+++ b/packages/fsrs/src/algorithm.ts
@@ -10,21 +10,16 @@ import {
 } from './models'
 import type { int } from './types'
 /**
- * $$\text{decay} = w_{20}$$
+ * $$\text{decay} = -w_{20}$$
  *
- * $$\text{factor} = e^{\frac{\ln 0.9}{-\text{decay}}} - 1$$
- *
- * TODO: decay was previously returned as negative (-w[20]).
- * Now returns positive (w[20]) with Math.abs for backwards compatibility.
- * Remove Math.abs in the next major version.
+ * $$\text{factor} = e^{\frac{\ln 0.9}{\text{decay}}} - 1$$
  */
 export const computeDecayFactor = (
   decayOrParams: number | number[] | readonly number[]
 ) => {
-  const decay = Math.abs(
-    typeof decayOrParams === 'number' ? decayOrParams : decayOrParams[20]
-  )
-  const factor = Math.exp(Math.pow(-decay, -1) * Math.log(0.9)) - 1.0
+  const decay =
+    typeof decayOrParams === 'number' ? -decayOrParams : -decayOrParams[20]
+  const factor = Math.exp(Math.pow(decay, -1) * Math.log(0.9)) - 1.0
   return { decay, factor: roundTo(factor, 8) }
 }
 
@@ -34,7 +29,7 @@ export function forgetting_curve_inner(
   elapsed_days: number,
   stability: number
 ): number {
-  return roundTo(Math.pow(1 + (factor * elapsed_days) / stability, -decay), 8)
+  return roundTo(Math.pow(1 + (factor * elapsed_days) / stability, decay), 8)
 }
 
 /**
@@ -111,7 +106,7 @@ export class FSRSAlgorithm {
       throw new Error('Requested retention rate should be in the range (0,1]')
     }
     return roundTo(
-      (Math.pow(request_retention, 1 / -this.cachedDecay) - 1) /
+      (Math.pow(request_retention, 1 / this.cachedDecay) - 1) /
         this.cachedFactor,
       8
     )

--- a/packages/fsrs/src/algorithm.ts
+++ b/packages/fsrs/src/algorithm.ts
@@ -57,16 +57,24 @@ export class FSRSAlgorithm {
   protected param!: FSRSParameters
   protected intervalModifier!: number
   protected _seed?: string
+  private cachedDecay!: number
+  private cachedFactor!: number
 
   constructor(params: Partial<FSRSParameters>) {
     this.param = new Proxy(
       generatorParameters(params),
       this.params_handler_proxy()
     )
+    this.updateDecayFactor()
     this.intervalModifier = this.calculate_interval_modifier(
       this.param.request_retention
     )
-    this.forgetting_curve = forgetting_curve.bind(this, this.param.w)
+  }
+
+  protected updateDecayFactor(): void {
+    const { decay, factor } = computeDecayFactor(this.param.w)
+    this.cachedDecay = decay
+    this.cachedFactor = factor
   }
 
   get interval_modifier(): number {
@@ -88,8 +96,11 @@ export class FSRSAlgorithm {
     if (request_retention <= 0 || request_retention > 1) {
       throw new Error('Requested retention rate should be in the range (0,1]')
     }
-    const { decay, factor } = computeDecayFactor(this.param.w)
-    return roundTo((Math.pow(request_retention, 1 / decay) - 1) / factor, 8)
+    return roundTo(
+      (Math.pow(request_retention, 1 / this.cachedDecay) - 1) /
+        this.cachedFactor,
+      8
+    )
   }
 
   /**
@@ -125,10 +136,12 @@ export class FSRSAlgorithm {
             target.relearning_steps.length,
             target.enable_short_term
           )
-          _this.forgetting_curve = forgetting_curve.bind(this, value)
+          Reflect.set(target, prop, value)
+          _this.updateDecayFactor()
           _this.intervalModifier = _this.calculate_interval_modifier(
             Number(target.request_retention)
           )
+          return true
         }
         Reflect.set(target, prop, value)
         return true
@@ -317,7 +330,15 @@ export class FSRSAlgorithm {
    * @param {number} stability Stability (interval when R=90%)
    * @return {number} r Retrievability (probability of recall)
    */
-  forgetting_curve: (elapsed_days: number, stability: number) => number
+  forgetting_curve(elapsed_days: number, stability: number): number {
+    return roundTo(
+      Math.pow(
+        1 + (this.cachedFactor * elapsed_days) / stability,
+        this.cachedDecay
+      ),
+      8
+    )
+  }
   /**
    * Calculates the next state of memory based on the current state, time elapsed, and grade.
    *

--- a/packages/fsrs/src/algorithm.ts
+++ b/packages/fsrs/src/algorithm.ts
@@ -10,16 +10,21 @@ import {
 } from './models'
 import type { int } from './types'
 /**
- * $$\text{decay} = -w_{20}$$
+ * $$\text{decay} = w_{20}$$
  *
- * $$\text{factor} = e^{\frac{\ln 0.9}{\text{decay}}} - 1$$
+ * $$\text{factor} = e^{\frac{\ln 0.9}{-\text{decay}}} - 1$$
+ *
+ * TODO: decay was previously returned as negative (-w[20]).
+ * Now returns positive (w[20]) with Math.abs for backwards compatibility.
+ * Remove Math.abs in the next major version.
  */
 export const computeDecayFactor = (
   decayOrParams: number | number[] | readonly number[]
 ) => {
-  const decay =
-    typeof decayOrParams === 'number' ? -decayOrParams : -decayOrParams[20]
-  const factor = Math.exp(Math.pow(decay, -1) * Math.log(0.9)) - 1.0
+  const decay = Math.abs(
+    typeof decayOrParams === 'number' ? decayOrParams : decayOrParams[20]
+  )
+  const factor = Math.exp(Math.pow(-decay, -1) * Math.log(0.9)) - 1.0
   return { decay, factor: roundTo(factor, 8) }
 }
 
@@ -29,7 +34,7 @@ export function forgetting_curve_inner(
   elapsed_days: number,
   stability: number
 ): number {
-  return roundTo(Math.pow(1 + (factor * elapsed_days) / stability, decay), 8)
+  return roundTo(Math.pow(1 + (factor * elapsed_days) / stability, -decay), 8)
 }
 
 /**
@@ -106,7 +111,7 @@ export class FSRSAlgorithm {
       throw new Error('Requested retention rate should be in the range (0,1]')
     }
     return roundTo(
-      (Math.pow(request_retention, 1 / this.cachedDecay) - 1) /
+      (Math.pow(request_retention, 1 / -this.cachedDecay) - 1) /
         this.cachedFactor,
       8
     )

--- a/packages/fsrs/src/algorithm.ts
+++ b/packages/fsrs/src/algorithm.ts
@@ -23,6 +23,15 @@ export const computeDecayFactor = (
   return { decay, factor: roundTo(factor, 8) }
 }
 
+export function _forgetting_curve(
+  decay: number,
+  factor: number,
+  elapsed_days: number,
+  stability: number
+): number {
+  return roundTo(Math.pow(1 + (factor * elapsed_days) / stability, decay), 8)
+}
+
 /**
  * The formula used is :
  * $$R(t,S) = (1 + \text{FACTOR} \times \frac{t}{9 \cdot S})^{\text{DECAY}}$$
@@ -47,7 +56,7 @@ export function forgetting_curve(
   stability: number
 ): number {
   const { decay, factor } = computeDecayFactor(decayOrParams)
-  return roundTo(Math.pow(1 + (factor * elapsed_days) / stability, decay), 8)
+  return _forgetting_curve(decay, factor, elapsed_days, stability)
 }
 
 /**
@@ -331,12 +340,11 @@ export class FSRSAlgorithm {
    * @return {number} r Retrievability (probability of recall)
    */
   forgetting_curve(elapsed_days: number, stability: number): number {
-    return roundTo(
-      Math.pow(
-        1 + (this.cachedFactor * elapsed_days) / stability,
-        this.cachedDecay
-      ),
-      8
+    return _forgetting_curve(
+      this.cachedDecay,
+      this.cachedFactor,
+      elapsed_days,
+      stability
     )
   }
   /**

--- a/packages/fsrs/src/algorithm.ts
+++ b/packages/fsrs/src/algorithm.ts
@@ -70,10 +70,10 @@ export class FSRSAlgorithm {
   private cachedFactor!: number
 
   constructor(params: Partial<FSRSParameters>) {
-    this.param = new Proxy(
-      generatorParameters(params),
-      this.params_handler_proxy()
-    )
+    const generated = generatorParameters(params)
+    this.param = new Proxy(generated, this.params_handler_proxy())
+    // Wrap initial w array with Proxy for in-place mutation detection
+    generated.w = this.createWProxy(generated.w as number[])
     this.updateDecayFactor()
     this.intervalModifier = this.calculate_interval_modifier(
       this.param.request_retention
@@ -127,23 +127,38 @@ export class FSRSAlgorithm {
     this.update_parameters(params)
   }
 
+  protected createWProxy(w: number[]): number[] {
+    const onUpdate = () => this.updateDecayFactor()
+    return new Proxy(w, {
+      set(target, prop, value) {
+        const result = Reflect.set(target, prop, value)
+        if (typeof prop === 'string' && !Number.isNaN(Number(prop))) {
+          onUpdate()
+        }
+        return result
+      },
+    })
+  }
+
   protected params_handler_proxy(): ProxyHandler<FSRSParameters> {
     const _this = this satisfies FSRSAlgorithm
     return {
-      set: function (
+      set: (
         target: FSRSParameters,
         prop: keyof FSRSParameters,
         value: FSRSParameters[keyof FSRSParameters]
-      ) {
+      ) => {
         if (prop === 'request_retention' && Number.isFinite(value)) {
           _this.intervalModifier = _this.calculate_interval_modifier(
             Number(value)
           )
         } else if (prop === 'w') {
-          value = migrateParameters(
-            value as FSRSParameters['w'],
-            target.relearning_steps.length,
-            target.enable_short_term
+          value = _this.createWProxy(
+            migrateParameters(
+              value as FSRSParameters['w'],
+              target.relearning_steps.length,
+              target.enable_short_term
+            )
           )
         }
         Reflect.set(target, prop, value)

--- a/packages/fsrs/src/algorithm.ts
+++ b/packages/fsrs/src/algorithm.ts
@@ -23,7 +23,7 @@ export const computeDecayFactor = (
   return { decay, factor: roundTo(factor, 8) }
 }
 
-export function _forgetting_curve(
+export function forgetting_curve_inner(
   decay: number,
   factor: number,
   elapsed_days: number,
@@ -56,7 +56,7 @@ export function forgetting_curve(
   stability: number
 ): number {
   const { decay, factor } = computeDecayFactor(decayOrParams)
-  return _forgetting_curve(decay, factor, elapsed_days, stability)
+  return forgetting_curve_inner(decay, factor, elapsed_days, stability)
 }
 
 /**
@@ -145,14 +145,14 @@ export class FSRSAlgorithm {
             target.relearning_steps.length,
             target.enable_short_term
           )
-          Reflect.set(target, prop, value)
+        }
+        Reflect.set(target, prop, value)
+        if (prop === 'w') {
           _this.updateDecayFactor()
           _this.intervalModifier = _this.calculate_interval_modifier(
             Number(target.request_retention)
           )
-          return true
         }
-        Reflect.set(target, prop, value)
         return true
       },
     }
@@ -340,7 +340,7 @@ export class FSRSAlgorithm {
    * @return {number} r Retrievability (probability of recall)
    */
   forgetting_curve(elapsed_days: number, stability: number): number {
-    return _forgetting_curve(
+    return forgetting_curve_inner(
       this.cachedDecay,
       this.cachedFactor,
       elapsed_days,

--- a/packages/fsrs/src/fsrs.ts
+++ b/packages/fsrs/src/fsrs.ts
@@ -129,14 +129,14 @@ export class FSRS extends FSRSAlgorithm implements IFSRS {
             target.relearning_steps.length,
             target.enable_short_term
           )
-          Reflect.set(target, prop, value)
+        }
+        Reflect.set(target, prop, value)
+        if (prop === 'w') {
           _this.updateDecayFactor()
           _this.intervalModifier = _this.calculate_interval_modifier(
             Number(target.request_retention)
           )
-          return true
         }
-        Reflect.set(target, prop, value)
         return true
       },
     }

--- a/packages/fsrs/src/fsrs.ts
+++ b/packages/fsrs/src/fsrs.ts
@@ -112,11 +112,11 @@ export class FSRS extends FSRSAlgorithm implements IFSRS {
   protected override params_handler_proxy(): ProxyHandler<FSRSParameters> {
     const _this = this satisfies FSRS
     return {
-      set: function (
+      set: (
         target: FSRSParameters,
         prop: keyof FSRSParameters,
         value: FSRSParameters[keyof FSRSParameters]
-      ) {
+      ) => {
         if (prop === 'request_retention' && Number.isFinite(value)) {
           _this.intervalModifier = _this.calculate_interval_modifier(
             Number(value)
@@ -124,10 +124,12 @@ export class FSRS extends FSRSAlgorithm implements IFSRS {
         } else if (prop === 'enable_short_term') {
           _this.Scheduler = value === true ? BasicScheduler : LongTermScheduler
         } else if (prop === 'w') {
-          value = migrateParameters(
-            value as FSRSParameters['w'],
-            target.relearning_steps.length,
-            target.enable_short_term
+          value = _this.createWProxy(
+            migrateParameters(
+              value as FSRSParameters['w'],
+              target.relearning_steps.length,
+              target.enable_short_term
+            )
           )
         }
         Reflect.set(target, prop, value)

--- a/packages/fsrs/src/fsrs.ts
+++ b/packages/fsrs/src/fsrs.ts
@@ -1,4 +1,4 @@
-import { FSRSAlgorithm, forgetting_curve } from './algorithm'
+import { FSRSAlgorithm } from './algorithm'
 import { TypeConvert } from './convert'
 import { createEmptyCard, migrateParameters } from './default'
 import { date_diff } from './help'
@@ -129,10 +129,12 @@ export class FSRS extends FSRSAlgorithm implements IFSRS {
             target.relearning_steps.length,
             target.enable_short_term
           )
-          _this.forgetting_curve = forgetting_curve.bind(this, value)
+          Reflect.set(target, prop, value)
+          _this.updateDecayFactor()
           _this.intervalModifier = _this.calculate_interval_modifier(
             Number(target.request_retention)
           )
+          return true
         }
         Reflect.set(target, prop, value)
         return true


### PR DESCRIPTION
This pull request optimizes the `FSRSAlgorithm` class by introducing caching for the decay and factor values used in the `forgetting_curve` calculation, which reduces redundant computation and improves performance. It also adds comprehensive tests to ensure cache consistency and independence across multiple instances, as well as new benchmark suites for performance analysis. The changes include updates to instance mutation handling, new utility functions, and enhancements to the development workflow.

**Performance Improvements:**
- The `FSRSAlgorithm` class now caches decay and factor values, updating them automatically when the `w` parameters change, leading to more efficient `forgetting_curve` calculations. [[1]](diffhunk://#diff-0448b6b679d45d3e934c7e9df66245a06bdfa5d65d63a1b311188731a933a9c4R69-R86) [[2]](diffhunk://#diff-0448b6b679d45d3e934c7e9df66245a06bdfa5d65d63a1b311188731a933a9c4L128-L133) [[3]](diffhunk://#diff-0448b6b679d45d3e934c7e9df66245a06bdfa5d65d63a1b311188731a933a9c4L320-R349)
- The instance method `forgetting_curve` replaces the previous bound function, using the cached values for improved speed. [[1]](diffhunk://#diff-0448b6b679d45d3e934c7e9df66245a06bdfa5d65d63a1b311188731a933a9c4L320-R349) [[2]](diffhunk://#diff-e40521ee18f693d14a77322a1cf6c0d0341b5d46eb7f9a9b2f585ce90151e24aR1-R10)

**Testing Enhancements:**
- Added a new test suite (`forgetting_curve.test.ts`) to verify cache consistency, correct behavior during concurrent and interleaved mutations, and independence between multiple instances.

**Benchmarking:**
- Introduced a benchmark suite (`next_state.bench.ts`) to measure and compare the performance of `next_state` and `forgetting_curve` methods under various scenarios.
- Added a new npm script `bench` to run benchmarks using Vitest.

**Codebase Maintenance:**
- Refactored code to use a new utility function `forgetting_curve_inner` for the core calculation, improving code clarity and reuse. [[1]](diffhunk://#diff-0448b6b679d45d3e934c7e9df66245a06bdfa5d65d63a1b311188731a933a9c4R26-R34) [[2]](diffhunk://#diff-0448b6b679d45d3e934c7e9df66245a06bdfa5d65d63a1b311188731a933a9c4L50-R59)
- Cleaned up unused imports and redundant code.

**Documentation and Release:**
- Updated the changeset to document the new caching behavior and added tests and benchmarks.

These changes collectively improve the reliability, performance, and maintainability of the FSRS implementation.

---
## Performance Report

### `forgetting_curve`

| Method | ops/s | vs standalone |
|--------|------:|:-------------:|
| standalone (decay number) | 11,678,519 | baseline |
| standalone (params array) | 13,132,511 | baseline |
| standalone (custom weights) | 17,235,429 | baseline |
| instance method (cached) | 26,909,447 | **×2.1** |
| multi-instance interleaved | 1,111,685/batch | (100 calls) |

### `computeDecayFactor`

| Input | ops/s |
|-------|------:|
| from decay number | 14,891,381 |
| from params array | 14,769,130 |

### `next_state`

| Scenario | ops/s |
|----------|------:|
| new card (Again) | 4,060,537 |
| new card (Hard) | 3,895,192 |
| new card (Good) | 3,817,949 |
| new card (Easy) | 3,807,070 |
| learning t=0 (Again) | 1,348,022 |
| learning t=0 (Hard) | 1,328,518 |
| learning t=0 (Good) | 1,336,903 |
| learning t=0 (Easy) | 1,280,819 |
| review t=5 (Again) | 265,007 |
| review t=5 (Hard) | 816,914 |
| review t=5 (Good) | 1,062,645 |
| review t=5 (Easy) | 1,077,339 |
| mature t=30 (Again) | 836,697 |
| mature t=30 (Hard) | 1,095,235 |
| mature t=30 (Good) | 1,171,405 |
| mature t=30 (Easy) | 1,112,380 |
| pre-computed r=0.9 (Good) | 1,113,424 |
| pre-computed r=0.7 (Again) | 838,974 |
| batch 100 reviews | 9,990 |

### Coverage

| Metric | Result |
|--------|--------|
| Statements | 100% (696/696) |
| Branches | 100% (345/345) |
| Functions | 100% (116/116) |
| Lines | 100% (683/683) |

