### PR TITLE
chore(release): add support for beta prerelease mode

### DIFF
--- a/.github/workflows/promote-preflight.yml
+++ b/.github/workflows/promote-preflight.yml
@@ -1,0 +1,45 @@
+name: Promote preflight
+
+# Detection only. On a preview -> main promotion PR, verify prerelease mode has
+# already been exited (.changeset/pre.json absent, or mode != "pre"). If it is
+# still "pre", fail the check so the PR cannot be promoted until someone exits
+# prerelease. This workflow never pushes or modifies anything.
+#
+# Draft PRs are skipped.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: promote-preflight-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check-pre-exited:
+    name: Check prerelease exited
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.head_ref == 'preview'
+    steps:
+      - name: Checkout PR head (preview)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Verify prerelease mode is exited
+        run: |
+          set -euo pipefail
+          mode="$(node -p "require('fs').existsSync('.changeset/pre.json') ? require('./.changeset/pre.json').mode : 'none'")"
+          echo "pre.json mode = '$mode'"
+          if [[ "$mode" == "pre" ]]; then
+            echo "::error::preview is still in prerelease mode (pre.json mode='pre'). Run \`changeset pre exit\` and update the PR before promoting to main."
+            exit 1
+          fi
+          echo "Prerelease mode already exited (mode='$mode') — promotion allowed."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,9 +96,29 @@ jobs:
       - name: Update npm
         run: npm install -g npm@latest
 
-      - name: Enter beta prerelease mode
-        if: github.ref != 'refs/heads/main'
-        run: npx changeset pre enter beta
+      # pre.json is committed, so we must make this step idempotent:
+      #   - non-main + pre.json absent  -> enter pre mode
+      #   - non-main + pre.json present -> already in pre mode, skip
+      #   - main     + pre.json present -> leftover from preview, exit it
+      #   - main     + pre.json absent  -> nothing to do
+      - name: Sync changeset prerelease mode
+        shell: bash
+        run: |
+          if [[ "$GITHUB_REF" == "refs/heads/main" ]]; then
+            if [[ -f .changeset/pre.json ]]; then
+              echo "On main with pre.json present — exiting prerelease mode."
+              npx changeset pre exit
+            else
+              echo "On main; not in prerelease mode — nothing to do."
+            fi
+          else
+            if [[ -f .changeset/pre.json ]]; then
+              echo "Already in prerelease mode — skipping pre enter."
+            else
+              echo "Entering beta prerelease mode."
+              npx changeset pre enter beta
+            fi
+          fi
 
       - name: Create Release PR or Publish
         id: changesets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ on:
   push:
     branches:
       - main
+      - preview
   workflow_dispatch:
 
 permissions:
@@ -95,6 +96,10 @@ jobs:
       - name: Update npm
         run: npm install -g npm@latest
 
+      - name: Enter beta prerelease mode
+        if: github.ref != 'refs/heads/main'
+        run: npx changeset pre enter beta
+
       - name: Create Release PR or Publish
         id: changesets
         uses: changesets/action@v1
@@ -106,3 +111,4 @@ jobs:
           title: "chore: release new versions"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_CONFIG_PROVENANCE: "true"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
           if [[ "$GITHUB_REF" == "refs/heads/main" ]]; then
             if [[ -f .changeset/pre.json ]]; then
               echo "On main with pre.json present — exiting prerelease mode."
-              npx changeset pre exit
+              pnpm exec changeset pre exit
             else
               echo "On main; not in prerelease mode — nothing to do."
             fi
@@ -116,7 +116,7 @@ jobs:
               echo "Already in prerelease mode — skipping pre enter."
             else
               echo "Entering beta prerelease mode."
-              npx changeset pre enter beta
+              pnpm exec changeset pre enter beta
             fi
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,30 +95,9 @@ jobs:
       # https://docs.npmjs.com/trusted-publishers#step-2-configure-your-cicd-workflow
       - name: Update npm
         run: npm install -g npm@latest
-
-      # pre.json is committed, so we must make this step idempotent:
-      #   - non-main + pre.json absent  -> enter pre mode
-      #   - non-main + pre.json present -> already in pre mode, skip
-      #   - main     + pre.json present -> leftover from preview, exit it
-      #   - main     + pre.json absent  -> nothing to do
-      - name: Sync changeset prerelease mode
-        shell: bash
-        run: |
-          if [[ "$GITHUB_REF" == "refs/heads/main" ]]; then
-            if [[ -f .changeset/pre.json ]]; then
-              echo "On main with pre.json present — exiting prerelease mode."
-              pnpm exec changeset pre exit
-            else
-              echo "On main; not in prerelease mode — nothing to do."
-            fi
-          else
-            if [[ -f .changeset/pre.json ]]; then
-              echo "Already in prerelease mode — skipping pre enter."
-            else
-              echo "Entering beta prerelease mode."
-              pnpm exec changeset pre enter beta
-            fi
-          fi
+      - name: Enter beta prerelease mode (preview only)
+        if: github.ref == 'refs/heads/preview'
+        run: '[ -f .changeset/pre.json ] || pnpm exec changeset pre enter beta'
 
       - name: Create Release PR or Publish
         id: changesets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ on:
   push:
     branches:
       - main
+      - preview
   workflow_dispatch:
 
 permissions:
@@ -94,6 +95,10 @@ jobs:
       # https://docs.npmjs.com/trusted-publishers#step-2-configure-your-cicd-workflow
       - name: Update npm
         run: npm install -g npm@latest
+
+      - name: Enter beta prerelease mode
+        if: github.ref != 'refs/heads/main'
+        run: npx changeset pre enter beta
 
       - name: Create Release PR or Publish
         id: changesets

--- a/.gitignore
+++ b/.gitignore
@@ -44,8 +44,3 @@ pnpm-debug.log*
 # Rust
 target/
 artifacts/
-
-# Changesets — pre.json is created at CI-time by `changeset pre enter`
-# and must never be committed, otherwise the next preview run would
-# start in pre mode and `pre enter beta` would throw.
-.changeset/pre.json

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,8 @@ pnpm-debug.log*
 # Rust
 target/
 artifacts/
+
+# Changesets — pre.json is created at CI-time by `changeset pre enter`
+# and must never be committed, otherwise the next preview run would
+# start in pre mode and `pre enter beta` would throw.
+.changeset/pre.json


### PR DESCRIPTION
This pull request introduces a new workflow to enforce prerelease exit before promoting the `preview` branch to `main`, and updates the release workflow to support prerelease handling on the `preview` branch. The main goal is to ensure that promotion PRs can't proceed if prerelease mode hasn't been exited, and to automate prerelease mode entry for the `preview` branch.

**Promotion preflight enforcement:**

* Added a new workflow `.github/workflows/promote-preflight.yml` that checks if prerelease mode has been exited before allowing a `preview` → `main` promotion PR to proceed. Promotion is blocked if `.changeset/pre.json` exists and its mode is `"pre"`.

**Release workflow enhancements:**

* Updated `.github/workflows/release.yml` to trigger on both `main` and `preview` branches, ensuring releases and prereleases are handled appropriately.
* Added a step to `.github/workflows/release.yml` to automatically enter beta prerelease mode when running on the `preview` branch (creates `.changeset/pre.json` if not present).