### PR TITLE
fix: clamp w[11, 13, 14] to prevent -Infinity in w[17, 18] ceiling calculation

### DIFF
--- a/.changeset/fix-clip-parameters-w17-w18-ceiling.md
+++ b/.changeset/fix-clip-parameters-w17-w18-ceiling.md
@@ -1,0 +1,5 @@
+---
+'ts-fsrs': patch
+---
+
+fix(clipParameters): clamp w[11]/w[13]/w[14] before computing the w[17]/w[18] ceiling so that out-of-range inputs (e.g. 0 or negative values) no longer produce NaN/-Infinity via Math.log, and avoid invoking CLAMP_PARAMETERS twice by reusing the same clip ranges.

--- a/packages/fsrs/__tests__/default.test.ts
+++ b/packages/fsrs/__tests__/default.test.ts
@@ -181,26 +181,31 @@ describe('default params', () => {
     const w = [...default_w]
     w[11] = 0
     w[13] = 0
-    w[14] = -1
+    w[14] = 0
     w[17] = Number.MAX_VALUE
     w[18] = Number.MAX_VALUE
     const params = clipParameters(w, 2)
     expect(Number.isFinite(params[17])).toBe(true)
     expect(Number.isFinite(params[18])).toBe(true)
     // Clamped inputs: w11=0.001, w13=0.001, w14=0.0
-    // value = -(ln(0.001) + ln(2^0.001 - 1) + 0) / 2
-    //       = -(ln(0.001) + ln(0.000693387...)) / 2
-    const w11 = 0.001
-    const w13 = 0.001
-    const expectedCeiling = Math.max(
-      0.01,
-      Math.min(
-        2.0,
-        +(-(Math.log(w11) + Math.log(Math.pow(2.0, w13) - 1.0)) / 2).toFixed(8)
-      )
-    )
-    expect(params[17]).toEqual(expectedCeiling)
-    expect(params[18]).toEqual(expectedCeiling)
+    // value = -(ln(0.001) + ln(2^0.001 - 1) + 0) / 2 ~= 7.09, then
+    // clamped to [0, W17_W18_Ceiling=2.0] -> 2.0
+    expect(params[17]).toEqual(2.0)
+    expect(params[18]).toEqual(2.0)
+  })
+
+  it('skip w17/w18 ceiling update when parameters length < 18', () => {
+    // FSRS-4.5 has 17 parameters and no w[17]/w[18]; clip[17]/clip[18] are
+    // undefined after the length-aware view, so the ceiling update must be a no-op.
+    const w17 = [
+      0.4, 0.6, 2.4, 5.8, 4.93, 0.94, 0.86, 0.01, 1.49, 0.14, 0.94, 2.18, 0.05,
+      0.34, 1.26, 0.29, 2.61,
+    ]
+    expect(() => clipParameters(w17, 2)).not.toThrow()
+    const params = clipParameters(w17, 2)
+    expect(params).toHaveLength(17)
+    // Original values are all in-range and should pass through untouched.
+    expect(params).toEqual(w17)
   })
 })
 

--- a/packages/fsrs/__tests__/default.test.ts
+++ b/packages/fsrs/__tests__/default.test.ts
@@ -173,6 +173,35 @@ describe('default params', () => {
     expect(params[17]).toEqual(0.36055143)
     expect(params[18]).toEqual(0.36055143)
   })
+
+  it('clip w[11]/w[13]/w[14] before computing w17/w18 ceiling', () => {
+    // w[11] valid range is [0.001, 5.0]; w[13] is [0.001, 0.9]; w[14] is [0.0, 4.0].
+    // If raw values are 0 or negative, log() would yield NaN/-Infinity and
+    // the resulting ceiling would be NaN, leaving w[17]/w[18] uncapped.
+    const w = [...default_w]
+    w[11] = 0
+    w[13] = 0
+    w[14] = -1
+    w[17] = Number.MAX_VALUE
+    w[18] = Number.MAX_VALUE
+    const params = clipParameters(w, 2)
+    expect(Number.isFinite(params[17])).toBe(true)
+    expect(Number.isFinite(params[18])).toBe(true)
+    // Clamped inputs: w11=0.001, w13=0.001, w14=0.0
+    // value = -(ln(0.001) + ln(2^0.001 - 1) + 0) / 2
+    //       = -(ln(0.001) + ln(0.000693387...)) / 2
+    const w11 = 0.001
+    const w13 = 0.001
+    const expectedCeiling = Math.max(
+      0.01,
+      Math.min(
+        2.0,
+        +(-(Math.log(w11) + Math.log(Math.pow(2.0, w13) - 1.0)) / 2).toFixed(8)
+      )
+    )
+    expect(params[17]).toEqual(expectedCeiling)
+    expect(params[18]).toEqual(expectedCeiling)
+  })
 })
 
 describe('default Card', () => {

--- a/packages/fsrs/src/default.ts
+++ b/packages/fsrs/src/default.ts
@@ -38,7 +38,7 @@ export const clipParameters = (
       -(Math.log(w11) + Math.log(Math.pow(2.0, w13) - 1.0) + w14 * 0.3) /
       numRelearningSteps
 
-    const w17_w18_ceiling = clamp(roundTo(value, 8), 0, W17_W18_Ceiling)
+    const w17_w18_ceiling = clamp(roundTo(value, 8), 0.01, W17_W18_Ceiling)
     if (clip[17]) clip[17] = [clip[17][0], w17_w18_ceiling]
     if (clip[18]) clip[18] = [clip[18][0], w17_w18_ceiling]
   }

--- a/packages/fsrs/src/default.ts
+++ b/packages/fsrs/src/default.ts
@@ -39,8 +39,8 @@ export const clipParameters = (
       numRelearningSteps
 
     const w17_w18_ceiling = clamp(roundTo(value, 8), 0, W17_W18_Ceiling)
-    clip[17] = [clip[17][0], w17_w18_ceiling]
-    clip[18] = [clip[18][0], w17_w18_ceiling]
+    if (clip[17]) clip[17] = [clip[17][0], w17_w18_ceiling]
+    if (clip[18]) clip[18] = [clip[18][0], w17_w18_ceiling]
   }
   return clip.map(([min, max], index) =>
     clamp(parameters[index] || 0, min, max)

--- a/packages/fsrs/src/default.ts
+++ b/packages/fsrs/src/default.ts
@@ -11,7 +11,7 @@ import {
   W17_W18_Ceiling,
 } from './constant'
 import { TypeConvert } from './convert'
-import { clamp } from './help'
+import { clamp, roundTo } from './help'
 import { type Card, type DateInput, type FSRSParameters, State } from './models'
 
 export const clipParameters = (
@@ -19,7 +19,10 @@ export const clipParameters = (
   numRelearningSteps: number,
   enableShortTerm: boolean = default_enable_short_term
 ) => {
-  let w17_w18_ceiling = W17_W18_Ceiling
+  const clip = CLAMP_PARAMETERS(W17_W18_Ceiling, enableShortTerm).slice(
+    0,
+    parameters.length
+  )
   if (Math.max(0, numRelearningSteps) > 1) {
     // PLS = w11 * D ^ -w12 * [(S + 1) ^ w13 - 1] * e ^ (w14 * (1 - R))
     // PLS * e ^ (num_relearning_steps * w17 * w18) should be <= S
@@ -27,19 +30,18 @@ export const clipParameters = (
     // So num_relearning_steps * w17 * w18 + ln(w11) + ln(2 ^ w13 - 1) + w14 * 0.3 should be <= ln(1)
     // => num_relearning_steps * w17 * w18 <= - ln(w11) - ln(2 ^ w13 - 1) - w14 * 0.3
     // => w17 * w18 <= -[ln(w11) + ln(2 ^ w13 - 1) + w14 * 0.3] / num_relearning_steps
+    // Clamp w11/w13/w14 first so log() never receives <= 0 (otherwise NaN/-Infinity)
+    const w11 = clamp(parameters[11] || 0, clip[11][0], clip[11][1])
+    const w13 = clamp(parameters[13] || 0, clip[13][0], clip[13][1])
+    const w14 = clamp(parameters[14] || 0, clip[14][0], clip[14][1])
     const value =
-      -(
-        Math.log(parameters[11]) +
-        Math.log(Math.pow(2.0, parameters[13]) - 1.0) +
-        parameters[14] * 0.3
-      ) / numRelearningSteps
+      -(Math.log(w11) + Math.log(Math.pow(2.0, w13) - 1.0) + w14 * 0.3) /
+      numRelearningSteps
 
-    w17_w18_ceiling = clamp(+value.toFixed(8), 0.01, 2.0)
+    const w17_w18_ceiling = clamp(roundTo(value, 8), 0, W17_W18_Ceiling)
+    clip[17] = [clip[17][0], w17_w18_ceiling]
+    clip[18] = [clip[18][0], w17_w18_ceiling]
   }
-  const clip = CLAMP_PARAMETERS(w17_w18_ceiling, enableShortTerm).slice(
-    0,
-    parameters.length
-  )
   return clip.map(([min, max], index) =>
     clamp(parameters[index] || 0, min, max)
   )


### PR DESCRIPTION

- https://github.com/open-spaced-repetition/go-fsrs/pull/60

This pull request addresses a bug in the `clipParameters` function of the `ts-fsrs` package that could result in out-of-range parameter values producing `NaN` or `-Infinity` due to invalid inputs to `Math.log`. The fix ensures that the relevant parameters are clamped before any calculations involving logarithms, and also avoids redundant clamping operations. Comprehensive tests have been added to verify the fix.

**Parameter clamping and bug fix:**

* Updated `clipParameters` in `packages/fsrs/src/default.ts` to clamp `w[11]`, `w[13]`, and `w[14]` before computing the ceiling for `w[17]` and `w[18]`, preventing `NaN` or `-Infinity` results from invalid log operations. The function now also reuses the same clamping ranges, avoiding duplicate work.

**Testing improvements:**

* Added a new test in `packages/fsrs/__tests__/default.test.ts` to verify that clamping occurs before computing the ceiling for `w[17]` and `w[18]`, ensuring finite and valid results even for out-of-range inputs.

**Documentation:**

* Added a changeset `.changeset/fix-clip-parameters-w17-w18-ceiling.md` describing the bug fix and the rationale behind the changes.