### PR TITLE
refactor(fsrs): add optional desired_retention to next_interval

### DIFF
--- a/.changeset/dynamic-desired-retention.md
+++ b/.changeset/dynamic-desired-retention.md
@@ -1,0 +1,9 @@
+---
+"ts-fsrs": major
+---
+
+- feat: Add optional `desired_retention` to `FSRSAlgorithm.next_interval`.
+
+`next_interval(stability)` is now `next_interval(stability, desired_retention?)`. When omitted, `desired_retention` defaults to `parameters.request_retention`. The algorithm layer no longer clamps by `parameters.maximum_interval`; scheduler paths continue to read `request_retention` from parameters and apply maximum interval limits.
+
+- - **BREAKING CHANGE:** The `interval_modifier` getter and `calculate_interval_modifier()` method have been removed.

--- a/.changeset/dynamic-desired-retention.md
+++ b/.changeset/dynamic-desired-retention.md
@@ -6,4 +6,4 @@
 
 `next_interval(stability)` is now `next_interval(stability, desired_retention?)`. When omitted, `desired_retention` defaults to `parameters.request_retention`. The algorithm layer no longer clamps by `parameters.maximum_interval`; scheduler paths continue to read `request_retention` from parameters and apply maximum interval limits.
 
-- - **BREAKING CHANGE:** The `interval_modifier` getter and `calculate_interval_modifier()` method have been removed.
+- **BREAKING CHANGE:** The `interval_modifier` getter and `calculate_interval_modifier()` method have been removed.

--- a/packages/fsrs/__tests__/algorithm.test.ts
+++ b/packages/fsrs/__tests__/algorithm.test.ts
@@ -341,7 +341,7 @@ describe('next_interval', () => {
       fsrs({
         request_retention: r,
         maximum_interval: Number.MAX_VALUE,
-      }).next_interval(1.0)
+      }).next_interval(1.0, r)
     )
     // https://github.com/open-spaced-repetition/fsrs-rs/blob/78c36e6b21182c5a13f8649eafe2eb62c1dbdabe/src/inference.rs#L852
     // Result differs by +3 days compared to the reference test due to differing numeric precision: fsrs-rs uses f32, while ts-fsrs uses f64
@@ -359,8 +359,13 @@ describe('next_interval', () => {
     ])
   })
 
+  it('defaults desired_retention to parameters.request_retention', () => {
+    const f = fsrs({ request_retention: 0.8 })
+    expect(f.next_interval(1.0)).toEqual(f.next_interval(1.0, 0.8))
+  })
+
   // https://github.com/open-spaced-repetition/ts-fsrs/pull/74
-  it('next_ivl[max_limit]', () => {
+  it('next_ivl does not apply maximum_interval', () => {
     const params = generatorParameters({ maximum_interval: 365 })
     const { decay, factor } = computeDecayFactor(params.w)
     const intervalModifier =
@@ -368,12 +373,16 @@ describe('next_interval', () => {
     const f: FSRS = fsrs(params)
 
     const s = 737.47
-    const next_ivl = f.next_interval(s)
-    expect(next_ivl).toEqual(params.maximum_interval)
+    const next_ivl = f.next_interval(s, params.request_retention)
+    expect(next_ivl).toEqual(Math.round(s * intervalModifier))
+    expect(next_ivl).toBeGreaterThan(params.maximum_interval)
 
     const t_fuzz = 98
     const fuzzed_params = generatorParameters({ ...params, enable_fuzz: true })
-    const base_ivl = fsrs(fuzzed_params).next_interval(s)
+    const base_ivl = fsrs(fuzzed_params).next_interval(
+      s,
+      fuzzed_params.request_retention
+    )
     const next_ivl_fuzz = withFuzzing(base_ivl, t_fuzz, fuzzed_params)
     const { min_ivl, max_ivl } = get_fuzz_range(
       Math.round(s * intervalModifier),
@@ -429,8 +438,6 @@ describe('withFuzzing', () => {
 describe('change Params', () => {
   test('change FSRSParameters[FSRS]', () => {
     const f = fsrs()
-    // I(r,s),r=0.9 then I(r,s)=s
-    expect(f.interval_modifier).toEqual(1)
     expect(f.parameters).toEqual(generatorParameters())
 
     const request_retention = 0.8
@@ -466,14 +473,9 @@ describe('change Params', () => {
     expect(f.parameters.request_retention).toEqual(request_retention)
     expect(f.parameters.w).toEqual(update_w)
     expect(f.parameters.enable_fuzz).toEqual(true)
-    expect(f.interval_modifier).toEqual(
-      f.calculate_interval_modifier(request_retention)
-    )
 
     f.parameters.request_retention = default_request_retention
-    expect(f.interval_modifier).toEqual(
-      f.calculate_interval_modifier(default_request_retention)
-    )
+    expect(f.parameters.request_retention).toEqual(default_request_retention)
 
     f.parameters.w = default_w
     expect(f.parameters.w).toEqual(default_w)
@@ -494,8 +496,6 @@ describe('change Params', () => {
   test('change FSRSParameters[FSRSAlgorithm]', () => {
     const params = generatorParameters()
     const f = new FSRSAlgorithm(params)
-    // I(r,s),r=0.9 then I(r,s)=s
-    expect(f.interval_modifier).toEqual(1)
     expect(f.parameters).toEqual(generatorParameters())
 
     const request_retention = 0.8
@@ -531,14 +531,9 @@ describe('change Params', () => {
     expect(f.parameters.request_retention).toEqual(request_retention)
     expect(f.parameters.w).toEqual(update_w)
     expect(f.parameters.enable_fuzz).toEqual(true)
-    expect(f.interval_modifier).toEqual(
-      f.calculate_interval_modifier(request_retention)
-    )
 
     f.parameters.request_retention = default_request_retention
-    expect(f.interval_modifier).toEqual(
-      f.calculate_interval_modifier(default_request_retention)
-    )
+    expect(f.parameters.request_retention).toEqual(default_request_retention)
 
     f.parameters.w = default_w
     expect(f.parameters.w).toEqual(default_w)
@@ -556,17 +551,15 @@ describe('change Params', () => {
     expect(f.parameters.enable_short_term).toEqual(false)
   })
 
-  test('calculate_interval_modifier', () => {
+  test('next_interval validates desired_retention', () => {
     const f = new FSRSAlgorithm(generatorParameters())
-    expect(f.interval_modifier).toEqual(
-      f.calculate_interval_modifier(default_request_retention)
-    )
+    expect(f.next_interval(1, default_request_retention)).toEqual(1)
     expect(() => {
-      f.parameters.request_retention = 1.2
-    }).toThrow('Requested retention rate should be in the range (0,1]')
+      f.next_interval(1, 1.2)
+    }).toThrow('Desired retention rate should be in the range (0,1]')
     expect(() => {
-      f.parameters.request_retention = -0.2
-    }).toThrow('Requested retention rate should be in the range (0,1]')
+      f.next_interval(1, -0.2)
+    }).toThrow('Desired retention rate should be in the range (0,1]')
   })
 })
 

--- a/packages/fsrs/__tests__/impl/basic_scheduler.test.ts
+++ b/packages/fsrs/__tests__/impl/basic_scheduler.test.ts
@@ -1,5 +1,4 @@
 import {
-
   createEmptyCard,
   FSRSAlgorithm,
   type Grade,

--- a/packages/fsrs/src/algorithm.ts
+++ b/packages/fsrs/src/algorithm.ts
@@ -150,7 +150,11 @@ export class FSRSAlgorithm {
     s: number,
     desired_retention: number = this.param.request_retention
   ): int {
-    if (desired_retention <= 0 || desired_retention > 1) {
+    if (
+      !Number.isFinite(desired_retention) ||
+      desired_retention <= 0 ||
+      desired_retention > 1
+    ) {
       throw new FSRSValidationError(
         'Desired retention rate should be in the range (0,1]'
       )

--- a/packages/fsrs/src/algorithm.ts
+++ b/packages/fsrs/src/algorithm.ts
@@ -55,38 +55,13 @@ export function forgetting_curve(
  */
 export class FSRSAlgorithm {
   protected param!: FSRSParameters
-  protected intervalModifier!: number
 
   constructor(params: Partial<FSRSParameters>) {
     this.param = new Proxy(
       generatorParameters(params),
       this.params_handler_proxy()
     )
-    this.intervalModifier = this.calculate_interval_modifier(
-      this.param.request_retention
-    )
     this.forgetting_curve = forgetting_curve.bind(this, this.param.w)
-  }
-
-  get interval_modifier(): number {
-    return this.intervalModifier
-  }
-
-  /**
-   * @see https://github.com/open-spaced-repetition/fsrs4anki/wiki/The-Algorithm#fsrs-5
-   *
-   * The formula used is: $$I(r,s) = (r^{\frac{1}{DECAY}} - 1) / FACTOR \times s$$
-   * @param request_retention 0<request_retention<=1,Requested retention rate
-   * @throws {Error} Requested retention rate should be in the range (0,1]
-   */
-  calculate_interval_modifier(request_retention: number): number {
-    if (request_retention <= 0 || request_retention > 1) {
-      throw new FSRSValidationError(
-        'Requested retention rate should be in the range (0,1]'
-      )
-    }
-    const { decay, factor } = computeDecayFactor(this.param.w)
-    return roundTo((Math.pow(request_retention, 1 / decay) - 1) / factor, 8)
   }
 
   /**
@@ -112,20 +87,13 @@ export class FSRSAlgorithm {
         prop: keyof FSRSParameters,
         value: FSRSParameters[keyof FSRSParameters]
       ) {
-        if (prop === 'request_retention' && Number.isFinite(value)) {
-          _this.intervalModifier = _this.calculate_interval_modifier(
-            Number(value)
-          )
-        } else if (prop === 'w') {
+        if (prop === 'w') {
           value = migrateParameters(
             value as FSRSParameters['w'],
             target.relearning_steps.length,
             target.enable_short_term
           )
           _this.forgetting_curve = forgetting_curve.bind(this, value)
-          _this.intervalModifier = _this.calculate_interval_modifier(
-            Number(target.request_retention)
-          )
         }
         Reflect.set(target, prop, value)
         return true
@@ -173,14 +141,24 @@ export class FSRSAlgorithm {
    *   Computes the base interval (no fuzzing). Fuzzing is applied by the scheduler
    *   layer via the `withFuzzing` strategy helper.
    *
-   *   @see The formula used is : {@link FSRSAlgorithm.calculate_interval_modifier}
+   *   The formula used is: $$I(r,s) = \frac{s}{FACTOR} \times (r^{\frac{1}{DECAY}} - 1)$$
    *   @param {number} s - Stability (interval when R=90%)
+   *   @param {number} desired_retention - Desired retention rate for this interval
+   *   @throws {Error} Desired retention rate should be in the range (0,1]
    */
-  next_interval(s: number): int {
-    return clamp(
-      Math.round(s * this.intervalModifier),
-      1,
-      this.param.maximum_interval
+  next_interval(
+    s: number,
+    desired_retention: number = this.param.request_retention
+  ): int {
+    if (desired_retention <= 0 || desired_retention > 1) {
+      throw new FSRSValidationError(
+        'Desired retention rate should be in the range (0,1]'
+      )
+    }
+    const { decay, factor } = computeDecayFactor(this.param.w)
+    return Math.max(
+      Math.round((s / factor) * (Math.pow(desired_retention, 1 / decay) - 1)),
+      1
     ) as int
   }
 

--- a/packages/fsrs/src/fsrs.ts
+++ b/packages/fsrs/src/fsrs.ts
@@ -86,11 +86,7 @@ export class FSRS extends FSRSAlgorithm implements IFSRS {
         prop: keyof FSRSParameters,
         value: FSRSParameters[keyof FSRSParameters]
       ) {
-        if (prop === 'request_retention' && Number.isFinite(value)) {
-          _this.intervalModifier = _this.calculate_interval_modifier(
-            Number(value)
-          )
-        } else if (prop === 'enable_short_term') {
+        if (prop === 'enable_short_term') {
           _this.Scheduler = value === true ? BasicScheduler : LongTermScheduler
         } else if (prop === 'w') {
           value = migrateParameters(
@@ -99,9 +95,6 @@ export class FSRS extends FSRSAlgorithm implements IFSRS {
             target.enable_short_term
           )
           _this.forgetting_curve = forgetting_curve.bind(this, value)
-          _this.intervalModifier = _this.calculate_interval_modifier(
-            Number(target.request_retention)
-          )
         }
         Reflect.set(target, prop, value)
         return true

--- a/packages/fsrs/src/impl/basic_scheduler.ts
+++ b/packages/fsrs/src/impl/basic_scheduler.ts
@@ -217,14 +217,21 @@ export default class BasicScheduler extends AbstractScheduler {
     next_easy: Card,
     interval: number
   ): void {
+    const { maximum_interval } = this.algorithm.parameters
     let hard_interval: int, good_interval: int
     hard_interval = this.scheduler_next_interval(next_hard.stability, interval)
     good_interval = this.scheduler_next_interval(next_good.stability, interval)
     hard_interval = Math.min(hard_interval, good_interval) as int
-    good_interval = Math.max(good_interval, hard_interval + 1) as int
-    const easy_interval = Math.max(
-      this.scheduler_next_interval(next_easy.stability, interval),
-      good_interval + 1
+    good_interval = Math.min(
+      Math.max(good_interval, hard_interval + 1),
+      maximum_interval
+    ) as int
+    const easy_interval = Math.min(
+      Math.max(
+        this.scheduler_next_interval(next_easy.stability, interval),
+        good_interval + 1
+      ),
+      maximum_interval
     ) as int
 
     next_hard.scheduled_days = hard_interval
@@ -246,7 +253,7 @@ export default class BasicScheduler extends AbstractScheduler {
       params.request_retention
     )
     const interval = withFuzzing(base, elapsed_days, params, this._seed)
-    return Math.min(interval, params.maximum_interval) as int
+    return interval
   }
 
   /**

--- a/packages/fsrs/src/impl/basic_scheduler.ts
+++ b/packages/fsrs/src/impl/basic_scheduler.ts
@@ -99,12 +99,9 @@ export default class BasicScheduler extends AbstractScheduler {
         nextCard.scheduled_days = Math.floor(scheduled_minutes / 1440)
       } else {
         nextCard.learning_steps = 0
-        const base = this.algorithm.next_interval(nextCard.stability)
-        const interval = withFuzzing(
-          base,
-          this.elapsed_days,
-          this.algorithm.parameters,
-          this._seed
+        const interval = this.scheduler_next_interval(
+          nextCard.stability,
+          this.elapsed_days
         )
         nextCard.scheduled_days = interval
         nextCard.due = date_scheduler(this.review_time, interval as int, true)
@@ -220,16 +217,13 @@ export default class BasicScheduler extends AbstractScheduler {
     next_easy: Card,
     interval: number
   ): void {
-    const params = this.algorithm.parameters
-    const fuzz = (ivl: int): int =>
-      withFuzzing(ivl, interval, params, this._seed)
     let hard_interval: int, good_interval: int
-    hard_interval = fuzz(this.algorithm.next_interval(next_hard.stability))
-    good_interval = fuzz(this.algorithm.next_interval(next_good.stability))
+    hard_interval = this.scheduler_next_interval(next_hard.stability, interval)
+    good_interval = this.scheduler_next_interval(next_good.stability, interval)
     hard_interval = Math.min(hard_interval, good_interval) as int
     good_interval = Math.max(good_interval, hard_interval + 1) as int
     const easy_interval = Math.max(
-      fuzz(this.algorithm.next_interval(next_easy.stability)),
+      this.scheduler_next_interval(next_easy.stability, interval),
       good_interval + 1
     ) as int
 
@@ -240,6 +234,19 @@ export default class BasicScheduler extends AbstractScheduler {
 
     next_easy.scheduled_days = easy_interval
     next_easy.due = date_scheduler(this.review_time, easy_interval, true)
+  }
+
+  private scheduler_next_interval(
+    stability: number,
+    elapsed_days: number
+  ): int {
+    const params = this.algorithm.parameters
+    const base = this.algorithm.next_interval(
+      stability,
+      params.request_retention
+    )
+    const interval = withFuzzing(base, elapsed_days, params, this._seed)
+    return Math.min(interval, params.maximum_interval) as int
   }
 
   /**

--- a/packages/fsrs/src/impl/long_term_scheduler.ts
+++ b/packages/fsrs/src/impl/long_term_scheduler.ts
@@ -96,6 +96,7 @@ export default class LongTermScheduler extends AbstractScheduler {
     next_easy: Card,
     interval: number
   ): void {
+    const { maximum_interval } = this.algorithm.parameters
     let again_interval: int,
       hard_interval: int,
       good_interval: int,
@@ -109,9 +110,18 @@ export default class LongTermScheduler extends AbstractScheduler {
     easy_interval = this.scheduler_next_interval(next_easy.stability, interval)
 
     again_interval = Math.min(again_interval, hard_interval) as int
-    hard_interval = Math.max(hard_interval, again_interval + 1) as int
-    good_interval = Math.max(good_interval, hard_interval + 1) as int
-    easy_interval = Math.max(easy_interval, good_interval + 1) as int
+    hard_interval = Math.min(
+      Math.max(hard_interval, again_interval + 1),
+      maximum_interval
+    ) as int
+    good_interval = Math.min(
+      Math.max(good_interval, hard_interval + 1),
+      maximum_interval
+    ) as int
+    easy_interval = Math.min(
+      Math.max(easy_interval, good_interval + 1),
+      maximum_interval
+    ) as int
 
     next_again.scheduled_days = again_interval
     next_again.due = date_scheduler(this.review_time, again_interval, true)
@@ -136,7 +146,7 @@ export default class LongTermScheduler extends AbstractScheduler {
       params.request_retention
     )
     const interval = withFuzzing(base, elapsed_days, params, this._seed)
-    return Math.min(interval, params.maximum_interval) as int
+    return interval
   }
 
   /**

--- a/packages/fsrs/src/impl/long_term_scheduler.ts
+++ b/packages/fsrs/src/impl/long_term_scheduler.ts
@@ -96,17 +96,17 @@ export default class LongTermScheduler extends AbstractScheduler {
     next_easy: Card,
     interval: number
   ): void {
-    const params = this.algorithm.parameters
-    const fuzz = (ivl: int): int =>
-      withFuzzing(ivl, interval, params, this._seed)
     let again_interval: int,
       hard_interval: int,
       good_interval: int,
       easy_interval: int
-    again_interval = fuzz(this.algorithm.next_interval(next_again.stability))
-    hard_interval = fuzz(this.algorithm.next_interval(next_hard.stability))
-    good_interval = fuzz(this.algorithm.next_interval(next_good.stability))
-    easy_interval = fuzz(this.algorithm.next_interval(next_easy.stability))
+    again_interval = this.scheduler_next_interval(
+      next_again.stability,
+      interval
+    )
+    hard_interval = this.scheduler_next_interval(next_hard.stability, interval)
+    good_interval = this.scheduler_next_interval(next_good.stability, interval)
+    easy_interval = this.scheduler_next_interval(next_easy.stability, interval)
 
     again_interval = Math.min(again_interval, hard_interval) as int
     hard_interval = Math.max(hard_interval, again_interval + 1) as int
@@ -124,6 +124,19 @@ export default class LongTermScheduler extends AbstractScheduler {
 
     next_easy.scheduled_days = easy_interval
     next_easy.due = date_scheduler(this.review_time, easy_interval, true)
+  }
+
+  private scheduler_next_interval(
+    stability: number,
+    elapsed_days: number
+  ): int {
+    const params = this.algorithm.parameters
+    const base = this.algorithm.next_interval(
+      stability,
+      params.request_retention
+    )
+    const interval = withFuzzing(base, elapsed_days, params, this._seed)
+    return Math.min(interval, params.maximum_interval) as int
   }
 
   /**


### PR DESCRIPTION
## Summary
- Add an optional `desired_retention` parameter to `FSRSAlgorithm.next_interval()`.
- Move default interval target and maximum interval handling into scheduler paths.
- Remove `interval_modifier` and `calculate_interval_modifier` from the public algorithm API.
- Prepare the scheduler and algorithm boundary for future Cost ADR support.

## Validation
- `pnpm --filter ts-fsrs check`
- `pnpm --filter ts-fsrs test`
- `pnpm --filter ts-fsrs build:types`