### PR TITLE
feat(binding): implement `memoryStateFromSM2` method for FSRSBinding

### DIFF
--- a/.changeset/binding-memory-state-from-sm2.md
+++ b/.changeset/binding-memory-state-from-sm2.md
@@ -1,0 +1,5 @@
+---
+"@open-spaced-repetition/binding": minor
+---
+
+feat(binding): expose `memoryStateFromSM2(easeFactor, interval, sm2Retention)` on `FSRSBinding`, mirroring `fsrs-rs`'s `FSRS::memory_state_from_sm2` for seeding `MemoryState` from legacy SM-2 parameters

--- a/.changeset/binding-memory-state-from-sm2.md
+++ b/.changeset/binding-memory-state-from-sm2.md
@@ -1,5 +1,5 @@
 ---
-"@open-spaced-repetition/binding": minor
+"@open-spaced-repetition/binding": patch
 ---
 
-feat(binding): expose `memoryStateFromSM2(easeFactor, interval, sm2Retention)` on `FSRSBinding`, mirroring `fsrs-rs`'s `FSRS::memory_state_from_sm2` for seeding `MemoryState` from legacy SM-2 parameters
+feat(binding): implement `memoryStateFromSM2` method for FSRSBinding

--- a/packages/binding-test/src/dynamic.spec.ts
+++ b/packages/binding-test/src/dynamic.spec.ts
@@ -104,6 +104,18 @@ describeIfWasm('initOptimizer', () => {
     expect(nextStates.easy).toBeDefined()
   })
 
+  test('memoryStateFromSM2 works after init', async () => {
+    const binding = await initOptimizer({
+      wasm: wasmPath!,
+      worker: workerPath!,
+    })
+    const fsrs = new binding.FSRSBinding()
+    expect(typeof fsrs.memoryStateFromSM2).toBe('function')
+    const m = fsrs.memoryStateFromSM2(2.5, 10, 0.9)
+    expect(m.stability).toBeCloseTo(10.0, 3)
+    expect(m.difficulty).toBeCloseTo(6.9140563, 3)
+  })
+
   test('computeParameters works after init', async () => {
     const binding = await initOptimizer({
       wasm: wasmPath!,

--- a/packages/binding-test/src/mode.spec.ts
+++ b/packages/binding-test/src/mode.spec.ts
@@ -38,6 +38,41 @@ describe('FSRS model', () => {
     console.log(nextStates)
   })
 
+  test('memoryStateFromSM2', () => {
+    const f = new FSRSBinding()
+
+    let m = f.memoryStateFromSM2(2.5, 10, 0.9)
+    expect(m).toBeInstanceOf(BindingMemoryState)
+    expect(m.stability).toBeCloseTo(10.0, 3)
+    expect(m.difficulty).toBeCloseTo(6.9140563, 3)
+
+    m = f.memoryStateFromSM2(2.5, 10, 0.8)
+    expect(m.stability).toBeCloseTo(3.01572, 3)
+    expect(m.difficulty).toBeCloseTo(9.393428, 3)
+
+    m = f.memoryStateFromSM2(2.5, 10, 0.95)
+    expect(m.stability).toBeCloseTo(24.841097, 3)
+    expect(m.difficulty).toBeCloseTo(1.2974405, 3)
+
+    // clamps difficulty to D_MAX
+    m = f.memoryStateFromSM2(1.3, 20, 0.9)
+    expect(m.stability).toBeCloseTo(20.0, 3)
+    expect(m.difficulty).toBeCloseTo(10.0, 3)
+
+    // fsrs_factor consistency: next_states(good).stability / interval ≈ ease_factor
+    const interval = 15
+    const easeFactor = 2.0
+    const seed = f.memoryStateFromSM2(easeFactor, interval, 0.9)
+    const fsrsFactor =
+      f.nextStates(seed, 0.9, interval).good.memory.stability / interval
+    expect(Math.abs(fsrsFactor - easeFactor)).toBeLessThan(0.01)
+  })
+
+  test('memoryStateFromSM2 throws on invalid input', () => {
+    const f = new FSRSBinding()
+    expect(() => f.memoryStateFromSM2(2.5, 10, 1.0)).toThrow()
+  })
+
   /**
 diff --git a/src/inference.rs b/src/inference.rs
 index f5b20bf..6ff1d3b 100644

--- a/packages/binding/src/lib.rs
+++ b/packages/binding/src/lib.rs
@@ -84,7 +84,9 @@ impl FSRS {
       .inner
       .memory_state_from_sm2(ease_factor as f32, interval as f32, sm2_retention as f32)
       .map(|inner| MemoryState { inner })
-      .map_err(|e| napi::Error::from_reason(format!("Failed memory_state_from_sm2: {}", e)))
+      .map_err(|e| {
+        napi::Error::from_reason(format!("Failed to create memory state from SM-2: {}", e))
+      })
   }
 
   #[napi]

--- a/packages/binding/src/lib.rs
+++ b/packages/binding/src/lib.rs
@@ -73,6 +73,20 @@ impl FSRS {
     }
   }
 
+  #[napi(js_name = "memoryStateFromSM2")]
+  pub fn memory_state_from_sm2(
+    &self,
+    ease_factor: f64,
+    interval: f64,
+    sm2_retention: f64,
+  ) -> Result<MemoryState> {
+    self
+      .inner
+      .memory_state_from_sm2(ease_factor as f32, interval as f32, sm2_retention as f32)
+      .map(|inner| MemoryState { inner })
+      .map_err(|e| napi::Error::from_reason(format!("Failed memory_state_from_sm2: {}", e)))
+  }
+
   #[napi]
   pub fn universal_metrics(
     &self,


### PR DESCRIPTION
This pull request introduces a new feature to the `@open-spaced-repetition/binding` package, allowing users to seed a `MemoryState` from legacy SM-2 spaced repetition parameters via the new `memoryStateFromSM2` method on `FSRSBinding`. Comprehensive tests have been added to ensure correctness and error handling. The most important changes are summarized below:

### New Feature: SM-2 Compatibility

* Added `memoryStateFromSM2(easeFactor, interval, sm2Retention)` method to `FSRSBinding`, which mirrors the behavior of `fsrs-rs`'s `FSRS::memory_state_from_sm2`. This enables seeding `MemoryState` objects from legacy SM-2 parameters for improved migration and compatibility. [[1]](diffhunk://#diff-a293ee49dc3f70a1d1469811c9c83e40327dfe68e6f06b4f2830dc7e87ff8f0cR76-R89) [[2]](diffhunk://#diff-84a01a161311c84043579737f3ec0573dd36aa7ea39a1a8e30a873fc5cdaa7f4R1-R5)

### Testing Enhancements

* Added tests in `dynamic.spec.ts` and `mode.spec.ts` to verify that `memoryStateFromSM2` produces expected stability and difficulty values, clamps difficulty appropriately, maintains consistency with FSRS factors, and throws errors on invalid input. [[1]](diffhunk://#diff-13d316d281318b4eddfd4b49ae2639e884ed7d78b78946c294ddd771ebd85e22R107-R118) [[2]](diffhunk://#diff-08cc9d343061cddb96c075c6c6af39645e312a42134db83450b96687a86d18b6R41-R75)