### PR TITLE
fix(parameters): apply sqrt to W[17]/W[18] relearning ceiling with negative-value guard

### DIFF
--- a/.changeset/fix-w17-w18-ceiling-sqrt.md
+++ b/.changeset/fix-w17-w18-ceiling-sqrt.md
@@ -1,0 +1,5 @@
+---
+"ts-fsrs": patch
+---
+
+fix(clipParameters): apply sqrt ceiling to w[17]/w[18] to prevent constraint violation during relearning

--- a/packages/fsrs/__tests__/default.test.ts
+++ b/packages/fsrs/__tests__/default.test.ts
@@ -174,8 +174,10 @@ describe('default params', () => {
     w[17] = Number.MAX_VALUE
     w[18] = Number.MAX_VALUE
     const params = clipParameters(w, 2)
-    expect(params[17]).toEqual(0.36055143)
-    expect(params[18]).toEqual(0.36055143)
+    expect(params[17]).toEqual(0.60045935)
+    expect(params[18]).toEqual(0.60045935)
+    // Verify constraint: w17 * w18 <= value (0.36055143)
+    expect(params[17] * params[18]).toBeLessThanOrEqual(0.36056)
   })
 
   it('clip w[11]/w[13]/w[14] before computing w17/w18 ceiling', () => {
@@ -192,8 +194,8 @@ describe('default params', () => {
     expect(Number.isFinite(params[17])).toBe(true)
     expect(Number.isFinite(params[18])).toBe(true)
     // Clamped inputs: w11=0.001, w13=0.001, w14=0.0
-    // value = -(ln(0.001) + ln(2^0.001 - 1) + 0) / 2 ~= 7.09, then
-    // clamped to [0, W17_W18_Ceiling=2.0] -> 2.0
+    // value = -(ln(0.001) + ln(2^0.001 - 1) + 0) / 2 ~= 7.09
+    // sqrt(7.09) ~= 2.66, clamped to [0.01, W17_W18_Ceiling=2.0] -> 2.0
     expect(params[17]).toEqual(2.0)
     expect(params[18]).toEqual(2.0)
   })
@@ -210,6 +212,50 @@ describe('default params', () => {
     expect(params).toHaveLength(17)
     // Original values are all in-range and should pass through untouched.
     expect(params).toEqual(w17)
+  })
+
+  it('single relearning step uses default ceiling of 2.0', () => {
+    const params = generatorParameters({
+      relearning_steps: ['10m'],
+      w: default_w.map((v, i) => (i === 17 || i === 18 ? 2.5 : v)),
+    })
+    expect(params.w[17]).toEqual(2.0)
+    expect(params.w[18]).toEqual(2.0)
+  })
+
+  it('negative value produces finite ceiling via sqrt guard', () => {
+    const w = [...default_w]
+    w[11] = 5.0
+    w[13] = 0.9
+    w[14] = 4.0
+    w[17] = Number.MAX_VALUE
+    w[18] = Number.MAX_VALUE
+    const params = clipParameters(w, 2)
+    // value = -(ln(5) + ln(2^0.9 - 1) + 4*0.3) / 2 ≈ -1.333
+    // sqrt(max(-1.333, 0)) = sqrt(0) = 0, clamp(0, 0.01, 2.0) = 0.01
+    expect(Number.isFinite(params[17])).toBe(true)
+    expect(Number.isFinite(params[18])).toBe(true)
+    expect(params[17]).toBeGreaterThanOrEqual(0)
+    expect(params[18]).toBeGreaterThanOrEqual(0)
+    expect(params[17]).toEqual(0.01)
+    expect(params[18]).toEqual(0.01)
+  })
+
+  it('W17/W18 ceiling with 4 relearning steps applies sqrt', () => {
+    const w = [...default_w]
+    w[11] = 0.1
+    w[13] = 0.1
+    w[14] = 0.5
+    w[17] = 2.0
+    w[18] = 2.0
+    const params = clipParameters(w, 4)
+    // value = -(ln(0.1) + ln(2^0.1 - 1) + 0.5*0.3) / 4 ≈ 1.1967
+    // ceiling = sqrt(value) ≈ 1.0939
+    const expectedCeiling = 1.09394076
+    expect(Math.abs(params[17] - expectedCeiling)).toBeLessThan(1e-5)
+    expect(Math.abs(params[18] - expectedCeiling)).toBeLessThan(1e-5)
+    // Verify constraint: w17 * w18 <= value
+    expect(params[17] * params[18]).toBeLessThanOrEqual(1.19671)
   })
 })
 

--- a/packages/fsrs/src/default.ts
+++ b/packages/fsrs/src/default.ts
@@ -39,7 +39,13 @@ export const clipParameters = (
       -(Math.log(w11) + Math.log(Math.pow(2.0, w13) - 1.0) + w14 * 0.3) /
       numRelearningSteps
 
-    const w17_w18_ceiling = clamp(roundTo(value, 8), 0.01, W17_W18_Ceiling)
+    // sqrt converts the product constraint (w17 * w18 <= value) into per-parameter
+    // ceilings, so each individually satisfies the bound. Math.max guards against NaN.
+    const w17_w18_ceiling = clamp(
+      roundTo(Math.sqrt(Math.max(value, 0)), 8),
+      0.01,
+      W17_W18_Ceiling
+    )
     if (clip[17]) clip[17] = [clip[17][0], w17_w18_ceiling]
     if (clip[18]) clip[18] = [clip[18][0], w17_w18_ceiling]
   }


### PR DESCRIPTION
## Summary

Fix the dynamic ceiling calculation for W[17] and W[18] by applying `sqrt` and adding a negative-value guard, ensuring `w17 * w18 <= value` and preventing NaN.

## Bug Description

- **What was happening:** The ceiling was `clamp(value, 0.01, 2.0)`, so `w17*w18` could reach `value²`, exceeding the theoretical limit. When `value < 0`, `sqrt` produced NaN.
- **Expected behavior:** Ceiling = `sqrt(value)` ensures `ceiling² <= value`. Negative values guard to floor 0.01.
- **Root cause:** Missing `sqrt` transformation and no negative-value protection.

## Changes Made

- `default.ts`: `clamp(roundTo(value, 8), 0.01, W17_W18_Ceiling)` → `clamp(roundTo(Math.sqrt(Math.max(value, 0)), 8), 0.01, W17_W18_Ceiling)`
- `default.test.ts`: Update expected values, add constraint assertions, add 3 new tests (single step, negative value guard, 4-step sqrt ceiling)

## Testing

- [x] Tested locally
- [x] Unit tests added/updated
- [x] No regressions (193 tests passed)

## Breaking Changes

None — correctness fix. No API changes.

## Related

Mirrors [go-fsrs PR #68](https://github.com/open-spaced-repetition/go-fsrs/pull/68)