### PR TITLE
feat(kit): support revlog chrono projections

### DIFF
--- a/.changeset/srs-kit-chrono.md
+++ b/.changeset/srs-kit-chrono.md
@@ -10,3 +10,6 @@ exports presets for numeric elapsed days, `Date`, and `Temporal.Instant`.
 Chrono projections now derive previous/current times from card fields plus the
 scheduler-provided time, giving schedulers a stable input for difference and
 default-value generation.
+
+Projection inputs also accept revlog fields for rollback flows, and the `Date`
+and `Temporal.Instant` revlog schemas now use `reviewTime` consistently.

--- a/packages/srs-kit/src/chrono/chrono.ts
+++ b/packages/srs-kit/src/chrono/chrono.ts
@@ -180,10 +180,6 @@ export type ChronoCreate<Env extends BlankChronoEnv = BlankChronoEnv> = [
         readonly config: SchemaOutput<ChronoConfigSchema<Env>>
       }) => ChronoCore<SchemaOutput<Env['time']>>
 
-export type AnyChronoCreate = (ctx?: {
-  readonly config: unknown
-}) => AnyChronoCore
-
 export interface Chrono<Env extends BlankChronoEnv = BlankChronoEnv> {
   readonly schema: ChronoSchema<Env>
   readonly projection: ChronoProjection<Env>

--- a/packages/srs-kit/src/chrono/chrono.ts
+++ b/packages/srs-kit/src/chrono/chrono.ts
@@ -6,6 +6,7 @@ import type {
   EmptyPart,
   emptyObjectSchema,
   FieldDefault,
+  IsAny,
   SchemaInput,
   SchemaOutput,
 } from '../schema/index.js'
@@ -71,11 +72,25 @@ export interface ChronoTimeProjection<Time> {
   readonly current: Time
 }
 
-export type ChronoProjectionInput<Time, CardFields = never> = [
-  CardFields,
-] extends [never]
+type ChronoReviewProjectionInput<Time, CardFields> = [CardFields] extends [
+  never,
+]
   ? { readonly time: Time }
   : { readonly card: Readonly<CardFields>; readonly time: Time }
+
+type ChronoRollbackProjectionInput<RevlogFields> = [RevlogFields] extends [
+  never,
+]
+  ? never
+  : { readonly revlog: Readonly<RevlogFields> }
+
+export type ChronoProjectionInput<
+  Time,
+  CardFields = never,
+  RevlogFields = never,
+> =
+  | ChronoReviewProjectionInput<Time, CardFields>
+  | ChronoRollbackProjectionInput<RevlogFields>
 
 type ChronoProjectedCard<Env extends BlankChronoEnv> = [
   ChronoFieldSchema<Env, 'card'>,
@@ -83,11 +98,32 @@ type ChronoProjectedCard<Env extends BlankChronoEnv> = [
   ? never
   : SchemaInput<ChronoFieldSchema<Env, 'card'>>
 
+type ChronoProjectedRevlog<Env extends BlankChronoEnv> = [
+  ChronoFieldSchema<Env, 'revlog'>,
+] extends [never]
+  ? never
+  : SchemaInput<ChronoFieldSchema<Env, 'revlog'>>
+
 export type ChronoProjection<Env extends BlankChronoEnv = BlankChronoEnv> =
   StandardSchemaV1<
-    ChronoProjectionInput<SchemaOutput<Env['time']>, ChronoProjectedCard<Env>>,
+    ChronoProjectionInput<
+      SchemaOutput<Env['time']>,
+      ChronoProjectedCard<Env>,
+      ChronoProjectedRevlog<Env>
+    >,
     ChronoTimeProjection<SchemaOutput<Env['time']>>
   >
+
+type ChronoProjectionRuntimeEnv = {
+  readonly time: StandardSchemaV1<unknown, unknown>
+  readonly fields: {
+    readonly card: StandardSchemaV1<unknown, object>
+    readonly revlog: StandardSchemaV1<unknown, object>
+  }
+}
+
+export type ChronoProjectionRuntimeSchema =
+  ChronoProjection<ChronoProjectionRuntimeEnv>
 
 // ==========
 // Chrono
@@ -98,10 +134,24 @@ export interface ChronoDefaultCtx<Config, Value> {
   readonly previous?: Readonly<ChronoTimeProjection<Value>>
 }
 
-export type ChronoSchema<Env extends BlankChronoEnv = BlankChronoEnv> = {
-  readonly time: Env['time']
-} & ChronoPart<'config', ChronoConfigSchema<Env>> &
-  ChronoSchemaFields<Env>
+export type ChronoDefaultRuntimeFn = (
+  ctx: ChronoDefaultCtx<unknown, unknown>
+) => object
+
+export type AnyChronoSchema = {
+  readonly time: AnySchema
+  readonly config?: AnySchema
+  readonly card?: AnyObjectSchema
+  readonly revlog?: AnyObjectSchema
+}
+
+export type ChronoSchema<Env extends BlankChronoEnv = BlankChronoEnv> =
+  IsAny<Env> extends true
+    ? AnyChronoSchema
+    : {
+        readonly time: Env['time']
+      } & ChronoPart<'config', ChronoConfigSchema<Env>> &
+        ChronoSchemaFields<Env>
 
 type ChronoDefaultPart<
   Env extends BlankChronoEnv,
@@ -129,6 +179,10 @@ export type ChronoCreate<Env extends BlankChronoEnv = BlankChronoEnv> = [
     : (ctx: {
         readonly config: SchemaOutput<ChronoConfigSchema<Env>>
       }) => ChronoCore<SchemaOutput<Env['time']>>
+
+export type AnyChronoCreate = (ctx?: {
+  readonly config: unknown
+}) => AnyChronoCore
 
 export interface Chrono<Env extends BlankChronoEnv = BlankChronoEnv> {
   readonly schema: ChronoSchema<Env>

--- a/packages/srs-kit/src/chrono/define-chrono.spec.ts
+++ b/packages/srs-kit/src/chrono/define-chrono.spec.ts
@@ -1,14 +1,23 @@
 import { describe, expect, expectTypeOf, it } from 'vitest'
 import { defineSchema, emptyObjectSchema } from '../schema/index.js'
 import {
+  type AnyChrono,
+  type AnyChronoSchema,
   type ChronoCardOf,
   type ChronoRevlogOf,
+  type ChronoSchema,
   type ChronoTimeOf,
   defineChrono,
   defineChronoProjection,
 } from './index.js'
 
 describe('defineChrono', () => {
+  it('erases any chrono schema to the runtime schema shape', () => {
+    expectTypeOf<AnyChrono['schema']>().toEqualTypeOf<AnyChronoSchema>()
+    // biome-ignore lint/suspicious/noExplicitAny: verifies ChronoSchema<any> erasure
+    expectTypeOf<ChronoSchema<any>>().toEqualTypeOf<AnyChronoSchema>()
+  })
+
   it('fills omitted schema slots and default values', () => {
     const chrono = defineChrono({
       schema: {
@@ -50,6 +59,21 @@ describe('defineChrono', () => {
         time: numberSchema,
       },
       projection(value) {
+        if ('revlog' in value) {
+          expectTypeOf(value.revlog).toEqualTypeOf<
+            Readonly<{
+              readonly elapsedDays: number
+            }>
+          >()
+
+          return {
+            value: {
+              previous: value.revlog.elapsedDays,
+              current: value.revlog.elapsedDays,
+            },
+          }
+        }
+
         expectTypeOf(value).toEqualTypeOf<{
           readonly card: Readonly<{
             readonly previous: number | null
@@ -183,6 +207,51 @@ describe('defineChrono', () => {
     }>()
   })
 
+  it('types projection revlog as schema input', () => {
+    defineChrono({
+      schema: {
+        revlog: revlogSchema,
+        time: numberSchema,
+      },
+      projection(value) {
+        if ('revlog' in value) {
+          expectTypeOf(value.revlog).toEqualTypeOf<
+            Readonly<{
+              readonly elapsedDays: number
+            }>
+          >()
+
+          return {
+            value: {
+              previous: value.revlog.elapsedDays,
+              current: value.revlog.elapsedDays,
+            },
+          }
+        }
+
+        return {
+          value: {
+            previous: value.time,
+            current: value.time,
+          },
+        }
+      },
+      create() {
+        return {
+          now() {
+            return 0
+          },
+          difference(from, to) {
+            return to - from
+          },
+          add(from, days) {
+            return from + days
+          },
+        }
+      },
+    })
+  })
+
   it('preserves card presence in projection helpers', () => {
     defineChronoProjection<{
       readonly card: {
@@ -204,6 +273,30 @@ describe('defineChrono', () => {
           current: value.time,
         },
       }
+    })
+
+    defineChronoProjection<{
+      readonly time: number
+      readonly revlog: {
+        readonly elapsedDays: number
+      }
+    }>((value) => {
+      if ('revlog' in value) {
+        expectTypeOf(value.revlog).toEqualTypeOf<
+          Readonly<{
+            readonly elapsedDays: number
+          }>
+        >()
+
+        return {
+          value: {
+            previous: value.revlog.elapsedDays,
+            current: value.revlog.elapsedDays,
+          },
+        }
+      }
+
+      return { value: { previous: 0, current: value.time } }
     })
 
     defineChronoProjection<{

--- a/packages/srs-kit/src/chrono/define-chrono.ts
+++ b/packages/srs-kit/src/chrono/define-chrono.ts
@@ -17,13 +17,15 @@ import type {
 
 type ChronoProjectionDefinitionInput = {
   readonly card?: unknown
+  readonly revlog?: unknown
   readonly time: unknown
 }
 
 type ChronoProjectionInputOf<Input extends ChronoProjectionDefinitionInput> =
   ChronoProjectionInput<
     Input['time'],
-    Input extends { readonly card: infer Card } ? Card : never
+    Input extends { readonly card: infer Card } ? Card : never,
+    Input extends { readonly revlog: infer Revlog } ? Revlog : never
   >
 
 export function defineChronoProjection<
@@ -46,21 +48,24 @@ export function defineChronoProjection<
 type ChronoProjectionInputFor<
   TimeSchema extends AnySchema,
   CardSchema extends AnyObjectSchema | undefined,
+  RevlogSchema extends AnyObjectSchema | undefined,
 > = ChronoProjectionInput<
   SchemaOutput<TimeSchema>,
-  CardSchema extends AnyObjectSchema ? SchemaInput<CardSchema> : never
+  CardSchema extends AnyObjectSchema ? SchemaInput<CardSchema> : never,
+  RevlogSchema extends AnyObjectSchema ? SchemaInput<RevlogSchema> : never
 >
 
 type ChronoProjectionDefinition<
   TimeSchema extends AnySchema,
   CardSchema extends AnyObjectSchema | undefined,
+  RevlogSchema extends AnyObjectSchema | undefined,
 > =
   | StandardSchemaV1<
-      ChronoProjectionInputFor<TimeSchema, CardSchema>,
+      ChronoProjectionInputFor<TimeSchema, CardSchema, RevlogSchema>,
       ChronoTimeProjection<SchemaOutput<TimeSchema>>
     >
   | ((
-      value: ChronoProjectionInputFor<TimeSchema, CardSchema>
+      value: ChronoProjectionInputFor<TimeSchema, CardSchema, RevlogSchema>
     ) => StandardSchemaV1.Result<
       ChronoTimeProjection<SchemaOutput<TimeSchema>>
     >)
@@ -98,13 +103,29 @@ type ChronoDefinitionFields<Schema extends ChronoDefinitionSchema> =
       : EmptyPart)
 
 type ChronoDefinitionEnv<Schema extends ChronoDefinitionSchema> = {
-  readonly time: Schema['time']
-  readonly fields: ChronoDefinitionFields<Schema>
-} & ChronoDefinitionConfig<Schema>
+  readonly [Key in keyof ({
+    readonly time: Schema['time']
+  } & ChronoDefinitionConfig<Schema> & {
+      readonly fields: {
+        readonly [Field in keyof ChronoDefinitionFields<Schema>]: ChronoDefinitionFields<Schema>[Field]
+      }
+    })]: ({
+    readonly time: Schema['time']
+  } & ChronoDefinitionConfig<Schema> & {
+      readonly fields: {
+        readonly [Field in keyof ChronoDefinitionFields<Schema>]: ChronoDefinitionFields<Schema>[Field]
+      }
+    })[Key]
+}
 
 type ChronoDefinitionCard<Schema extends ChronoDefinitionSchema> =
   Schema extends { readonly card: infer Card extends AnyObjectSchema }
     ? Card
+    : undefined
+
+type ChronoDefinitionRevlog<Schema extends ChronoDefinitionSchema> =
+  Schema extends { readonly revlog: infer Revlog extends AnyObjectSchema }
+    ? Revlog
     : undefined
 
 type ChronoDefinition<Schema extends ChronoDefinitionSchema> = {
@@ -112,7 +133,8 @@ type ChronoDefinition<Schema extends ChronoDefinitionSchema> = {
   readonly defaultValue?: ChronoDefaultValue<ChronoDefinitionEnv<Schema>>
   readonly projection: ChronoProjectionDefinition<
     Schema['time'],
-    ChronoDefinitionCard<Schema>
+    ChronoDefinitionCard<Schema>,
+    ChronoDefinitionRevlog<Schema>
   >
   readonly create: ChronoCreate<ChronoDefinitionEnv<Schema>>
 }

--- a/packages/srs-kit/src/chrono/define-chrono.ts
+++ b/packages/srs-kit/src/chrono/define-chrono.ts
@@ -118,23 +118,20 @@ type ChronoDefinitionEnv<Schema extends ChronoDefinitionSchema> = {
     })[Key]
 }
 
-type ChronoDefinitionCard<Schema extends ChronoDefinitionSchema> =
-  Schema extends { readonly card: infer Card extends AnyObjectSchema }
-    ? Card
-    : undefined
-
-type ChronoDefinitionRevlog<Schema extends ChronoDefinitionSchema> =
-  Schema extends { readonly revlog: infer Revlog extends AnyObjectSchema }
-    ? Revlog
-    : undefined
+type ChronoDefinitionField<
+  Schema extends ChronoDefinitionSchema,
+  Key extends 'card' | 'revlog',
+> = Schema extends { readonly [K in Key]: infer Field extends AnyObjectSchema }
+  ? Field
+  : undefined
 
 type ChronoDefinition<Schema extends ChronoDefinitionSchema> = {
   readonly schema: Schema
   readonly defaultValue?: ChronoDefaultValue<ChronoDefinitionEnv<Schema>>
   readonly projection: ChronoProjectionDefinition<
     Schema['time'],
-    ChronoDefinitionCard<Schema>,
-    ChronoDefinitionRevlog<Schema>
+    ChronoDefinitionField<Schema, 'card'>,
+    ChronoDefinitionField<Schema, 'revlog'>
   >
   readonly create: ChronoCreate<ChronoDefinitionEnv<Schema>>
 }

--- a/packages/srs-kit/src/chrono/define-chrono.type-display.spec.ts
+++ b/packages/srs-kit/src/chrono/define-chrono.type-display.spec.ts
@@ -47,11 +47,11 @@ describe('defineChrono type display', () => {
         readonly revlog: SRSSchema<{
             input: {
                 dueAt: Date;
-                lastReviewAt: Date;
+                reviewTime: Date;
             };
             output: {
                 dueAt: Date;
-                lastReviewAt: Date;
+                reviewTime: Date;
             };
         }>;
     };
@@ -85,11 +85,11 @@ describe('defineChrono type display', () => {
         readonly revlog: SRSSchema<{
             input: {
                 dueAt: Temporal.Instant;
-                lastReviewAt: Temporal.Instant;
+                reviewTime: Temporal.Instant;
             };
             output: {
                 dueAt: Temporal.Instant;
-                lastReviewAt: Temporal.Instant;
+                reviewTime: Temporal.Instant;
             };
         }>;
     };

--- a/packages/srs-kit/src/chrono/infer.ts
+++ b/packages/srs-kit/src/chrono/infer.ts
@@ -1,4 +1,9 @@
-import type { SchemaOutputOf } from '../schema/index.js'
+import type {
+  EmptyPart,
+  SchemaInputOf,
+  SchemaOf,
+  SchemaOutputOf,
+} from '../schema/index.js'
 import type { AnyChrono } from './chrono.js'
 
 export type ChronoTimeOf<T extends AnyChrono> = SchemaOutputOf<T, 'time'>
@@ -6,3 +11,14 @@ export type ChronoTimeOf<T extends AnyChrono> = SchemaOutputOf<T, 'time'>
 export type ChronoCardOf<T extends AnyChrono> = SchemaOutputOf<T, 'card'>
 
 export type ChronoRevlogOf<T extends AnyChrono> = SchemaOutputOf<T, 'revlog'>
+
+export type ChronoConfigPart<
+  T extends AnyChrono,
+  Mode extends 'input' | 'output',
+> = [SchemaOf<T, 'config'>] extends [never]
+  ? Mode extends 'input'
+    ? EmptyPart
+    : { readonly chrono: Record<string, never> }
+  : Mode extends 'input'
+    ? { readonly chrono: SchemaInputOf<T, 'config'> }
+    : { readonly chrono: SchemaOutputOf<T, 'config'> }

--- a/packages/srs-kit/src/chrono/presets/date/chrono.spec.ts
+++ b/packages/srs-kit/src/chrono/presets/date/chrono.spec.ts
@@ -16,7 +16,7 @@ describe('dateChrono', () => {
     }>()
     expectTypeOf<ChronoRevlogOf<typeof dateChrono>>().toEqualTypeOf<{
       dueAt: Date
-      lastReviewAt: Date
+      reviewTime: Date
     }>()
 
     const now = new Date('2026-06-20T00:00:00.000Z')
@@ -55,25 +55,25 @@ describe('dateChrono', () => {
     ).toThrow('Expected valid Date fields')
     expect(
       parse(dateChrono.schema.revlog, {
-        dueAt: later,
-        lastReviewAt: now,
+        dueAt: now,
+        reviewTime: later,
       })
-    ).toEqual({ dueAt: later, lastReviewAt: now })
+    ).toEqual({ dueAt: now, reviewTime: later })
     expect(() =>
       parse(dateChrono.schema.revlog, {
-        dueAt: later,
-        lastReviewAt: null,
-      })
-    ).toThrow('Expected valid Date fields')
-    expect(() =>
-      parse(dateChrono.schema.revlog, {
-        dueAt: later,
+        dueAt: null,
+        reviewTime: later,
       })
     ).toThrow('Expected valid Date fields')
     expect(() =>
       parse(dateChrono.schema.revlog, {
         dueAt: later,
-        lastReviewAt: epoch,
+      })
+    ).toThrow('Expected valid Date fields')
+    expect(() =>
+      parse(dateChrono.schema.revlog, {
+        dueAt: epoch,
+        reviewTime: later,
       })
     ).toThrow('Expected valid Date fields')
     expect(
@@ -111,6 +111,14 @@ describe('dateChrono', () => {
         time: later,
       })
     ).toEqual({ previous: later, current: later })
+    expect(
+      parse(dateChrono.projection, {
+        revlog: {
+          dueAt: now,
+          reviewTime: later,
+        },
+      })
+    ).toEqual({ previous: now, current: later })
     expect(() =>
       parse(dateChrono.projection, {
         card: null,
@@ -191,13 +199,13 @@ describe('dateChrono', () => {
           current: later,
         },
       })
-    ).toEqual({ dueAt: later, lastReviewAt: now })
+    ).toEqual({ dueAt: now, reviewTime: later })
     expect(
       dateChrono.defaultValue.revlog!({
         config: {},
         time: now,
       })
-    ).toEqual({ dueAt: now, lastReviewAt: now })
+    ).toEqual({ dueAt: now, reviewTime: now })
   })
 
   it('compares only UTC calendar dates', () => {

--- a/packages/srs-kit/src/chrono/presets/date/chrono.spec.ts
+++ b/packages/srs-kit/src/chrono/presets/date/chrono.spec.ts
@@ -119,6 +119,19 @@ describe('dateChrono', () => {
         },
       })
     ).toEqual({ previous: now, current: later })
+    expect(dateChrono.projection['~standard'].validate(123)).toEqual({
+      issues: [{ message: 'Expected valid Date fields' }],
+    })
+    expect(() => parse(dateChrono.projection, 123)).toThrow(
+      'Expected valid Date fields'
+    )
+    expect(() =>
+      parse(dateChrono.projection, {
+        revlog: {
+          dueAt: now,
+        },
+      })
+    ).toThrow('Expected valid Date fields')
     expect(() =>
       parse(dateChrono.projection, {
         card: null,

--- a/packages/srs-kit/src/chrono/presets/date/chrono.ts
+++ b/packages/srs-kit/src/chrono/presets/date/chrono.ts
@@ -13,20 +13,34 @@ export const dateChrono = defineChrono({
     time: dateSchema,
   },
   projection(value) {
-    const card = dateCardFieldsSchema['~standard'].validate(value.card)
-    if (card.issues) {
-      return card
+    if ('card' in value) {
+      const card = dateCardFieldsSchema['~standard'].validate(value.card)
+      if (card.issues) {
+        return card
+      }
+
+      const time = dateSchema['~standard'].validate(value.time)
+      if (time.issues) {
+        return time
+      }
+
+      return {
+        value: {
+          previous: card.value.lastReviewAt ?? time.value,
+          current: time.value,
+        },
+      }
     }
 
-    const time = dateSchema['~standard'].validate(value.time)
-    if (time.issues) {
-      return time
+    const revlog = dateRevlogFieldsSchema['~standard'].validate(value.revlog)
+    if (revlog.issues) {
+      return revlog
     }
 
     return {
       value: {
-        previous: card.value.lastReviewAt ?? time.value,
-        current: time.value,
+        previous: revlog.value.dueAt,
+        current: revlog.value.reviewTime,
       },
     }
   },
@@ -39,8 +53,8 @@ export const dateChrono = defineChrono({
     },
     revlog({ time, previous }) {
       return {
-        dueAt: previous?.current ?? time,
-        lastReviewAt: previous?.previous ?? time,
+        dueAt: previous?.previous ?? time,
+        reviewTime: previous?.current ?? time,
       }
     },
   },

--- a/packages/srs-kit/src/chrono/presets/date/chrono.ts
+++ b/packages/srs-kit/src/chrono/presets/date/chrono.ts
@@ -1,5 +1,6 @@
 import { defineChrono } from '@/chrono/define-chrono.js'
 import { dateSchema } from '@/schema/field.js'
+import { isObject } from '@/schema/index.js'
 import {
   dateCardFieldsSchema,
   dateRevlogFieldsSchema,
@@ -13,6 +14,10 @@ export const dateChrono = defineChrono({
     time: dateSchema,
   },
   projection(value) {
+    if (!isObject(value)) {
+      return { issues: [{ message: 'Expected valid Date fields' }] }
+    }
+
     if ('card' in value) {
       const card = dateCardFieldsSchema['~standard'].validate(value.card)
       if (card.issues) {

--- a/packages/srs-kit/src/chrono/presets/date/schema.ts
+++ b/packages/srs-kit/src/chrono/presets/date/schema.ts
@@ -15,7 +15,7 @@ export type DateCardOutputFields = {
 
 export type DateRevlogFields = {
   dueAt: Date
-  lastReviewAt: Date
+  reviewTime: Date
 }
 
 function isValidDate(value: unknown): value is Date {
@@ -56,15 +56,15 @@ export const dateCardFieldsSchema = defineSchema<
 
 export const dateRevlogFieldsSchema = defineSchema<DateRevlogFields>(
   (value: unknown) => {
-    if (!isObject(value) || !('dueAt' in value) || !('lastReviewAt' in value)) {
+    if (!isObject(value) || !('dueAt' in value) || !('reviewTime' in value)) {
       return invalidDateFields()
     }
 
-    const { dueAt, lastReviewAt } = value
-    if (!isValidDate(dueAt) || !isValidDate(lastReviewAt)) {
+    const { dueAt, reviewTime } = value
+    if (!isValidDate(dueAt) || !isValidDate(reviewTime)) {
       return invalidDateFields()
     }
 
-    return { value: { dueAt, lastReviewAt } }
+    return { value: { dueAt, reviewTime } }
   }
 )

--- a/packages/srs-kit/src/chrono/presets/temporal-instant/chrono.spec.ts
+++ b/packages/srs-kit/src/chrono/presets/temporal-instant/chrono.spec.ts
@@ -58,7 +58,7 @@ describe('temporalInstantChrono', () => {
     }>()
     expectTypeOf<ChronoRevlogOf<typeof temporalInstantChrono>>().toEqualTypeOf<{
       dueAt: Temporal.Instant
-      lastReviewAt: Temporal.Instant
+      reviewTime: Temporal.Instant
     }>()
 
     const now = createInstant(0n)
@@ -139,25 +139,25 @@ describe('temporalInstantChrono', () => {
     ).toEqual({ dueAt: now, lastReviewAt: null })
     expect(
       parse(temporalInstantChrono.schema.revlog, {
-        dueAt: later,
-        lastReviewAt: now,
+        dueAt: now,
+        reviewTime: later,
       })
-    ).toEqual({ dueAt: later, lastReviewAt: now })
+    ).toEqual({ dueAt: now, reviewTime: later })
     expect(() =>
       parse(temporalInstantChrono.schema.revlog, {
-        dueAt: later,
-        lastReviewAt: null,
-      })
-    ).toThrow('Expected Temporal.Instant fields')
-    expect(() =>
-      parse(temporalInstantChrono.schema.revlog, {
-        dueAt: later,
+        dueAt: null,
+        reviewTime: later,
       })
     ).toThrow('Expected Temporal.Instant fields')
     expect(() =>
       parse(temporalInstantChrono.schema.revlog, {
-        dueAt: {},
-        lastReviewAt: now,
+        dueAt: later,
+      })
+    ).toThrow('Expected Temporal.Instant fields')
+    expect(() =>
+      parse(temporalInstantChrono.schema.revlog, {
+        dueAt: now,
+        reviewTime: {},
       })
     ).toThrow('Expected Temporal.Instant fields')
     expect(
@@ -195,6 +195,14 @@ describe('temporalInstantChrono', () => {
         time: later,
       })
     ).toEqual({ previous: later, current: later })
+    expect(
+      parse(temporalInstantChrono.projection, {
+        revlog: {
+          dueAt: now,
+          reviewTime: later,
+        },
+      })
+    ).toEqual({ previous: now, current: later })
     expect(() =>
       parse(temporalInstantChrono.projection, {
         card: null,
@@ -275,12 +283,12 @@ describe('temporalInstantChrono', () => {
           current: later,
         },
       })
-    ).toEqual({ dueAt: later, lastReviewAt: now })
+    ).toEqual({ dueAt: now, reviewTime: later })
     expect(
       temporalInstantChrono.defaultValue.revlog!({
         config: temporalConfig,
         time: now,
       })
-    ).toEqual({ dueAt: now, lastReviewAt: now })
+    ).toEqual({ dueAt: now, reviewTime: now })
   })
 })

--- a/packages/srs-kit/src/chrono/presets/temporal-instant/chrono.spec.ts
+++ b/packages/srs-kit/src/chrono/presets/temporal-instant/chrono.spec.ts
@@ -203,6 +203,21 @@ describe('temporalInstantChrono', () => {
         },
       })
     ).toEqual({ previous: now, current: later })
+    expect(temporalInstantChrono.projection['~standard'].validate(123)).toEqual(
+      {
+        issues: [{ message: 'Expected Temporal.Instant fields' }],
+      }
+    )
+    expect(() => parse(temporalInstantChrono.projection, 123)).toThrow(
+      'Expected Temporal.Instant fields'
+    )
+    expect(() =>
+      parse(temporalInstantChrono.projection, {
+        revlog: {
+          dueAt: now,
+        },
+      })
+    ).toThrow('Expected Temporal.Instant fields')
     expect(() =>
       parse(temporalInstantChrono.projection, {
         card: null,

--- a/packages/srs-kit/src/chrono/presets/temporal-instant/chrono.ts
+++ b/packages/srs-kit/src/chrono/presets/temporal-instant/chrono.ts
@@ -48,22 +48,38 @@ export const temporalInstantChrono = defineChrono({
     time: temporalInstantSchema,
   },
   projection(value) {
-    const card = temporalInstantCardFieldsSchema['~standard'].validate(
-      value.card
-    )
-    if (card.issues) {
-      return card
+    if ('card' in value) {
+      const card = temporalInstantCardFieldsSchema['~standard'].validate(
+        value.card
+      )
+      if (card.issues) {
+        return card
+      }
+
+      const time = temporalInstantSchema['~standard'].validate(value.time)
+      if (time.issues) {
+        return time
+      }
+
+      return {
+        value: {
+          previous: card.value.lastReviewAt ?? time.value,
+          current: time.value,
+        },
+      }
     }
 
-    const time = temporalInstantSchema['~standard'].validate(value.time)
-    if (time.issues) {
-      return time
+    const revlog = temporalInstantRevlogFieldsSchema['~standard'].validate(
+      value.revlog
+    )
+    if (revlog.issues) {
+      return revlog
     }
 
     return {
       value: {
-        previous: card.value.lastReviewAt ?? time.value,
-        current: time.value,
+        previous: revlog.value.dueAt,
+        current: revlog.value.reviewTime,
       },
     }
   },
@@ -76,8 +92,8 @@ export const temporalInstantChrono = defineChrono({
     },
     revlog({ time, previous }) {
       return {
-        dueAt: previous?.current ?? time,
-        lastReviewAt: previous?.previous ?? time,
+        dueAt: previous?.previous ?? time,
+        reviewTime: previous?.current ?? time,
       }
     },
   },

--- a/packages/srs-kit/src/chrono/presets/temporal-instant/chrono.ts
+++ b/packages/srs-kit/src/chrono/presets/temporal-instant/chrono.ts
@@ -1,4 +1,5 @@
 import { defineChrono } from '@/chrono/define-chrono.js'
+import { isObject } from '@/schema/index.js'
 import {
   getTemporalInstantConstructor,
   temporalInstantCardFieldsSchema,
@@ -48,6 +49,10 @@ export const temporalInstantChrono = defineChrono({
     time: temporalInstantSchema,
   },
   projection(value) {
+    if (!isObject(value)) {
+      return { issues: [{ message: 'Expected Temporal.Instant fields' }] }
+    }
+
     if ('card' in value) {
       const card = temporalInstantCardFieldsSchema['~standard'].validate(
         value.card

--- a/packages/srs-kit/src/chrono/presets/temporal-instant/schema.ts
+++ b/packages/srs-kit/src/chrono/presets/temporal-instant/schema.ts
@@ -17,7 +17,7 @@ export type TemporalInstantCardOutputFields = {
 
 export type TemporalInstantRevlogFields = {
   dueAt: Temporal.Instant
-  lastReviewAt: Temporal.Instant
+  reviewTime: Temporal.Instant
 }
 
 export function getTemporalInstantConstructor(): typeof Temporal.Instant {
@@ -118,7 +118,7 @@ export const temporalInstantCardFieldsSchema = defineSchema<
 
 export const temporalInstantRevlogFieldsSchema =
   defineSchema<TemporalInstantRevlogFields>((value) => {
-    if (!isObject(value) || !('dueAt' in value) || !('lastReviewAt' in value)) {
+    if (!isObject(value) || !('dueAt' in value) || !('reviewTime' in value)) {
       return invalidInstantFields()
     }
 
@@ -127,10 +127,12 @@ export const temporalInstantRevlogFieldsSchema =
       return invalidInstantFields()
     }
 
-    const lastReviewAt = temporalInstantSchema.safeParse(value.lastReviewAt)
-    if (!lastReviewAt.success) {
+    const reviewTime = temporalInstantSchema.safeParse(value.reviewTime)
+    if (!reviewTime.success) {
       return invalidInstantFields()
     }
 
-    return { value: { dueAt: dueAt.data, lastReviewAt: lastReviewAt.data } }
+    return {
+      value: { dueAt: dueAt.data, reviewTime: reviewTime.data },
+    }
   })

--- a/packages/srs-kit/src/schema/utils.ts
+++ b/packages/srs-kit/src/schema/utils.ts
@@ -1,5 +1,9 @@
 /** biome-ignore-all lint/suspicious/noExplicitAny: wildcard constraint for generic bounds */
-type IsAny<T> = 0 extends 1 & T ? true : false
+export type IsAny<T> = unknown extends T
+  ? [keyof T] extends [never]
+    ? false
+    : true
+  : false
 
 type Primitive = null | undefined | string | number | boolean | symbol | bigint
 


### PR DESCRIPTION
- https://github.com/open-spaced-repetition/ts-fsrs/issues/373

## Summary
- allow chrono projections to accept revlog fields for rollback flows
- rename Date and Temporal.Instant revlog time fields to reviewTime
- update chrono inference tests, preset tests, schema typing, and the existing changeset

## Tests
- ../../node_modules/.bin/vitest run --config=vitest.config.ts src/chrono/define-chrono.spec.ts src/chrono/define-chrono.type-display.spec.ts src/chrono/presets/date/chrono.spec.ts src/chrono/presets/temporal-instant/chrono.spec.ts
- ../../node_modules/.bin/tsc --noEmit --pretty false