### PR TITLE
refactor(fsrs): extract `applyAfterHandler` to reduce duplication

### DIFF
--- a/.changeset/refactor-after-handler.md
+++ b/.changeset/refactor-after-handler.md
@@ -1,0 +1,5 @@
+---
+"ts-fsrs": patch
+---
+
+refactor(fsrs): extract `applyAfterHandler` helper to deduplicate `afterHandler` plumbing in `repeat`, `next`, `rollback`, `forget`, and `reschedule`

--- a/packages/fsrs/src/fsrs.ts
+++ b/packages/fsrs/src/fsrs.ts
@@ -35,10 +35,7 @@ type RequireOnly<A, K extends keyof A> = { [P in K]-?: A[P] } & Partial<
   Omit<A, K>
 >
 
-function applyAfterHandler<T, R>(
-  value: T,
-  afterHandler?: (value: T) => R
-): R {
+function applyAfterHandler<T, R>(value: T, afterHandler?: (value: T) => R): R {
   return typeof afterHandler === 'function'
     ? afterHandler(value)
     : (value as unknown as R)

--- a/packages/fsrs/src/fsrs.ts
+++ b/packages/fsrs/src/fsrs.ts
@@ -35,6 +35,15 @@ type RequireOnly<A, K extends keyof A> = { [P in K]-?: A[P] } & Partial<
   Omit<A, K>
 >
 
+function applyAfterHandler<T, R>(
+  value: T,
+  afterHandler?: (value: T) => R
+): R {
+  return typeof afterHandler === 'function'
+    ? afterHandler(value)
+    : (value as unknown as R)
+}
+
 export interface IFSRS {
   useStrategy<T extends StrategyMode>(
     mode: T,
@@ -240,11 +249,7 @@ export class FSRS extends FSRSAlgorithm implements IFSRS {
   ): R {
     const instance = this.getScheduler(card, now)
     const recordLog = instance.preview()
-    if (afterHandler && typeof afterHandler === 'function') {
-      return afterHandler(recordLog)
-    } else {
-      return recordLog as R
-    }
+    return applyAfterHandler(recordLog, afterHandler)
   }
 
   next(card: CardInput | Card, now: DateInput, grade: Grade): RecordLogItem
@@ -320,11 +325,7 @@ export class FSRS extends FSRSAlgorithm implements IFSRS {
       throw new Error('Cannot review a manual rating')
     }
     const recordLogItem = instance.review(g)
-    if (afterHandler && typeof afterHandler === 'function') {
-      return afterHandler(recordLogItem)
-    } else {
-      return recordLogItem as R
-    }
+    return applyAfterHandler(recordLogItem, afterHandler)
   }
 
   get_retrievability(
@@ -439,11 +440,7 @@ export class FSRS extends FSRSAlgorithm implements IFSRS {
       state: processedLog.state,
       last_review: last_review,
     }
-    if (afterHandler && typeof afterHandler === 'function') {
-      return afterHandler(prevCard)
-    } else {
-      return prevCard as R
-    }
+    return applyAfterHandler(prevCard, afterHandler)
   }
 
   forget(
@@ -546,11 +543,7 @@ export class FSRS extends FSRSAlgorithm implements IFSRS {
       last_review: processedCard.last_review,
     }
     const recordLogItem: RecordLogItem = { card: forget_card, log: forget_log }
-    if (afterHandler && typeof afterHandler === 'function') {
-      return afterHandler(recordLogItem)
-    } else {
-      return recordLogItem as R
-    }
+    return applyAfterHandler(recordLogItem, afterHandler)
   }
 
   reschedule<T = RecordLogItem>(
@@ -634,15 +627,14 @@ export class FSRS extends FSRSAlgorithm implements IFSRS {
       updateMemoryState
     )
 
-    if (recordLogHandler && typeof recordLogHandler === 'function') {
-      return {
-        collections: collections.map(recordLogHandler),
-        reschedule_item: manual_item ? recordLogHandler(manual_item) : null,
-      }
-    }
     return {
-      collections,
-      reschedule_item: manual_item,
+      collections:
+        typeof recordLogHandler === 'function'
+          ? collections.map(recordLogHandler)
+          : collections,
+      reschedule_item: manual_item
+        ? applyAfterHandler(manual_item, recordLogHandler)
+        : null,
     } as IReschedule<T>
   }
 }


### PR DESCRIPTION
This pull request refactors the FSRS scheduling logic to reduce code duplication by introducing a new helper function, `applyAfterHandler`. This function centralizes the logic for applying optional handler functions after core operations, which previously was repeated across several methods. The refactor improves maintainability and readability by consolidating this pattern in one place.

**Refactoring to deduplicate after-handler logic:**

* Introduced a new helper function `applyAfterHandler` in `fsrs.ts` to encapsulate the logic of applying an optional `afterHandler` function, reducing repeated code.
* Updated the `repeat`, `next`, `rollback`, and `forget` methods in the `FSRS` class to use `applyAfterHandler` instead of duplicating the after-handler logic. [[1]](diffhunk://#diff-ae17df51bde7b66b7de51b3ea455a2733a035566a1347d9346d977a113187909L243-R252) [[2]](diffhunk://#diff-ae17df51bde7b66b7de51b3ea455a2733a035566a1347d9346d977a113187909L323-R328) [[3]](diffhunk://#diff-ae17df51bde7b66b7de51b3ea455a2733a035566a1347d9346d977a113187909L442-R443) [[4]](diffhunk://#diff-ae17df51bde7b66b7de51b3ea455a2733a035566a1347d9346d977a113187909L549-R546)
* Refactored the `reschedule` method to use `applyAfterHandler` for the `manual_item`, and to streamline how the `recordLogHandler` is applied to collections, further reducing code duplication.

**Documentation:**

* Added a changeset file documenting the refactor and its motivation to deduplicate after-handler plumbing across multiple methods.