### PR TITLE
feat(kit): add schedule status primitives

### DIFF
--- a/.changeset/srs-kit-schedule-status.md
+++ b/.changeset/srs-kit-schedule-status.md
@@ -1,0 +1,8 @@
+---
+"@open-spaced-repetition/srs-kit": minor
+---
+
+feat(kit): add schedule status primitives
+
+Adds shared schedule status values and schema validation for scheduler status
+fields.

--- a/packages/srs-kit/src/primitives/index.ts
+++ b/packages/srs-kit/src/primitives/index.ts
@@ -1,2 +1,3 @@
 export * from './rating.js'
 export * from './state.js'
+export * from './status.js'

--- a/packages/srs-kit/src/primitives/status.spec.ts
+++ b/packages/srs-kit/src/primitives/status.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, expectTypeOf, it } from 'vitest'
+import { SRSSchemaError } from '@/schema/index.js'
+import {
+  type ScheduleStatus,
+  scheduleStatuses,
+  scheduleStatusSchema,
+} from './status.js'
+
+describe('ScheduleStatus', () => {
+  it('defines fixed schedule status values and schema', () => {
+    expect(scheduleStatuses).toEqual(['new', 'learning', 'review'])
+    expect(scheduleStatusSchema.parse('new')).toBe('new')
+    expect(scheduleStatusSchema.parse('learning')).toBe('learning')
+    expect(scheduleStatusSchema.parse('review')).toBe('review')
+    expect(() => scheduleStatusSchema.parse('relearning')).toThrow(
+      SRSSchemaError
+    )
+    expectTypeOf<ScheduleStatus>().toEqualTypeOf<
+      'new' | 'learning' | 'review'
+    >()
+  })
+
+  it('prevents mutation of scheduleStatuses', () => {
+    expect(() => {
+      ;(scheduleStatuses as unknown as string[])[0] = 'invalid'
+    }).toThrow(TypeError)
+    expect(() => {
+      ;(scheduleStatuses as unknown as string[]).push('invalid')
+    }).toThrow(TypeError)
+  })
+})

--- a/packages/srs-kit/src/primitives/status.ts
+++ b/packages/srs-kit/src/primitives/status.ts
@@ -1,0 +1,15 @@
+import { defineSchema } from '@/schema/index.js'
+
+export const scheduleStatuses = Object.freeze([
+  'new',
+  'learning',
+  'review',
+] as const)
+
+export type ScheduleStatus = (typeof scheduleStatuses)[number]
+
+export const scheduleStatusSchema = defineSchema<ScheduleStatus>((value) =>
+  value === 'new' || value === 'learning' || value === 'review'
+    ? { value }
+    : { issues: [{ message: 'Expected schedule status' }] }
+)


### PR DESCRIPTION
- https://github.com/open-spaced-repetition/ts-fsrs/issues/373

## Summary
- add shared schedule status values and schema validation
- export schedule status primitives from the primitives entrypoint
- add focused tests and a changeset

## Tests
- ../../node_modules/.bin/vitest run --config=vitest.config.ts src/primitives/status.spec.ts