### PR TITLE
feat(kit): add middleware definitions

### DIFF
--- a/.changeset/srs-kit-middleware-model.md
+++ b/.changeset/srs-kit-middleware-model.md
@@ -1,0 +1,8 @@
+---
+"@open-spaced-repetition/srs-kit": minor
+---
+
+feat(kit): add middleware definition and schema helpers
+
+Adds typed middleware definition helpers, middleware schema composition helpers,
+and supporting schema utilities for middleware-driven scheduler extensions.

--- a/packages/srs-kit/src/middleware/config.spec.ts
+++ b/packages/srs-kit/src/middleware/config.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import { defineSchema } from '@/schema/index.js'
+import type { MiddlewareConfigPart } from './config.js'
+import { defineMiddleware } from './middleware.js'
+
+const normalizedConfigMiddleware = defineMiddleware({
+  name: 'normalizedConfig',
+  schema: {
+    config: defineSchema<unknown, { readonly normalizedSource: string }>(
+      (value) => {
+        if (
+          typeof value !== 'object' ||
+          value === null ||
+          !('rawSource' in value) ||
+          typeof value.rawSource !== 'string'
+        ) {
+          return { issues: [{ message: 'Expected rawSource config' }] }
+        }
+
+        return {
+          value: {
+            normalizedSource: value.rawSource.trim(),
+          },
+        }
+      }
+    ),
+  },
+})
+
+describe('MiddlewareConfigPart', () => {
+  it('preserves output config fields when input is unknown', () => {
+    type Middlewares = readonly [typeof normalizedConfigMiddleware]
+
+    expectTypeOf<MiddlewareConfigPart<Middlewares, 'input'>>().toEqualTypeOf<
+      Record<never, never>
+    >()
+    expectTypeOf<MiddlewareConfigPart<Middlewares, 'output'>>().toEqualTypeOf<{
+      readonly normalizedSource: string
+    }>()
+  })
+})

--- a/packages/srs-kit/src/middleware/config.ts
+++ b/packages/srs-kit/src/middleware/config.ts
@@ -1,0 +1,24 @@
+import type {
+  EmptyPart,
+  IsNonEmptyObject,
+  MergeAllObjects,
+  MergePart,
+  Prettify,
+} from '@/schema/index.js'
+import type { MiddlewareConfigResolveOf } from './infer.js'
+import type { AnyMiddleware } from './middleware.js'
+
+type MiddlewareConfigMap<
+  MWs extends readonly AnyMiddleware[],
+  Mode extends 'input' | 'output',
+> = Prettify<
+  MergePart<MergeAllObjects<MiddlewareConfigResolveOf<MWs[number], Mode>>>
+>
+
+export type MiddlewareConfigPart<
+  MWs extends readonly AnyMiddleware[],
+  Mode extends 'input' | 'output',
+> =
+  IsNonEmptyObject<MiddlewareConfigMap<MWs, Mode>> extends false
+    ? EmptyPart
+    : MiddlewareConfigMap<MWs, Mode>

--- a/packages/srs-kit/src/middleware/index.ts
+++ b/packages/srs-kit/src/middleware/index.ts
@@ -1,0 +1,3 @@
+export * from './infer.js'
+export * from './middleware.js'
+export { schedulerStatsMiddleware } from './stats/index.js'

--- a/packages/srs-kit/src/middleware/infer.ts
+++ b/packages/srs-kit/src/middleware/infer.ts
@@ -1,0 +1,116 @@
+/** biome-ignore-all lint/suspicious/noExplicitAny: type-level widening for AnyMiddleware */
+
+import type { Grade } from '@/primitives/rating.js'
+import type { State } from '@/primitives/state.js'
+import type {
+  AnyObjectSchema,
+  AnySchema,
+  Assign,
+  EmptyPart,
+  Mutable,
+  Prettify,
+  SchemaInput,
+  SchemaOutput,
+} from '@/schema/index.js'
+import type { Middleware } from './middleware.js'
+
+export type MiddlewareEnv = {
+  readonly config?: AnySchema
+  readonly card?: AnyObjectSchema
+  readonly revlog?: AnyObjectSchema
+  readonly scheduleStatus?: string
+}
+
+export type MiddlewareSchemaOf<
+  Env extends MiddlewareEnv,
+  Key extends keyof MiddlewareEnv,
+  Schema extends AnySchema,
+> = Extract<Env[Key], Schema>
+
+type MiddlewareSchemaResolveOf<
+  Env extends MiddlewareEnv,
+  Key extends keyof MiddlewareEnv,
+  Schema extends AnySchema,
+  Fallback,
+  Mode extends 'input' | 'output' = 'output',
+> = [MiddlewareSchemaOf<Env, Key, Schema>] extends [never]
+  ? Fallback
+  : Mode extends 'input'
+    ? SchemaInput<MiddlewareSchemaOf<Env, Key, Schema>>
+    : SchemaOutput<MiddlewareSchemaOf<Env, Key, Schema>>
+
+export type MiddlewareConfigOf<Env extends MiddlewareEnv> =
+  MiddlewareSchemaResolveOf<Env, 'config', AnySchema, EmptyPart>
+
+export type MiddlewareRuntimeConfig = Readonly<Record<PropertyKey, unknown>>
+
+type SchedulerCoreFields<ScheduleStatus extends string = string> = {
+  readonly state: State
+  readonly scheduleStatus: ScheduleStatus
+}
+
+type SchedulerRevlogCoreFields<ScheduleStatus extends string = string> =
+  SchedulerCoreFields<ScheduleStatus> & {
+    readonly rating: Grade
+  }
+
+export type MiddlewareContextConfig<Env extends MiddlewareEnv> =
+  MiddlewareRuntimeConfig &
+    Readonly<
+      Assign<
+        MiddlewareConfigOf<Env>,
+        {
+          readonly chrono: unknown
+        }
+      >
+    >
+
+export type MiddlewareContextObjectOf<
+  Env extends MiddlewareEnv,
+  Key extends 'card' | 'revlog',
+> = Prettify<
+  Assign<
+    MiddlewareSchemaResolveOf<Env, Key, AnyObjectSchema, EmptyPart>,
+    Key extends 'card' ? SchedulerCoreFields : SchedulerRevlogCoreFields
+  >
+>
+
+export type MiddlewareResultObjectOf<
+  Env extends MiddlewareEnv,
+  Key extends 'card' | 'revlog',
+> = Prettify<
+  Partial<Mutable<MiddlewareContextObjectOf<Env, Key>>> &
+    Record<string, unknown>
+>
+
+type MiddlewareObjectOf<TMiddleware, Key extends 'card' | 'revlog'> =
+  TMiddleware extends Middleware<any, infer Env>
+    ? MiddlewareSchemaResolveOf<Env, Key, AnyObjectSchema, EmptyPart>
+    : never
+
+export type MiddlewareCardOf<TMiddleware> = MiddlewareObjectOf<
+  TMiddleware,
+  'card'
+>
+
+export type MiddlewareRevlogOf<TMiddleware> = MiddlewareObjectOf<
+  TMiddleware,
+  'revlog'
+>
+
+export type MiddlewareConfigResolveOf<
+  TMiddleware,
+  Mode extends 'input' | 'output' = 'output',
+> =
+  TMiddleware extends Middleware<any, infer Env>
+    ? Mode extends 'input'
+      ? MiddlewareSchemaResolveOf<Env, 'config', AnySchema, EmptyPart, 'input'>
+      : MiddlewareConfigOf<Env>
+    : never
+
+export type MiddlewareStatusOf<TMiddleware> =
+  TMiddleware extends Middleware<any, infer Env>
+    ? Env extends { readonly scheduleStatus: infer Status extends string }
+      ? Status
+      : never
+    : never

--- a/packages/srs-kit/src/middleware/middleware.ts
+++ b/packages/srs-kit/src/middleware/middleware.ts
@@ -1,0 +1,168 @@
+/** biome-ignore-all lint/suspicious/noExplicitAny: type-level widening for AnyMiddleware */
+
+import type { Grade } from '@/primitives/rating.js'
+import type {
+  AnyObjectSchema,
+  Assign,
+  Constrain,
+  EmptyPart,
+  FieldDefault,
+  Prettify,
+} from '@/schema/index.js'
+import type {
+  MiddlewareContextConfig,
+  MiddlewareContextObjectOf,
+  MiddlewareEnv,
+  MiddlewareResultObjectOf,
+  MiddlewareSchemaOf,
+} from './infer.js'
+
+export type ReviewMiddlewareResult<Env extends MiddlewareEnv = MiddlewareEnv> =
+  {
+    readonly card: MiddlewareResultObjectOf<Env, 'card'>
+    readonly revlog: MiddlewareResultObjectOf<Env, 'revlog'>
+  }
+
+export type RollbackMiddlewareResult<
+  Env extends MiddlewareEnv = MiddlewareEnv,
+> = {
+  readonly card: MiddlewareResultObjectOf<Env, 'card'>
+}
+
+export interface MiddlewareContextBase<Env extends MiddlewareEnv> {
+  readonly config: MiddlewareContextConfig<Env>
+}
+
+export interface ReviewCandidateContext {
+  readonly step: (grade: Grade) => Readonly<Record<string, unknown>>
+  readonly nextInterval: (
+    memoryState: Readonly<Record<string, unknown>>,
+    desiredRetention: number
+  ) => number
+}
+
+export interface ReviewMiddlewareContext<
+  Env extends MiddlewareEnv = MiddlewareEnv,
+> extends MiddlewareContextBase<Env> {
+  readonly input: {
+    readonly card: MiddlewareContextObjectOf<Env, 'card'>
+    readonly grade: Grade
+    readonly now: unknown
+  }
+  desiredRetention: number
+  readonly elapsedDays: number
+  scheduledDays: number | undefined
+  readonly candidate: ReviewCandidateContext
+  readonly result: ReviewMiddlewareResult<Env>
+}
+
+export interface RollbackMiddlewareContext<
+  Env extends MiddlewareEnv = MiddlewareEnv,
+> extends MiddlewareContextBase<Env> {
+  readonly input: {
+    readonly card: MiddlewareContextObjectOf<Env, 'card'>
+    readonly revlog: MiddlewareContextObjectOf<Env, 'revlog'>
+  }
+  readonly result: RollbackMiddlewareResult<Env>
+}
+
+export type MiddlewareHandler<Context> = (
+  ctx: Context,
+  next: () => void
+) => void
+
+export type ReviewMiddlewareHandler<Env extends MiddlewareEnv = MiddlewareEnv> =
+  MiddlewareHandler<ReviewMiddlewareContext<Env>>
+
+export type RollbackMiddlewareHandler<
+  Env extends MiddlewareEnv = MiddlewareEnv,
+> = MiddlewareHandler<RollbackMiddlewareContext<Env>>
+
+type MiddlewareScheduleStatus<Env extends MiddlewareEnv> = Env extends {
+  readonly scheduleStatus: infer Status extends string
+}
+  ? readonly Status[]
+  : undefined
+
+export interface Middleware<
+  Name extends PropertyKey = PropertyKey,
+  Env extends MiddlewareEnv = MiddlewareEnv,
+> {
+  readonly name: Name
+  readonly scheduleStatus?: MiddlewareScheduleStatus<Env>
+
+  readonly schema?: {
+    readonly config?: Env['config']
+    readonly card?: Env['card']
+    readonly revlog?: Env['revlog']
+  }
+
+  readonly defaultValue?: {
+    readonly card?: FieldDefault<
+      MiddlewareSchemaOf<Env, 'card', AnyObjectSchema>,
+      MiddlewareContextBase<Env>
+    >
+
+    readonly revlog?: FieldDefault<
+      MiddlewareSchemaOf<Env, 'revlog', AnyObjectSchema>,
+      MiddlewareContextBase<Env>
+    >
+  }
+
+  readonly handlers?: {
+    readonly review?: ReviewMiddlewareHandler<Env>
+    readonly rollback?: RollbackMiddlewareHandler<Env>
+  }
+}
+
+export type AnyMiddleware = Middleware<any, any>
+
+type MiddlewareDefinitionSchema = Pick<
+  MiddlewareEnv,
+  'config' | 'card' | 'revlog'
+>
+
+type MiddlewareStatusEnv<Status extends string> = [Status] extends [never]
+  ? EmptyPart
+  : { readonly scheduleStatus: Status }
+
+type MiddlewareDefinitionEnv<
+  Schema extends MiddlewareDefinitionSchema,
+  Status extends string,
+> = Constrain<
+  Prettify<Assign<MiddlewareStatusEnv<Status>, Schema>>,
+  MiddlewareEnv,
+  never
+>
+
+type MiddlewareDefinition<
+  Schema extends MiddlewareDefinitionSchema,
+  Name extends PropertyKey,
+  Status extends string,
+> = {
+  readonly name: Name
+  readonly scheduleStatus?: readonly Status[]
+  readonly schema?: Schema
+  readonly defaultValue?: Middleware<
+    Name,
+    MiddlewareDefinitionEnv<Schema, Status>
+  >['defaultValue']
+  readonly handlers?: {
+    readonly review?: MiddlewareHandler<
+      ReviewMiddlewareContext<MiddlewareDefinitionEnv<Schema, Status>>
+    >
+    readonly rollback?: MiddlewareHandler<
+      RollbackMiddlewareContext<MiddlewareDefinitionEnv<Schema, Status>>
+    >
+  }
+}
+
+export function defineMiddleware<
+  const Name extends PropertyKey,
+  const Schema extends MiddlewareDefinitionSchema = EmptyPart,
+  const Status extends string = never,
+>(
+  definition: MiddlewareDefinition<Schema, Name, Status>
+): Middleware<Name, MiddlewareDefinitionEnv<Schema, Status>> {
+  return definition as Middleware<Name, MiddlewareDefinitionEnv<Schema, Status>>
+}

--- a/packages/srs-kit/src/middleware/middleware.type-display.spec.ts
+++ b/packages/srs-kit/src/middleware/middleware.type-display.spec.ts
@@ -1,0 +1,164 @@
+/** biome-ignore-all lint/correctness/noUnusedVariables: type-display fixtures read by LanguageService */
+import { describe, expect, it } from 'vitest'
+import {
+  defineStringFieldOutputSchema,
+  defineStringFieldSchema,
+} from '@/schema/string-field.test.js'
+import { defineMiddleware } from './middleware.js'
+
+const displayConfigSchema = defineStringFieldSchema({
+  field: 'source',
+  message: 'Expected source config',
+})
+
+const displayCardSchema = defineStringFieldOutputSchema({
+  field: 'source',
+  message: 'Expected source card',
+})
+
+const displayRevlogSchema = defineStringFieldOutputSchema({
+  field: 'audit',
+  message: 'Expected audit revlog',
+})
+
+const displayMiddlewareName = Symbol('displayMiddleware')
+
+const displayMiddleware = defineMiddleware({
+  name: displayMiddlewareName,
+  scheduleStatus: ['paused'],
+  schema: {
+    config: displayConfigSchema,
+    card: displayCardSchema,
+    revlog: displayRevlogSchema,
+  },
+  defaultValue: {
+    card(ctx) {
+      const defaultConfigHoverTarget = ctx.config
+      return { source: defaultConfigHoverTarget.source }
+    },
+    revlog(ctx) {
+      return { audit: ctx.config.source }
+    },
+  },
+  handlers: {
+    review(ctx, next) {
+      const reviewConfigHoverTarget = ctx.config
+      const reviewCardHoverTarget = ctx.input.card
+      const reviewResultRevlogHoverTarget = ctx.result.revlog
+      next()
+      ctx.result.card.source = reviewConfigHoverTarget.source
+      ctx.result.revlog.audit = reviewConfigHoverTarget.source
+    },
+    rollback(ctx, next) {
+      const rollbackRevlogHoverTarget = ctx.input.revlog
+      next()
+      ctx.result.card.source = rollbackRevlogHoverTarget.audit
+    },
+  },
+})
+
+const middlewareHoverTarget = displayMiddleware
+const scheduleStatusHoverTarget = displayMiddleware.scheduleStatus
+
+const SELF = 'src/middleware/middleware.type-display.spec.ts'
+
+describe('middleware type display', () => {
+  const service = getTypeDisplayService()
+
+  const expectedDefineMiddleware = {
+    middlewareHoverTarget: `const middlewareHoverTarget: Middleware<typeof displayMiddlewareName, {
+    readonly scheduleStatus: "paused";
+    readonly config: SRSSchema<{
+        input: {
+            readonly source: string;
+        };
+        output: {
+            readonly source: string;
+        };
+    }>;
+    readonly card: SRSSchema<{
+        input: {};
+        output: {
+            readonly source: string;
+        };
+    }>;
+    readonly revlog: SRSSchema<{
+        input: {};
+        output: {
+            readonly audit: string;
+        };
+    }>;
+}>`,
+    defaultConfigHoverTarget: `const defaultConfigHoverTarget: MiddlewareContextConfig<{
+    readonly scheduleStatus: "paused";
+    readonly config: SRSSchema<{
+        input: {
+            readonly source: string;
+        };
+        output: {
+            readonly source: string;
+        };
+    }>;
+    readonly card: SRSSchema<{
+        input: {};
+        output: {
+            readonly source: string;
+        };
+    }>;
+    readonly revlog: SRSSchema<{
+        input: {};
+        output: {
+            readonly audit: string;
+        };
+    }>;
+}>`,
+    reviewConfigHoverTarget: `const reviewConfigHoverTarget: MiddlewareContextConfig<{
+    readonly scheduleStatus: "paused";
+    readonly config: SRSSchema<{
+        input: {
+            readonly source: string;
+        };
+        output: {
+            readonly source: string;
+        };
+    }>;
+    readonly card: SRSSchema<{
+        input: {};
+        output: {
+            readonly source: string;
+        };
+    }>;
+    readonly revlog: SRSSchema<{
+        input: {};
+        output: {
+            readonly audit: string;
+        };
+    }>;
+}>`,
+    reviewCardHoverTarget: `const reviewCardHoverTarget: {
+    readonly source: string;
+    readonly state: State;
+    readonly scheduleStatus: string;
+}`,
+    reviewResultRevlogHoverTarget: `const reviewResultRevlogHoverTarget: {
+    [x: string]: unknown;
+    audit?: string | undefined;
+    state?: 0 | 1 | 2 | 3 | undefined;
+    scheduleStatus?: string | undefined;
+    rating?: 1 | 2 | 3 | 4 | undefined;
+}`,
+    rollbackRevlogHoverTarget: `const rollbackRevlogHoverTarget: {
+    readonly audit: string;
+    readonly state: State;
+    readonly scheduleStatus: string;
+    readonly rating: Grade;
+}`,
+    scheduleStatusHoverTarget: `const scheduleStatusHoverTarget: readonly "paused"[] | undefined`,
+  }
+
+  it('infers defineMiddleware definition and context hovers', () => {
+    for (const [marker, expected] of Object.entries(expectedDefineMiddleware)) {
+      expect(quickInfoAt(service, SELF, marker)).toBe(expected)
+    }
+  })
+}, 20_000)

--- a/packages/srs-kit/src/middleware/stats/index.ts
+++ b/packages/srs-kit/src/middleware/stats/index.ts
@@ -1,0 +1,2 @@
+export { schedulerStatsMiddleware } from './middleware.js'
+export { type StatsCardFields, statsFieldsSchema } from './schema.js'

--- a/packages/srs-kit/src/middleware/stats/middleware.spec.ts
+++ b/packages/srs-kit/src/middleware/stats/middleware.spec.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest'
+import type { Grade } from '@/primitives/rating.js'
+import { Rating } from '@/primitives/rating.js'
+import { State } from '@/primitives/state.js'
+import { schedulerStatsMiddleware } from './middleware.js'
+
+type ReviewHandler = NonNullable<
+  NonNullable<typeof schedulerStatsMiddleware.handlers>['review']
+>
+
+type RollbackHandler = NonNullable<
+  NonNullable<typeof schedulerStatsMiddleware.handlers>['rollback']
+>
+
+type ReviewContext = Parameters<ReviewHandler>[0]
+type RollbackContext = Parameters<RollbackHandler>[0]
+
+function reviewContext({
+  grade = Rating.Good,
+  state = State.Learning,
+  reps = 1,
+  lapses = 0,
+}: {
+  readonly grade?: Grade
+  readonly state?: State
+  readonly reps?: number
+  readonly lapses?: number
+} = {}): ReviewContext {
+  return {
+    config: { chrono: 0 },
+    input: {
+      card: { reps, lapses, state, scheduleStatus: 'review' },
+      grade,
+      now: 0,
+    },
+    desiredRetention: 0.9,
+    elapsedDays: 1,
+    scheduledDays: undefined,
+    candidate: {
+      step: () => ({}),
+      nextInterval: () => 1,
+    },
+    result: {
+      card: {},
+      revlog: {},
+    },
+  }
+}
+
+function rollbackContext({
+  rating = Rating.Good,
+  state = State.Learning,
+  reps = 1,
+  lapses = 0,
+}: {
+  readonly rating?: Grade
+  readonly state?: State
+  readonly reps?: number
+  readonly lapses?: number
+} = {}): RollbackContext {
+  return {
+    config: { chrono: 0 },
+    input: {
+      card: { reps, lapses, state, scheduleStatus: 'review' },
+      revlog: { state, rating, scheduleStatus: 'review' },
+    },
+    result: {
+      card: {},
+    },
+  }
+}
+
+describe('schedulerStatsMiddleware', () => {
+  it('provides default stats fields', () => {
+    expect(
+      schedulerStatsMiddleware.defaultValue?.card?.({ config: { chrono: 0 } })
+    ).toEqual({
+      reps: 0,
+      lapses: 0,
+    })
+  })
+
+  it('increments reps without a lapse for non-review again ratings', () => {
+    const ctx = reviewContext({ reps: 2, lapses: 1 })
+
+    schedulerStatsMiddleware.handlers?.review?.(ctx, () => {
+      ctx.result.card.state = State.Review
+    })
+
+    expect(ctx.result.card.reps).toBe(3)
+    expect(ctx.result.card.lapses).toBe(1)
+  })
+
+  it('increments lapses when review cards are rated again', () => {
+    const ctx = reviewContext({
+      grade: Rating.Again,
+      state: State.Review,
+      reps: 2,
+      lapses: 1,
+    })
+
+    schedulerStatsMiddleware.handlers?.review?.(ctx, () => {})
+
+    expect(ctx.result.card.reps).toBe(3)
+    expect(ctx.result.card.lapses).toBe(2)
+  })
+
+  it('rolls back reps and non-lapse reviews without going below zero', () => {
+    const ctx = rollbackContext({ reps: 0, lapses: 0 })
+
+    schedulerStatsMiddleware.handlers?.rollback?.(ctx, () => {})
+
+    expect(ctx.result.card.reps).toBe(0)
+    expect(ctx.result.card.lapses).toBe(0)
+  })
+
+  it('rolls back lapse counts for review again revlogs', () => {
+    const ctx = rollbackContext({
+      rating: Rating.Again,
+      state: State.Review,
+      reps: 3,
+      lapses: 2,
+    })
+
+    schedulerStatsMiddleware.handlers?.rollback?.(ctx, () => {})
+
+    expect(ctx.result.card.reps).toBe(2)
+    expect(ctx.result.card.lapses).toBe(1)
+  })
+})

--- a/packages/srs-kit/src/middleware/stats/middleware.ts
+++ b/packages/srs-kit/src/middleware/stats/middleware.ts
@@ -1,0 +1,43 @@
+import { Rating } from '@/primitives/rating.js'
+import { State } from '@/primitives/state.js'
+import { defineMiddleware } from '../middleware.js'
+import { statsFieldsSchema } from './schema.js'
+
+export const schedulerStatsMiddleware = defineMiddleware({
+  name: Symbol('srs-kit.stats'),
+  schema: {
+    card: statsFieldsSchema,
+  },
+  defaultValue: {
+    card(_ctx) {
+      return {
+        reps: 0,
+        lapses: 0,
+      }
+    },
+  },
+  handlers: {
+    review(ctx, next) {
+      next()
+      const card = ctx.input.card
+      const previousState = card.state
+      const previousLapses = card.lapses
+      const isLapse =
+        ctx.input.grade === Rating.Again && previousState === State.Review
+
+      ctx.result.card.reps = card.reps + 1
+      ctx.result.card.lapses = isLapse ? previousLapses + 1 : previousLapses
+    },
+
+    rollback(ctx, next) {
+      next()
+      const card = ctx.input.card
+      const revlog = ctx.input.revlog
+      const isLapse =
+        revlog.rating === Rating.Again && revlog.state === State.Review
+
+      ctx.result.card.reps = Math.max(0, card.reps - 1)
+      ctx.result.card.lapses = Math.max(0, card.lapses - (isLapse ? 1 : 0))
+    },
+  },
+})

--- a/packages/srs-kit/src/middleware/stats/schema.spec.ts
+++ b/packages/srs-kit/src/middleware/stats/schema.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { statsFieldsSchema } from './schema.js'
+
+describe('statsFieldsSchema', () => {
+  it('accepts non-negative integer stats fields', () => {
+    expect(statsFieldsSchema.parse({ reps: 1, lapses: 0 })).toEqual({
+      reps: 1,
+      lapses: 0,
+    })
+  })
+
+  it('rejects non-object values', () => {
+    expect(() => statsFieldsSchema.parse(null)).toThrow('Expected stats object')
+  })
+
+  it('rejects non-number stats fields', () => {
+    expect(() => statsFieldsSchema.parse({ reps: '1', lapses: 0 })).toThrow(
+      'Expected non-negative integer reps'
+    )
+    expect(() => statsFieldsSchema.parse({ reps: 1, lapses: '0' })).toThrow(
+      'Expected non-negative integer lapses'
+    )
+  })
+
+  it('rejects negative stats fields', () => {
+    expect(() => statsFieldsSchema.parse({ reps: -1, lapses: 0 })).toThrow(
+      'Expected non-negative integer reps'
+    )
+    expect(() => statsFieldsSchema.parse({ reps: 1, lapses: -1 })).toThrow(
+      'Expected non-negative integer lapses'
+    )
+  })
+
+  it('rejects fractional stats fields', () => {
+    expect(() => statsFieldsSchema.parse({ reps: 1.5, lapses: 0 })).toThrow(
+      'Expected non-negative integer reps'
+    )
+    expect(() => statsFieldsSchema.parse({ reps: 1, lapses: 0.5 })).toThrow(
+      'Expected non-negative integer lapses'
+    )
+  })
+})

--- a/packages/srs-kit/src/middleware/stats/schema.ts
+++ b/packages/srs-kit/src/middleware/stats/schema.ts
@@ -1,0 +1,27 @@
+import { defineSchema, isObject } from '@/schema/index.js'
+
+export type StatsCardFields = {
+  readonly reps: number
+  readonly lapses: number
+}
+
+export const statsFieldsSchema = defineSchema<StatsCardFields>((value) => {
+  if (!isObject(value)) {
+    return { issues: [{ message: 'Expected stats object' }] }
+  }
+
+  const { reps, lapses } = value
+  if (typeof reps !== 'number' || !Number.isInteger(reps) || reps < 0) {
+    return { issues: [{ message: 'Expected non-negative integer reps' }] }
+  }
+  if (typeof lapses !== 'number' || !Number.isInteger(lapses) || lapses < 0) {
+    return { issues: [{ message: 'Expected non-negative integer lapses' }] }
+  }
+
+  return {
+    value: {
+      reps,
+      lapses,
+    },
+  }
+})

--- a/packages/srs-kit/src/model/model.ts
+++ b/packages/srs-kit/src/model/model.ts
@@ -71,10 +71,7 @@ export interface ModelCore<Env extends BlankModelCoreEnv = BlankModelCoreEnv> {
   ) => readonly Env['memoryState'][]
 }
 
-export type AnyModelCore = ModelCore<{
-  readonly config: any
-  readonly memoryState: any
-}>
+export type AnyModelCore = ModelCore<any>
 
 // ==========
 // Model
@@ -92,12 +89,11 @@ export interface ModelSchema<
   readonly memoryState: Schema['memoryState']
 }
 
-export type ModelCreate<
-  ConfigSchema extends AnySchema,
-  MemoryStateSchema extends AnyObjectSchema,
-> = (ctx: { readonly config: SchemaInput<ConfigSchema> }) => ModelCore<{
-  readonly config: SchemaOutput<ConfigSchema>
-  readonly memoryState: SchemaOutput<MemoryStateSchema>
+export type ModelCreate<Schema extends BlankModelSchema> = (ctx: {
+  readonly config: SchemaInput<Schema['config']>
+}) => ModelCore<{
+  readonly config: SchemaOutput<Schema['config']>
+  readonly memoryState: SchemaOutput<Schema['memoryState']>
 }>
 
 export type BlankModelEnv = {
@@ -114,14 +110,10 @@ export interface Model<Env extends BlankModelEnv = BlankModelEnv> {
       readonly config: SchemaOutput<Env['config']>
     }) => SchemaInput<Env['memoryState']>
   }
-  readonly create: ModelCreate<Env['config'], Env['memoryState']>
+  readonly create: ModelCreate<Env>
 }
 
-export type AnyModel = Model<{
-  readonly name: any
-  readonly config: any
-  readonly memoryState: any
-}>
+export type AnyModel = Model<any>
 
 export function defineModel<
   const Name extends string | symbol,

--- a/packages/srs-kit/src/schema/cache.spec.ts
+++ b/packages/srs-kit/src/schema/cache.spec.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import { withCache } from './cache.js'
+
+describe('withCache', () => {
+  it('computes each key once', () => {
+    const calls: number[] = []
+    const cached = withCache((key: number) => {
+      calls.push(key)
+      return { value: key * 2 }
+    })
+
+    expect(cached(1)).toBe(cached(1))
+    expect(cached(2)).toEqual({ value: 4 })
+    expect(cached(1)).toEqual({ value: 2 })
+    expect(calls).toEqual([1, 2])
+  })
+
+  it('caches undefined values', () => {
+    let calls = 0
+    const cached = withCache((_key: string): undefined => {
+      calls += 1
+      return undefined
+    })
+
+    expect(cached('missing')).toBeUndefined()
+    expect(cached('missing')).toBeUndefined()
+    expect(calls).toBe(1)
+  })
+
+  it('preserves null values', () => {
+    let calls = 0
+    const cached = withCache((_key: string): null => {
+      calls += 1
+      return null
+    })
+
+    expect(cached('empty')).toBeNull()
+    expect(cached('empty')).toBeNull()
+    expect(calls).toBe(1)
+  })
+
+  it('evicts the least recently used key when the cache is full', () => {
+    const calls: number[] = []
+    const cached = withCache(
+      (key: number) => {
+        calls.push(key)
+        return key * 2
+      },
+      { size: 2 }
+    )
+
+    expect(cached(1)).toBe(2)
+    expect(cached(2)).toBe(4)
+    expect(cached(1)).toBe(2)
+    expect(cached(3)).toBe(6)
+    expect(cached(2)).toBe(4)
+    expect(calls).toEqual([1, 2, 3, 2])
+  })
+
+  it('keeps existing entries when LRU is disabled', () => {
+    const calls: number[] = []
+    const cached = withCache(
+      (key: number) => {
+        calls.push(key)
+        return key * 2
+      },
+      { lru: false, size: 1 }
+    )
+
+    expect(cached(1)).toBe(2)
+    expect(cached(2)).toBe(4)
+    expect(cached(1)).toBe(2)
+    expect(calls).toEqual([1, 2])
+  })
+
+  it('rejects invalid cache sizes', () => {
+    expect(() => withCache((key: number) => key, { size: 0 })).toThrow(
+      RangeError
+    )
+  })
+})

--- a/packages/srs-kit/src/schema/cache.ts
+++ b/packages/srs-kit/src/schema/cache.ts
@@ -1,0 +1,71 @@
+const undefinedCacheValue = Symbol('srs-kit.cache.undefined')
+
+const defaultCacheSize = 200
+
+export type CacheOptions = {
+  readonly lru?: boolean
+  readonly size?: number
+}
+
+type Cache<Key, Value> = {
+  get(key: Key): Value | undefined
+  set(key: Key, value: Value): void
+}
+
+class LRUMap<Key, Value> {
+  private readonly limit: number
+  private readonly values = new Map<Key, Value>()
+
+  constructor(options: { readonly size: number }) {
+    if (!Number.isInteger(options.size) || options.size < 1) {
+      throw new RangeError('LRUMap size must be a positive integer')
+    }
+
+    this.limit = options.size
+  }
+
+  get(key: Key): Value | undefined {
+    if (!this.values.has(key)) {
+      return undefined
+    }
+
+    const value = this.values.get(key) as Value
+    this.values.delete(key)
+    this.values.set(key, value)
+    return value
+  }
+
+  set(key: Key, value: Value): void {
+    this.values.set(key, value)
+
+    if (this.values.size > this.limit) {
+      const oldestKey = this.values.keys().next().value as Key
+      this.values.delete(oldestKey)
+    }
+  }
+}
+
+export function withCache<const Key, Value>(
+  getValue: (key: Key) => Value,
+  options: CacheOptions = {}
+): (key: Key) => Value {
+  const cache: Cache<Key, Value | typeof undefinedCacheValue> =
+    options.lru === false
+      ? new Map<Key, Value | typeof undefinedCacheValue>()
+      : new LRUMap<Key, Value | typeof undefinedCacheValue>({
+          size: options.size ?? defaultCacheSize,
+        })
+
+  return (key) => {
+    const cached = cache.get(key)
+    if (cached !== undefined) {
+      return (cached === undefinedCacheValue ? undefined : cached) as Value
+    }
+
+    const value = getValue(key)
+    // Map#get returns undefined for misses, so store an internal sentinel
+    // when the computed value itself is undefined.
+    cache.set(key, value === undefined ? undefinedCacheValue : value)
+    return value
+  }
+}

--- a/packages/srs-kit/src/schema/index.ts
+++ b/packages/srs-kit/src/schema/index.ts
@@ -2,8 +2,11 @@ export type {
   StandardSchemaV1,
   StandardTypedV1,
 } from '@vendor/standard-schema.js'
+export * from './cache.js'
 export * from './field.js'
 export * from './infer.js'
+export * from './iterable.js'
+export * from './middleware.js'
 export * from './standard.js'
 export * from './utils.js'
 export * from './validators.js'

--- a/packages/srs-kit/src/schema/iterable.spec.ts
+++ b/packages/srs-kit/src/schema/iterable.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { createLazyIterable } from './iterable.js'
+
+describe('createLazyIterable', () => {
+  it('computes values lazily in key order', () => {
+    const calls: number[] = []
+    const iterable = createLazyIterable([1, 2, 3] as const, (key) => {
+      calls.push(key)
+      return key * 2
+    })
+
+    expect(calls).toEqual([])
+
+    const iterator = iterable[Symbol.iterator]()
+    expect(iterator.next()).toEqual({ value: 2, done: false })
+    expect(calls).toEqual([1])
+    expect(iterator.next()).toEqual({ value: 4, done: false })
+    expect(iterator.next()).toEqual({ value: 6, done: false })
+    expect(iterator.next()).toEqual({ value: undefined, done: true })
+  })
+
+  it('returns an iterable iterator', () => {
+    const iterator = createLazyIterable(['a'] as const, (key) =>
+      key.toUpperCase()
+    )[Symbol.iterator]()
+
+    expect(iterator[Symbol.iterator]()).toBe(iterator)
+    expect(Array.from(iterator)).toEqual(['A'])
+  })
+
+  it('allows undefined as a key', () => {
+    const calls: unknown[] = []
+    const iterable = createLazyIterable([undefined, 'next'] as const, (key) => {
+      calls.push(key)
+      return key ?? 'missing'
+    })
+
+    expect(Array.from(iterable)).toEqual(['missing', 'next'])
+    expect(calls).toEqual([undefined, 'next'])
+  })
+})

--- a/packages/srs-kit/src/schema/iterable.ts
+++ b/packages/srs-kit/src/schema/iterable.ts
@@ -1,0 +1,31 @@
+export interface LazyIterable<Value> extends Iterable<Value> {
+  [Symbol.iterator](): IterableIterator<Value>
+}
+
+export function createLazyIterable<const Key, Value>(
+  keys: readonly Key[],
+  getValue: (key: Key) => Value
+): LazyIterable<Value> {
+  const result = Object.create(null)
+  Object.defineProperty(result, Symbol.iterator, {
+    enumerable: false,
+    value() {
+      let index = 0
+      const iterator: IterableIterator<Value> = {
+        next() {
+          if (index >= keys.length) {
+            return { value: undefined, done: true }
+          }
+
+          return { value: getValue(keys[index++]), done: false }
+        },
+        [Symbol.iterator]() {
+          return iterator
+        },
+      }
+      return iterator
+    },
+  })
+
+  return result as LazyIterable<Value>
+}

--- a/packages/srs-kit/src/schema/middleware.spec.ts
+++ b/packages/srs-kit/src/schema/middleware.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import {
+  composeMiddleware,
+  type MiddlewareRuntimeHandler,
+} from './middleware.js'
+
+type Runtime = {
+  readonly name: string
+  readonly enabled: boolean
+}
+
+type ComposeContext = {
+  readonly value: string
+}
+
+const composeContext: ComposeContext = { value: 'ctx' }
+
+describe('composeMiddleware', () => {
+  it('runs the terminal without runtimes', () => {
+    const trace: string[] = []
+
+    composeMiddleware([], composeContext, (_ctx) => {
+      trace.push('terminal')
+    })
+
+    expect(trace).toEqual(['terminal'])
+  })
+
+  it('runs handlers in onion order and skips missing handlers', () => {
+    const trace: string[] = []
+    const runtimes: readonly Runtime[] = [
+      { name: 'outer', enabled: true },
+      { name: 'skipped', enabled: false },
+      { name: 'inner', enabled: true },
+    ]
+    const createHandler =
+      (runtime: Runtime): MiddlewareRuntimeHandler<ComposeContext> =>
+      (ctx, next) => {
+        trace.push(`${runtime.name}:before:${ctx.value}`)
+        next()
+        trace.push(`${runtime.name}:after:${ctx.value}`)
+      }
+    const handlers = runtimes.map((runtime) =>
+      runtime.enabled ? createHandler(runtime) : undefined
+    )
+
+    composeMiddleware(handlers, composeContext, (_ctx) => {
+      trace.push('terminal')
+    })
+
+    expect(trace).toEqual([
+      'outer:before:ctx',
+      'inner:before:ctx',
+      'terminal',
+      'inner:after:ctx',
+      'outer:after:ctx',
+    ])
+  })
+
+  it('throws when next is called more than once', () => {
+    expect(() =>
+      composeMiddleware(
+        [
+          (_ctx: Runtime, next: () => void) => {
+            next()
+            next()
+          },
+        ],
+        { name: 'bad', enabled: true },
+        (_ctx) => {}
+      )
+    ).toThrow('Middleware next() called multiple times')
+  })
+})

--- a/packages/srs-kit/src/schema/middleware.ts
+++ b/packages/srs-kit/src/schema/middleware.ts
@@ -1,0 +1,38 @@
+export type MiddlewareRuntimeHandler<Context> = (
+  ctx: Context,
+  next: () => void
+) => void
+
+export function composeMiddleware<Context>(
+  handlers: readonly (MiddlewareRuntimeHandler<Context> | undefined)[],
+  context: Context,
+  terminal: (ctx: Context) => void
+): void {
+  if (handlers.length === 0) {
+    terminal(context)
+    return
+  }
+
+  let index = -1
+  const dispatch = (nextIndex: number): void => {
+    if (nextIndex <= index) {
+      throw new Error('Middleware next() called multiple times')
+    }
+    index = nextIndex
+
+    if (nextIndex >= handlers.length) {
+      terminal(context)
+      return
+    }
+
+    const handler = handlers[nextIndex]
+    if (!handler) {
+      dispatch(nextIndex + 1)
+      return
+    }
+
+    handler(context, () => dispatch(nextIndex + 1))
+  }
+
+  dispatch(0)
+}

--- a/packages/srs-kit/src/schema/string-field.test.ts
+++ b/packages/srs-kit/src/schema/string-field.test.ts
@@ -1,0 +1,39 @@
+import { isObject } from './utils.js'
+import { defineSchema } from './validators.js'
+
+type StringField<Field extends string> = {
+  readonly [K in Field]: string
+}
+
+interface StringFieldSchemaOptions<Field extends string> {
+  readonly field: Field
+  readonly message: string
+}
+
+export function defineStringFieldSchema<const Field extends string>({
+  field,
+  message,
+}: StringFieldSchemaOptions<Field>) {
+  return defineSchema<StringField<Field>>((value) => {
+    if (isObject(value) && typeof value[field] === 'string') {
+      return {
+        value: { [field]: value[field] } as StringField<Field>,
+      }
+    }
+    return { issues: [{ message }] }
+  })
+}
+
+export function defineStringFieldOutputSchema<const Field extends string>({
+  field,
+  message,
+}: StringFieldSchemaOptions<Field>) {
+  return defineSchema<unknown, StringField<Field>>((value) => {
+    if (isObject(value) && typeof value[field] === 'string') {
+      return {
+        value: { [field]: value[field] } as StringField<Field>,
+      }
+    }
+    return { issues: [{ message }] }
+  })
+}

--- a/packages/srs-kit/src/schema/utils.spec.ts
+++ b/packages/srs-kit/src/schema/utils.spec.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import { assert, isFunction, isObject, noop, run } from './utils.js'
+import {
+  assert,
+  assignObjectFields,
+  isFunction,
+  isObject,
+  noop,
+  run,
+} from './utils.js'
 
 describe('isObject', () => {
   it('returns true for plain objects', () => {
@@ -51,5 +58,25 @@ describe('assert', () => {
 
   it('includes custom message', () => {
     expect(() => assert(false, 'custom')).toThrow('AssertionError: custom')
+  })
+})
+
+describe('assignObjectFields', () => {
+  it('assigns own enumerable fields', () => {
+    const target: Record<PropertyKey, unknown> = {}
+
+    assignObjectFields(target, { source: 'test', count: 1 })
+
+    expect(target).toEqual({ source: 'test', count: 1 })
+  })
+
+  it('skips inherited fields', () => {
+    const target: Record<PropertyKey, unknown> = {}
+    const source = Object.create({ inherited: 'skip' }) as { own?: string }
+    source.own = 'keep'
+
+    assignObjectFields(target, source)
+
+    expect(target).toEqual({ own: 'keep' })
   })
 })

--- a/packages/srs-kit/src/schema/utils.ts
+++ b/packages/srs-kit/src/schema/utils.ts
@@ -46,6 +46,10 @@ export type EmptyObject = Record<PropertyKey, never>
 
 export type EmptyPart = Record<never, never>
 
+export type MergePart<Value> = [Value] extends [never] ? EmptyPart : Value
+
+export type Mutable<T> = { -readonly [Key in keyof T]: T[Key] }
+
 export type MutableRecord = Record<PropertyKey, unknown>
 
 /** @internal */
@@ -161,5 +165,17 @@ export function assert(
 ): asserts condition {
   if (!condition) {
     throw new Error(`AssertionError: ${msg}`)
+  }
+}
+
+export function assignObjectFields(
+  target: Record<PropertyKey, unknown>,
+  source: object
+) {
+  const fields = source as Record<string, unknown>
+  for (const key in fields) {
+    if (Object.hasOwn(fields, key)) {
+      target[key] = fields[key]
+    }
   }
 }

--- a/packages/srs-kit/vitest.setup.ts
+++ b/packages/srs-kit/vitest.setup.ts
@@ -25,11 +25,17 @@ const typeDisplayPrinter = ts.createPrinter({
   newLine: ts.NewLineKind.LineFeed,
 })
 
-function getTypeDisplayProgram(): ts.Program {
+function getTypeDisplayProgram(svc: ts.LanguageService): ts.Program {
   if (!typeDisplayProgram) {
+    const program = svc.getProgram()
+
+    if (!program) {
+      throw new Error('Missing TypeScript language service program')
+    }
+
     typeDisplayProgram = ts.createProgram(
-      parsedConfig.fileNames.map((file) => path.resolve(file)),
-      parsedConfig.options
+      program.getRootFileNames(),
+      program.getCompilerOptions()
     )
   }
 
@@ -130,7 +136,7 @@ globalThis.getTypeDisplayService = () => {
   return service
 }
 
-globalThis.quickInfoAt = (_svc, rel, marker) => {
+globalThis.quickInfoAt = (svc, rel, marker) => {
   const fileName = path.join(packageRoot, rel)
   const source = ts.sys.readFile(fileName)
 
@@ -143,7 +149,7 @@ globalThis.quickInfoAt = (_svc, rel, marker) => {
     throw new Error(`Missing marker "${marker}" in ${rel}`)
   }
 
-  const program = getTypeDisplayProgram()
+  const program = getTypeDisplayProgram(svc)
   const sourceFile = program.getSourceFile(fileName)
 
   if (!sourceFile) {


### PR DESCRIPTION
- https://github.com/open-spaced-repetition/ts-fsrs/issues/373

## Summary
- add typed middleware definition helpers and middleware inference tests
- include schema helpers used by middleware composition
- simplify model broad aliases and update type-display setup
- add runtime coverage for stats middleware, stats validation, and schema utils

## Scope
- packages/srs-kit/vitest.setup.ts
- packages/srs-kit/src/model/model.ts
- packages/srs-kit/src/middleware/**
- packages/srs-kit/src/schema/** files required by middleware helpers

## Validation
- ../../node_modules/.bin/biome check ./src vitest.setup.ts
- ../../node_modules/.bin/tsc --noEmit --pretty false
- ../../node_modules/.bin/vitest run --config=vitest.config.ts src/middleware src/schema src/model
- ../../node_modules/.bin/vitest run --config=vitest.config.ts --coverage (100% statements / branches / functions / lines)