### PR TITLE
chore: upgrade pnpm to v11 and bump Node to 22

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -15,7 +15,7 @@ runs:
   using: 'composite'
   steps:
     - name: Setup pnpm
-      run: npm install -g corepack@0.32.0 --force && corepack enable pnpm
+      run: npm install -g corepack@0.34.6 --force && corepack enable pnpm
       shell: bash
 
     - name: Install Node.js

--- a/.github/workflows/build-napi.yml
+++ b/.github/workflows/build-napi.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Setup pnpm (x86)
         if: matrix.settings.target == 'i686-pc-windows-msvc'
         shell: bash
-        run: npm install -g corepack@0.32.0 --force && corepack enable pnpm
+        run: npm install -g corepack@0.34.6 --force && corepack enable pnpm
 
       - name: Setup node x86
         uses: actions/setup-node@v4

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -44,7 +44,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node: [20]
+        node: [22]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     name: '${{matrix.platform}} / Node.js ${{ matrix.node }}'
     runs-on: ${{matrix.platform}}

--- a/examples/vite/Dockerfile
+++ b/examples/vite/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1
 
-FROM node:20-alpine AS base
+FROM node:22-alpine AS base
 
 # Install dependencies only when needed
 FROM base AS deps

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "homepage": "https://github.com/open-spaced-repetition/ts-fsrs#readme",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "pnpm": {
     "overrides": {
@@ -62,5 +62,5 @@
       "@napi-rs/cli": "patches/@napi-rs__cli.patch"
     }
   },
-  "packageManager": "pnpm@10.15.0+sha512.486ebc259d3e999a4e8691ce03b5cac4a71cbeca39372a9b762cb500cfdf0873e2cb16abe3d951b1ee2cf012503f027b98b6584e4df22524e0c7450d9ec7aa7b"
+  "packageManager": "pnpm@11.10.0"
 }


### PR DESCRIPTION
### Motivation
- Bring the repository package manager pin up to `pnpm` v11 to use the latest features and fixes. 
- Ensure CI and local tooling run a pnpm-compatible Node version by raising the project Node engine to `>=22.0.0`.
- Update Corepack bootstrap pins used in CI and example Dockerfiles so they reliably enable the newer pnpm.

### Description
- Update `package.json` to set `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a0ce69264832ba69091e758b3ccce)