### PR TITLE
feat(kit): add scheduler primitives to srs-kit

### DIFF
--- a/.changeset/srs-kit-scheduler.md
+++ b/.changeset/srs-kit-scheduler.md
@@ -1,0 +1,8 @@
+---
+"@open-spaced-repetition/srs-kit": minor
+---
+
+feat(kit): add scheduler primitives
+
+Adds composable scheduler creation APIs, scheduler schemas, and scheduler
+runtime helpers for model, chrono, and middleware integration.

--- a/packages/fsrs/tsdown.config.ts
+++ b/packages/fsrs/tsdown.config.ts
@@ -25,7 +25,10 @@ export default defineConfig([
     globalName: 'FSRS',
     platform: 'browser',
     deps: {
-      alwaysBundle: ['@open-spaced-repetition/srs-kit'],
+      alwaysBundle: [
+        '@open-spaced-repetition/srs-kit',
+        '@open-spaced-repetition/srs-kit/chrono/date',
+      ],
     },
     sourcemap: false,
     minify: false,

--- a/packages/srs-kit/bench/cache.bench.ts
+++ b/packages/srs-kit/bench/cache.bench.ts
@@ -1,0 +1,45 @@
+import { bench, describe } from 'vitest'
+import { withCache } from '@/schema/index.js'
+
+let cacheSink = 0
+
+function consume(value: number | undefined): void {
+  cacheSink = (cacheSink + (value ?? 0)) % Number.MAX_SAFE_INTEGER
+}
+
+describe('withCache', () => {
+  const keys = [1, 2, 3, 4] as const
+  const hitCache = withCache((key: number) => key * 2)
+  const undefinedCache = withCache((key: number) =>
+    key === 0 ? undefined : key * 2
+  )
+  const missCache = withCache((key: number) => key * 2)
+  const cycleCache = withCache((key: number) => key * 2)
+  let missKey = 0
+  let cycleIndex = 0
+
+  hitCache(1)
+  undefinedCache(0)
+  for (const key of keys) {
+    cycleCache(key)
+  }
+
+  bench('cache hit', () => {
+    consume(hitCache(1))
+  })
+
+  bench('cached undefined hit', () => {
+    consume(undefinedCache(0))
+  })
+
+  bench('cache miss', () => {
+    missKey += 1
+    consume(missCache(missKey))
+  })
+
+  bench('4-key cycle', () => {
+    const key = keys[cycleIndex & 3]
+    cycleIndex += 1
+    consume(cycleCache(key))
+  })
+})

--- a/packages/srs-kit/bench/chrono.bench.ts
+++ b/packages/srs-kit/bench/chrono.bench.ts
@@ -1,9 +1,7 @@
 import { bench, describe } from 'vitest'
-import { defineChrono, defineChronoProjection } from '@/chrono/index.js'
 import { dateChrono } from '@/chrono/presets/date/index.js'
 import { numericChrono } from '@/chrono/presets/numeric/index.js'
 import { temporalInstantChrono } from '@/chrono/presets/temporal-instant/index.js'
-import { numberSchema } from '@/schema/index.js'
 
 const NS_PER_DAY = 86_400_000_000_000n
 const temporalImplementations = ['native', 'polyfill'] as const
@@ -54,69 +52,6 @@ function createInstant(
 ): Temporal.Instant {
   return temporal.Instant.fromEpochNanoseconds(epochNanoseconds)
 }
-
-const numericProjection = defineChronoProjection<{
-  readonly time: number
-}>((value) => {
-  const time = numberSchema['~standard'].validate(value.time)
-  if (time.issues) {
-    return time
-  }
-
-  return { value: { previous: 0, current: time.value } }
-})
-
-describe('defineChrono', () => {
-  bench('defineChrono with schema projection', () => {
-    defineChrono({
-      schema: {
-        time: numberSchema,
-      },
-      projection: numericProjection,
-      create() {
-        return {
-          now: () => 0,
-          difference: (from: number, to: number) => to - from,
-          add: (from: number, days: number) => from + days,
-        }
-      },
-    })
-  })
-
-  bench('defineChrono with function projection', () => {
-    defineChrono({
-      schema: {
-        time: numberSchema,
-      },
-      projection(value) {
-        const time = numberSchema['~standard'].validate(value.time)
-        if (time.issues) {
-          return time
-        }
-
-        return { value: { previous: 0, current: time.value } }
-      },
-      create() {
-        return {
-          now: () => 0,
-          difference: (from: number, to: number) => to - from,
-          add: (from: number, days: number) => from + days,
-        }
-      },
-    })
-  })
-
-  bench('defineChronoProjection', () => {
-    defineChronoProjection<{ readonly time: number }>((value) => {
-      const time = numberSchema['~standard'].validate(value.time)
-      if (time.issues) {
-        return time
-      }
-
-      return { value: { previous: 0, current: time.value } }
-    })
-  })
-})
 
 describe('numericChrono preset', () => {
   const core = numericChrono.create()

--- a/packages/srs-kit/bench/compose-schema.bench.ts
+++ b/packages/srs-kit/bench/compose-schema.bench.ts
@@ -18,7 +18,7 @@ function consumeParsedCard(value: {
   composeSchemaSink =
     (composeSchemaSink +
       Number(value.card.interval ?? 0) +
-      Number(value.memoryState.reps ?? 0)) %
+      Number(value.memoryState.reviewStep ?? 0)) %
     Number.MAX_SAFE_INTEGER
 }
 

--- a/packages/srs-kit/bench/compose-schema.bench.ts
+++ b/packages/srs-kit/bench/compose-schema.bench.ts
@@ -1,0 +1,81 @@
+import { bench, describe } from 'vitest'
+import { numericChrono } from '@/chrono/presets/numeric/index.js'
+import type { Middleware } from '@/middleware/index.js'
+import { schedulerStatsMiddleware } from '@/middleware/stats/index.js'
+import { SM2_DEFAULT_WEIGHTS, SM2Model } from '@/model/sm2.test.js'
+import {
+  composeSchema,
+  getParsedCardMemoryState,
+} from '@/scheduler/compose-schema.js'
+import { defineScheduler } from '@/scheduler/index.js'
+
+let composeSchemaSink = 0
+
+function consumeParsedCard(value: {
+  readonly card: Readonly<Record<string, unknown>>
+  readonly memoryState: Readonly<Record<string, unknown>>
+}): void {
+  composeSchemaSink =
+    (composeSchemaSink +
+      Number(value.card.interval ?? 0) +
+      Number(value.memoryState.reps ?? 0)) %
+    Number.MAX_SAFE_INTEGER
+}
+
+function consumeCardWithRememberedMemoryState(
+  card: Readonly<Record<string, unknown>> & object
+): void {
+  const memoryState = getParsedCardMemoryState(card)
+  if (!memoryState) {
+    throw new Error('Parsed card is missing remembered memory state')
+  }
+  consumeParsedCard({ card, memoryState })
+}
+
+function createCard(middlewares: readonly Middleware[]) {
+  const scheduler = defineScheduler({
+    model: SM2Model,
+    chrono: numericChrono,
+  }).use(...middlewares)
+
+  return scheduler
+    .create({
+      config: {
+        weights: SM2_DEFAULT_WEIGHTS,
+      },
+    })
+    .newCard({ now: 0 })
+}
+
+describe('composeSchema', () => {
+  const noMiddleware = [] as const
+  const statsMiddlewares = [schedulerStatsMiddleware] as const
+  const baseSchema = composeSchema({
+    model: SM2Model,
+    chrono: numericChrono,
+    middlewares: noMiddleware,
+  })
+  const statsSchema = composeSchema({
+    model: SM2Model,
+    chrono: numericChrono,
+    middlewares: statsMiddlewares,
+  })
+  const baseCard = createCard(noMiddleware)
+  const statsCard = createCard(statsMiddlewares)
+
+  bench('compose schema', () => {
+    composeSchema({
+      model: SM2Model,
+      chrono: numericChrono,
+      middlewares: statsMiddlewares,
+    })
+  })
+
+  bench('parse card without middleware', () => {
+    consumeCardWithRememberedMemoryState(baseSchema.card.parse(baseCard))
+  })
+
+  bench('parse card with stats middleware', () => {
+    consumeCardWithRememberedMemoryState(statsSchema.card.parse(statsCard))
+  })
+})

--- a/packages/srs-kit/bench/middleware.bench.ts
+++ b/packages/srs-kit/bench/middleware.bench.ts
@@ -1,0 +1,118 @@
+import { bench, describe } from 'vitest'
+import { numericChrono } from '@/chrono/presets/numeric/index.js'
+import type { Middleware } from '@/middleware/index.js'
+import { schedulerStatsMiddleware } from '@/middleware/stats/index.js'
+import { SM2_DEFAULT_WEIGHTS, SM2Model } from '@/model/sm2.test.js'
+import { Rating } from '@/primitives/index.js'
+import { defineScheduler } from '@/scheduler/index.js'
+
+let benchmarkSink = 0
+
+function consume(value: number): void {
+  benchmarkSink = (benchmarkSink + value) % Number.MAX_SAFE_INTEGER
+}
+
+function consumeCard(card: Readonly<Record<string, unknown>>): void {
+  consume(Number(card.interval ?? 0))
+}
+
+function createMiddleware(offset: number): Middleware {
+  return {
+    name: `bench-${offset}`,
+    defaultValue: {
+      card() {
+        return { [`bench${offset}`]: offset }
+      },
+    },
+    handlers: {
+      review(_ctx, next) {
+        const result = next()
+        consume(offset)
+        return result
+      },
+      rollback(_ctx, next) {
+        const result = next()
+        consume(offset)
+        return result
+      },
+    },
+  } as Middleware
+}
+
+type BenchMiddleware = ReturnType<typeof createMiddleware>
+
+function createCore(middlewares: readonly BenchMiddleware[]) {
+  const scheduler = defineScheduler({
+    model: SM2Model,
+    chrono: numericChrono,
+  }).use(...middlewares, schedulerStatsMiddleware)
+  return scheduler.create({
+    config: {
+      weights: SM2_DEFAULT_WEIGHTS,
+    },
+  })
+}
+
+const middlewareSets = [
+  { label: '0 middleware', middlewares: [] },
+  { label: '1 middleware', middlewares: [createMiddleware(1)] },
+  {
+    label: '2 middlewares',
+    middlewares: [createMiddleware(1), createMiddleware(2)],
+  },
+  {
+    label: '4 middlewares',
+    middlewares: [
+      createMiddleware(1),
+      createMiddleware(2),
+      createMiddleware(3),
+      createMiddleware(4),
+    ],
+  },
+] as const satisfies readonly {
+  readonly label: string
+  readonly middlewares: readonly BenchMiddleware[]
+}[]
+
+for (const { label, middlewares } of middlewareSets) {
+  describe(`numeric scheduler (${label})`, () => {
+    const core = createCore(middlewares)
+    const newCard = core.newCard({ now: 0 })
+    const review = core.review({ card: newCard, grade: Rating.Good, now: 0 })
+    const reviewCard = review.card
+    const reviewRevlog = review.revlog
+
+    bench('create', () => {
+      createCore(middlewares)
+    })
+
+    bench('newCard', () => {
+      consumeCard(core.newCard({ now: 0 }))
+    })
+
+    bench('review new card', () => {
+      core.review({ card: newCard, grade: Rating.Good, now: 0 })
+    })
+
+    bench('review existing card', () => {
+      core.review({
+        card: reviewCard,
+        grade: Rating.Good,
+        now: reviewCard.interval,
+      })
+    })
+
+    bench('preview existing card', () => {
+      for (const item of core.preview({
+        card: reviewCard,
+        now: reviewCard.interval,
+      })) {
+        consume(item.grade)
+      }
+    })
+
+    bench('rollback', () => {
+      core.rollback({ card: reviewCard, revlog: reviewRevlog })
+    })
+  })
+}

--- a/packages/srs-kit/bench/scheduler.bench.ts
+++ b/packages/srs-kit/bench/scheduler.bench.ts
@@ -1,0 +1,76 @@
+import { bench, describe } from 'vitest'
+import { numericChrono } from '@/chrono/presets/numeric/index.js'
+import { schedulerStatsMiddleware } from '@/middleware/stats/index.js'
+import { SM2_DEFAULT_WEIGHTS, SM2Model } from '@/model/sm2.test.js'
+import { Rating } from '@/primitives/index.js'
+import { defineScheduler } from '@/scheduler/index.js'
+
+let _schedulerSink: unknown
+
+function consumeSchedulerName(value: string | symbol): void {
+  _schedulerSink = value
+}
+
+describe('SM2 numeric scheduler', () => {
+  const scheduler = defineScheduler({
+    model: SM2Model,
+    chrono: numericChrono,
+  }).use(schedulerStatsMiddleware)
+
+  const config = {
+    weights: SM2_DEFAULT_WEIGHTS,
+  }
+  const core = scheduler.create({ config })
+  const newCard = core.newCard({ now: 0 })
+  const reviewCard = core.review({
+    card: newCard,
+    grade: Rating.Good,
+    now: 0,
+  }).card
+
+  bench('create', () => {
+    scheduler.create({ config })
+  })
+
+  bench('newCard', () => {
+    core.newCard({ now: 0 })
+  })
+
+  bench('review new card', () => {
+    core.review({ card: newCard, grade: Rating.Good, now: 0 })
+  })
+
+  bench('review existing card', () => {
+    core.review({
+      card: reviewCard,
+      grade: Rating.Good,
+      now: reviewCard.interval,
+    })
+  })
+
+  bench('preview new card', () => {
+    core.preview({ card: newCard, now: 0 })
+  })
+
+  bench('preview existing card', () => {
+    core.preview({ card: reviewCard, now: reviewCard.interval })
+  })
+})
+
+describe('defineScheduler composition', () => {
+  bench('defineScheduler()', () => {
+    const scheduler = defineScheduler({
+      model: SM2Model,
+      chrono: numericChrono,
+    })
+    consumeSchedulerName(scheduler.name)
+  })
+
+  bench('defineScheduler().use(stats)', () => {
+    const scheduler = defineScheduler({
+      model: SM2Model,
+      chrono: numericChrono,
+    }).use(schedulerStatsMiddleware)
+    consumeSchedulerName(scheduler.name)
+  })
+})

--- a/packages/srs-kit/bench/scheduler.bench.ts
+++ b/packages/srs-kit/bench/scheduler.bench.ts
@@ -28,6 +28,10 @@ describe('SM2 numeric scheduler', () => {
     now: 0,
   }).card
 
+  function consumePreview(previews: ReturnType<typeof core.preview>) {
+    return Array.from(previews)
+  }
+
   bench('create', () => {
     scheduler.create({ config })
   })
@@ -49,11 +53,11 @@ describe('SM2 numeric scheduler', () => {
   })
 
   bench('preview new card', () => {
-    core.preview({ card: newCard, now: 0 })
+    consumePreview(core.preview({ card: newCard, now: 0 }))
   })
 
   bench('preview existing card', () => {
-    core.preview({ card: reviewCard, now: reviewCard.interval })
+    consumePreview(core.preview({ card: reviewCard, now: reviewCard.interval }))
   })
 })
 

--- a/packages/srs-kit/package.json
+++ b/packages/srs-kit/package.json
@@ -94,6 +94,17 @@
         "default": "./dist/esm/chrono/temporal-instant/index.js"
       },
       "default": "./dist/esm/chrono/temporal-instant/index.js"
+    },
+    "./scheduler": {
+      "require": {
+        "types": "./dist/cjs/scheduler/index.d.ts",
+        "default": "./dist/cjs/scheduler/index.js"
+      },
+      "import": {
+        "types": "./dist/esm/scheduler/index.d.ts",
+        "default": "./dist/esm/scheduler/index.js"
+      },
+      "default": "./dist/esm/scheduler/index.js"
     }
   },
   "sideEffects": false,

--- a/packages/srs-kit/package.json
+++ b/packages/srs-kit/package.json
@@ -51,6 +51,17 @@
       },
       "default": "./dist/esm/model/index.js"
     },
+    "./middleware": {
+      "require": {
+        "types": "./dist/cjs/middleware/index.d.ts",
+        "default": "./dist/cjs/middleware/index.js"
+      },
+      "import": {
+        "types": "./dist/esm/middleware/index.d.ts",
+        "default": "./dist/esm/middleware/index.js"
+      },
+      "default": "./dist/esm/middleware/index.js"
+    },
     "./chrono": {
       "require": {
         "types": "./dist/cjs/chrono/index.d.ts",

--- a/packages/srs-kit/src/index.ts
+++ b/packages/srs-kit/src/index.ts
@@ -1,4 +1,5 @@
 export * from './chrono/index.js'
 export * from './model/index.js'
 export * from './primitives/index.js'
+export * from './scheduler/index.js'
 export * from './schema/index.js'

--- a/packages/srs-kit/src/index.ts
+++ b/packages/srs-kit/src/index.ts
@@ -1,4 +1,5 @@
 export * from './chrono/index.js'
+export * from './middleware/index.js'
 export * from './model/index.js'
 export * from './primitives/index.js'
 export * from './scheduler/index.js'

--- a/packages/srs-kit/src/model/model.type-display.spec.ts
+++ b/packages/srs-kit/src/model/model.type-display.spec.ts
@@ -29,12 +29,12 @@ describe('defineModel type display', () => {
         input: {
             readonly interval: number;
             readonly easeFactor: number;
-            readonly reps: number;
+            readonly reviewStep: number;
         };
         output: {
             readonly interval: number;
             readonly easeFactor: number;
-            readonly reps: number;
+            readonly reviewStep: number;
         };
     }>;
 }>`,
@@ -53,12 +53,12 @@ describe('defineModel type display', () => {
     input: {
         readonly interval: number;
         readonly easeFactor: number;
-        readonly reps: number;
+        readonly reviewStep: number;
     };
     output: {
         readonly interval: number;
         readonly easeFactor: number;
-        readonly reps: number;
+        readonly reviewStep: number;
     };
 }>`,
   }
@@ -71,7 +71,7 @@ describe('defineModel type display', () => {
     readonly memoryState: {
         readonly interval: number;
         readonly easeFactor: number;
-        readonly reps: number;
+        readonly reviewStep: number;
     };
 }>`,
   }

--- a/packages/srs-kit/src/model/sm2.spec.ts
+++ b/packages/srs-kit/src/model/sm2.spec.ts
@@ -46,7 +46,7 @@ describe('SM2Model', () => {
     expect(state).toEqual({
       interval: SM2_DEFAULT_WEIGHTS[0],
       easeFactor: expect.any(Number),
-      reps: 1,
+      reviewStep: 1,
     })
   })
 
@@ -62,7 +62,7 @@ describe('SM2Model', () => {
       elapsedDays: 1,
     })
     expect(second.interval).toBe(SM2_DEFAULT_WEIGHTS[1])
-    expect(second.reps).toBe(2)
+    expect(second.reviewStep).toBe(2)
   })
 
   it('multiplies interval by ease factor from third review onward', () => {
@@ -82,10 +82,10 @@ describe('SM2Model', () => {
       elapsedDays: 6,
     })
     expect(third.interval).toBe(second.interval * second.easeFactor)
-    expect(third.reps).toBe(3)
+    expect(third.reviewStep).toBe(3)
   })
 
-  it('resets reps to 1 on Again', () => {
+  it('resets review step to 1 on Again', () => {
     const first = core.step({
       memoryState: null,
       rating: Rating.Good,
@@ -101,7 +101,7 @@ describe('SM2Model', () => {
       rating: Rating.Again,
       elapsedDays: 6,
     })
-    expect(lapse.reps).toBe(1)
+    expect(lapse.reviewStep).toBe(1)
     expect(lapse.interval).toBe(SM2_DEFAULT_WEIGHTS[0])
   })
 
@@ -138,13 +138,13 @@ describe('SM2Model', () => {
   })
 
   it('computes forgetting curve as 0.9^(t/interval)', () => {
-    const state = { interval: 10, easeFactor: 2.5, reps: 3 }
+    const state = { interval: 10, easeFactor: 2.5, reviewStep: 3 }
     expect(core.forgettingCurve(state, 10)).toBeCloseTo(0.9, 8)
     expect(core.forgettingCurve(state, 0)).toBeCloseTo(1.0, 8)
   })
 
   it('computes next interval from desired retention', () => {
-    const state = { interval: 10, easeFactor: 2.5, reps: 3 }
+    const state = { interval: 10, easeFactor: 2.5, reviewStep: 3 }
     expect(core.nextInterval(state, 0.9)).toBe(10)
   })
 
@@ -157,9 +157,9 @@ describe('SM2Model', () => {
       ],
     })
     expect(states).toHaveLength(3)
-    expect(states[0].reps).toBe(1)
-    expect(states[1].reps).toBe(2)
-    expect(states[2].reps).toBe(3)
+    expect(states[0].reviewStep).toBe(1)
+    expect(states[1].reviewStep).toBe(2)
+    expect(states[2].reviewStep).toBe(3)
 
     const manual = core.step({
       memoryState: core.step({
@@ -189,7 +189,7 @@ describe('SM2Model', () => {
     expect(defaultState).toEqual({
       interval: 0,
       easeFactor: SM2_DEFAULT_WEIGHTS[2],
-      reps: 0,
+      reviewStep: 0,
     })
   })
 })

--- a/packages/srs-kit/src/model/sm2.test.ts
+++ b/packages/srs-kit/src/model/sm2.test.ts
@@ -14,7 +14,7 @@ import { defineModel } from './model.js'
 export interface SM2State {
   readonly interval: number
   readonly easeFactor: number
-  readonly reps: number
+  readonly reviewStep: number
 }
 
 export interface SM2Config {
@@ -64,16 +64,16 @@ const sm2MemoryStateSchema = defineSchema<SM2State>((value) => {
     value !== null &&
     'interval' in value &&
     'easeFactor' in value &&
-    'reps' in value &&
+    'reviewStep' in value &&
     typeof value.interval === 'number' &&
     typeof value.easeFactor === 'number' &&
-    typeof value.reps === 'number'
+    typeof value.reviewStep === 'number'
   ) {
     return {
       value: {
         interval: value.interval,
         easeFactor: value.easeFactor,
-        reps: value.reps,
+        reviewStep: value.reviewStep,
       },
     }
   }
@@ -98,19 +98,19 @@ function createSM2Core(
     memoryState,
     rating,
   }: ModelStepInput<SM2State>): SM2State => {
-    const { interval, easeFactor, reps } = memoryState ?? {
+    const { interval, easeFactor, reviewStep } = memoryState ?? {
       interval: 0,
       easeFactor: w[2],
-      reps: 0,
+      reviewStep: 0,
     }
 
     const success = rating > 1
-    const newReps = success ? reps + 1 : 1
+    const newReviewStep = success ? reviewStep + 1 : 1
 
     let newInterval: number
-    if (newReps === 1) {
+    if (newReviewStep === 1) {
       newInterval = w[0]
-    } else if (newReps === 2) {
+    } else if (newReviewStep === 2) {
       newInterval = w[1]
     } else {
       newInterval = interval * easeFactor
@@ -122,7 +122,7 @@ function createSM2Core(
     return {
       interval: clamp(newInterval, bounds.iMin, bounds.iMax),
       easeFactor: clamp(newEf, bounds.eMin, bounds.eMax),
-      reps: newReps,
+      reviewStep: newReviewStep,
     }
   }
 
@@ -184,7 +184,7 @@ export const SM2Model = defineModel({
   },
   defaultValue: {
     memoryState({ config }) {
-      return { interval: 0, easeFactor: config.weights[2], reps: 0 }
+      return { interval: 0, easeFactor: config.weights[2], reviewStep: 0 }
     },
   },
   create({ config }) {

--- a/packages/srs-kit/src/scheduler/base.spec.ts
+++ b/packages/srs-kit/src/scheduler/base.spec.ts
@@ -8,6 +8,8 @@ import { defineModel } from '@/model/model.js'
 import { SM2_DEFAULT_WEIGHTS, SM2Model } from '@/model/sm2.test.js'
 import { Rating, State } from '@/primitives/index.js'
 import { defineSchema, isObject, numberSchema } from '@/schema/index.js'
+import { BaseScheduler } from './base.js'
+import { useComposeDefaultValue } from './default-value.js'
 import { defineScheduler } from './define-scheduler.js'
 import { SRSSchedulerError } from './error.js'
 import {
@@ -333,6 +335,33 @@ describe('SchedulerCore.newCard', () => {
     expect(result.card.interval).toBe(1)
   })
 
+  it('caches nextInterval by memory state and desired retention', () => {
+    const seen: number[] = []
+    const candidateMiddleware = defineMiddleware({
+      name: Symbol('candidate-retention-cache'),
+      handlers: {
+        review(ctx, next) {
+          const memoryState = ctx.candidate.step(ctx.input.grade)
+          seen.push(ctx.candidate.nextInterval(memoryState, 0.9))
+          seen.push(ctx.candidate.nextInterval(memoryState, 0.5))
+          next()
+        },
+      },
+    })
+    const candidateCore = createSM2NumericScheduler()
+      .use(candidateMiddleware, schedulerStatsMiddleware)
+      .create({ config: { weights: SM2_DEFAULT_WEIGHTS } })
+    const card = candidateCore.newCard({ now: 0 })
+
+    candidateCore.review({
+      card,
+      grade: Rating.Good,
+      now: 0,
+    })
+
+    expect(seen).toEqual([1, 7])
+  })
+
   it('lets middleware read the previous grade candidate separately', () => {
     const seen: unknown[] = []
     const candidateMiddleware = defineMiddleware({
@@ -526,6 +555,13 @@ describe('SchedulerCore.review', () => {
     ).toThrow('Expected finite number')
   })
 
+  it('validates grade input', () => {
+    const card = core.newCard()
+    expect(() =>
+      core.review({ card, grade: Rating.Manual as never, now: 0 })
+    ).toThrow('Expected grade')
+  })
+
   it('throws chrono projection errors', () => {
     const failingChrono = defineChrono({
       schema: { time: numberSchema },
@@ -613,6 +649,27 @@ describe('SchedulerCore middleware handlers', () => {
         revlog: {},
       },
     ])
+  })
+
+  it('lets review middleware read the immutable now input', () => {
+    const seen: unknown[] = []
+    const inputMiddleware = defineMiddleware({
+      name: Symbol('input-now'),
+      handlers: {
+        review(ctx, next) {
+          seen.push(ctx.input.now)
+          next()
+        },
+      },
+    })
+    const inputCore = createSM2NumericScheduler()
+      .use(inputMiddleware, schedulerStatsMiddleware)
+      .create({ config })
+    const card = inputCore.newCard({ now: 0 })
+
+    inputCore.review({ card, grade: Rating.Good, now: 7 })
+
+    expect(seen).toEqual([7])
   })
 
   it('validates the final review result with scheduler schemas', () => {
@@ -832,6 +889,14 @@ describe('SchedulerCore.preview', () => {
       'Expected finite number'
     )
   })
+
+  it('uses chrono now when preview time is omitted', () => {
+    const card = core.newCard()
+
+    expect(
+      Array.from(core.preview({ card })).map((item) => item.grade)
+    ).toEqual([Rating.Again, Rating.Hard, Rating.Good, Rating.Easy])
+  })
 })
 
 describe('SchedulerCore.rollback', () => {
@@ -964,6 +1029,82 @@ describe('SchedulerCore.rollback', () => {
     expect(restored.dueAt).toEqual(revlog.reviewTime)
     expect(restored.lastReviewAt).toEqual(revlog.dueAt)
   })
+
+  it('allows rollback when chrono card defaults are absent', () => {
+    const optionalNumberFields = defineSchema<
+      unknown,
+      { readonly previous: number; readonly current: number }
+    >((value) =>
+      isObject(value)
+        ? {
+            value: {
+              previous: typeof value.previous === 'number' ? value.previous : 0,
+              current: typeof value.current === 'number' ? value.current : 0,
+            },
+          }
+        : { issues: [{ message: 'Expected optional number fields' }] }
+    )
+    const projectionSchema = defineSchema<
+      | { readonly card: { readonly previous: number }; readonly time: number }
+      | {
+          readonly revlog: {
+            readonly previous: number
+            readonly current: number
+          }
+        },
+      { readonly previous: number; readonly current: number }
+    >((value) => {
+      if (!isObject(value)) {
+        return { issues: [{ message: 'Expected optional projection input' }] }
+      }
+      if ('card' in value) {
+        const time = typeof value.time === 'number' ? value.time : 0
+        return { value: { previous: 0, current: time } }
+      }
+
+      return optionalNumberFields['~standard'].validate(value.revlog)
+    })
+    const noCardDefaultChrono = defineChrono({
+      schema: {
+        card: optionalNumberFields,
+        revlog: optionalNumberFields,
+        time: numberSchema,
+      },
+      projection: projectionSchema,
+      create() {
+        return {
+          now: () => 0,
+          difference: (from: number, to: number) => to - from,
+          add: (from: number, days: number) => from + days,
+        }
+      },
+    })
+    const noCardDefaultCore = defineScheduler({
+      model: SM2Model,
+      chrono: noCardDefaultChrono,
+    }).create({ config })
+    const card = {
+      interval: 1,
+      easeFactor: SM2_DEFAULT_WEIGHTS[2],
+      reps: 1,
+      previous: 0,
+      current: 1,
+      state: State.Review,
+      scheduleStatus: 'review' as const,
+    }
+    const result = noCardDefaultCore.review({
+      card,
+      grade: Rating.Good,
+      now: 1,
+    })
+
+    const restored = noCardDefaultCore.rollback({
+      card: result.card,
+      revlog: result.revlog,
+    })
+
+    expect(restored.scheduleStatus).toBe('review')
+  })
 })
 
 describe('card schema validation', () => {
@@ -985,5 +1126,43 @@ describe('card schema validation', () => {
     expect(() =>
       core.review({ card: card as never, grade: Rating.Good })
     ).toThrow()
+  })
+
+  it('requires composed card parsing to preserve model memory state', () => {
+    const unmarkedCardSchema = defineSchema<unknown, Record<string, unknown>>(
+      (value) =>
+        isObject(value)
+          ? { value }
+          : { issues: [{ message: 'Expected card object' }] }
+    )
+    const scheduler = createSM2NumericScheduler()
+    const unmarkedCore = new BaseScheduler({
+      model: SM2Model,
+      chrono: numericChrono,
+      schema: {
+        ...scheduler.schema,
+        card: unmarkedCardSchema,
+      },
+      defaultValue: useComposeDefaultValue({
+        model: SM2Model,
+        chrono: numericChrono,
+        middlewares: [],
+      }),
+      config,
+    })
+
+    expect(() =>
+      unmarkedCore.review({
+        card: {
+          interval: 0,
+          easeFactor: SM2_DEFAULT_WEIGHTS[2],
+          reps: 0,
+          state: State.New,
+          scheduleStatus: 'new',
+        },
+        grade: Rating.Good,
+        now: 0,
+      })
+    ).toThrow('Parsed scheduler card is missing model memory state')
   })
 })

--- a/packages/srs-kit/src/scheduler/base.spec.ts
+++ b/packages/srs-kit/src/scheduler/base.spec.ts
@@ -113,6 +113,7 @@ describe('SchedulerCore.newCard', () => {
     expect(card.state).toBe(State.New)
     expect(card.interval).toBe(0)
     expect(card.easeFactor).toBe(SM2_DEFAULT_WEIGHTS[2])
+    expect(card.reviewStep).toBe(0)
     expect(card.reps).toBe(0)
     expect(card.scheduleStatus).toBe('new')
     expect(card).not.toHaveProperty('elapsedDays')
@@ -328,7 +329,7 @@ describe('SchedulerCore.newCard', () => {
       {
         interval: 1,
         easeFactor: 2.5,
-        reps: 1,
+        reviewStep: 1,
       },
       7,
     ])
@@ -516,7 +517,9 @@ describe('SchedulerCore.review', () => {
     expect(result.revlog.state).toBe(State.New)
     expect(result.revlog.scheduleStatus).toBe('new')
     expect(result.revlog.interval).toBe(0)
-    expect(result.revlog.reps).toBe(0)
+    expect(result.revlog.reviewStep).toBe(0)
+    expect(result.revlog).not.toHaveProperty('reps')
+    expect(result.revlog).not.toHaveProperty('lapses')
   })
 
   it('records rating and state in core revlog without stats middleware', () => {
@@ -911,16 +914,37 @@ describe('SchedulerCore.rollback', () => {
     expect(restored.reps).toBe(0)
   })
 
-  it('returns an empty card when revlog status is new', () => {
+  it('returns an empty card when revlog state is new', () => {
     const card = core.newCard()
     const result = core.review({ card: card, grade: Rating.Good, now: 0 })
     const restored = core.rollback({
       card: result.card,
       revlog: {
         ...result.revlog,
-        interval: 30,
-        easeFactor: 3,
-        reps: 10,
+        scheduleStatus: 'review',
+      },
+    })
+
+    expect(restored.interval).toBe(0)
+    expect(restored.easeFactor).toBe(SM2_DEFAULT_WEIGHTS[2])
+    expect(restored.reps).toBe(0)
+    expect(restored.state).toBe(State.New)
+    expect(restored.scheduleStatus).toBe('new')
+  })
+
+  it('returns an empty card when revlog schedule status is new', () => {
+    const card = core.newCard()
+    const first = core.review({ card: card, grade: Rating.Good, now: 0 })
+    const second = core.review({
+      card: first.card,
+      grade: Rating.Good,
+      now: first.card.interval,
+    })
+    const restored = core.rollback({
+      card: second.card,
+      revlog: {
+        ...second.revlog,
+        state: State.New,
         scheduleStatus: 'new',
       },
     })
@@ -928,6 +952,7 @@ describe('SchedulerCore.rollback', () => {
     expect(restored.interval).toBe(0)
     expect(restored.easeFactor).toBe(SM2_DEFAULT_WEIGHTS[2])
     expect(restored.reps).toBe(0)
+    expect(restored.state).toBe(State.New)
     expect(restored.scheduleStatus).toBe('new')
   })
 
@@ -1086,7 +1111,7 @@ describe('SchedulerCore.rollback', () => {
     const card = {
       interval: 1,
       easeFactor: SM2_DEFAULT_WEIGHTS[2],
-      reps: 1,
+      reviewStep: 1,
       previous: 0,
       current: 1,
       state: State.Review,
@@ -1119,7 +1144,7 @@ describe('card schema validation', () => {
       state: State.New,
       interval: 'bad',
       easeFactor: 2.5,
-      reps: 0,
+      reviewStep: 0,
       scheduleStatus: 'new',
       lapses: 0,
     }
@@ -1156,7 +1181,7 @@ describe('card schema validation', () => {
         card: {
           interval: 0,
           easeFactor: SM2_DEFAULT_WEIGHTS[2],
-          reps: 0,
+          reviewStep: 0,
           state: State.New,
           scheduleStatus: 'new',
         },

--- a/packages/srs-kit/src/scheduler/base.spec.ts
+++ b/packages/srs-kit/src/scheduler/base.spec.ts
@@ -914,7 +914,7 @@ describe('SchedulerCore.rollback', () => {
     expect(restored.reps).toBe(0)
   })
 
-  it('returns an empty card when revlog state is new', () => {
+  it('runs rollback handlers when revlog state is new', () => {
     const card = core.newCard()
     const result = core.review({ card: card, grade: Rating.Good, now: 0 })
     const restored = core.rollback({
@@ -929,10 +929,10 @@ describe('SchedulerCore.rollback', () => {
     expect(restored.easeFactor).toBe(SM2_DEFAULT_WEIGHTS[2])
     expect(restored.reps).toBe(0)
     expect(restored.state).toBe(State.New)
-    expect(restored.scheduleStatus).toBe('new')
+    expect(restored.scheduleStatus).toBe('review')
   })
 
-  it('returns an empty card when revlog schedule status is new', () => {
+  it('does not reset stats when revlog state is new', () => {
     const card = core.newCard()
     const first = core.review({ card: card, grade: Rating.Good, now: 0 })
     const second = core.review({
@@ -949,9 +949,9 @@ describe('SchedulerCore.rollback', () => {
       },
     })
 
-    expect(restored.interval).toBe(0)
+    expect(restored.interval).toBe(1)
     expect(restored.easeFactor).toBe(SM2_DEFAULT_WEIGHTS[2])
-    expect(restored.reps).toBe(0)
+    expect(restored.reps).toBe(1)
     expect(restored.state).toBe(State.New)
     expect(restored.scheduleStatus).toBe('new')
   })
@@ -1015,8 +1015,8 @@ describe('SchedulerCore.rollback', () => {
     })
     const restoredFields = restored as Record<string, unknown>
 
-    expect(restored.dueAt).toEqual(revlog.dueAt)
-    expect(restored.lastReviewAt).toBeNull()
+    expect(restored.dueAt).toEqual(revlog.reviewTime)
+    expect(restored.lastReviewAt).toEqual(revlog.dueAt)
     expect(restored.source).toBe('test-source')
     expect('audit' in restoredFields).toBe(false)
   })

--- a/packages/srs-kit/src/scheduler/base.spec.ts
+++ b/packages/srs-kit/src/scheduler/base.spec.ts
@@ -1,0 +1,1025 @@
+import { describe, expect, it, vi } from 'vitest'
+import { defineChrono } from '@/chrono/define-chrono.js'
+import { dateChrono } from '@/chrono/presets/date/chrono.js'
+import { numericChrono } from '@/chrono/presets/numeric/index.js'
+import type { Middleware } from '@/middleware/index.js'
+import { schedulerStatsMiddleware } from '@/middleware/stats.js'
+import { defineModel } from '@/model/model.js'
+import { SM2_DEFAULT_WEIGHTS, SM2Model } from '@/model/sm2.test.js'
+import { Rating, State } from '@/primitives/index.js'
+import { defineSchema, isObject, numberSchema } from '@/schema/index.js'
+import { defineScheduler } from './define-scheduler.js'
+import { SRSSchedulerError } from './error.js'
+import {
+  config,
+  createSM2NumericScheduler,
+  defineStringFieldConfigSchema,
+  sourceCardSchema,
+  sourceConfigSchema,
+  sourceMiddleware,
+} from './scheduler.test.js'
+
+const scheduler = createSM2NumericScheduler().use(schedulerStatsMiddleware)
+const core = scheduler.create({ config })
+
+const cachedMiddlewareName = 'cachedMiddleware'
+const badMiddlewareName = Symbol('badMiddleware')
+const retentionMiddlewareName = Symbol('retentionMiddleware')
+
+const middlewareScheduler = createSM2NumericScheduler().use(
+  sourceMiddleware,
+  schedulerStatsMiddleware
+)
+
+const middlewareCore = middlewareScheduler.create({
+  config: {
+    ...config,
+    source: 'test-source',
+  },
+})
+
+const usedScheduler = createSM2NumericScheduler().use(
+  sourceMiddleware,
+  schedulerStatsMiddleware
+)
+const usedCore = usedScheduler.create({
+  config: {
+    ...config,
+    source: 'used-source',
+  },
+})
+
+describe('SchedulerCore.create', () => {
+  it('validates config and returns core', () => {
+    expect(core.config).toEqual({ ...config, chrono: {} })
+  })
+
+  it('does not expose desiredRetention on config', () => {
+    const c = scheduler.create({
+      config: { weights: SM2_DEFAULT_WEIGHTS },
+    })
+
+    expect(c.config).toEqual({
+      weights: SM2_DEFAULT_WEIGHTS,
+      chrono: {},
+    })
+    expect(c.config).not.toHaveProperty('desiredRetention')
+  })
+
+  it('rejects invalid config', () => {
+    expect(() =>
+      scheduler.create({ config: { weights: [1] } as never })
+    ).toThrow()
+  })
+
+  it('does not copy inherited middleware config fields', () => {
+    const inheritedConfigSchema = defineSchema<
+      { readonly own: string },
+      { readonly own: string }
+    >((value) => {
+      if (!isObject(value) || typeof value.own !== 'string') {
+        return { issues: [{ message: 'Expected own config' }] }
+      }
+
+      const prototype = { inherited: 'prototype-value' }
+      const config = Object.create(prototype) as { own: string }
+      config.own = value.own
+
+      return { value: config }
+    })
+    const inheritedMiddleware = {
+      name: 'inheritedConfig',
+      schema: { config: inheritedConfigSchema },
+    } satisfies Middleware<
+      { readonly config: typeof inheritedConfigSchema },
+      'inheritedConfig'
+    >
+    const inheritedCore = createSM2NumericScheduler()
+      .use(inheritedMiddleware)
+      .create({
+        config: {
+          weights: SM2_DEFAULT_WEIGHTS,
+          own: 'own-value',
+        },
+      })
+
+    expect(inheritedCore.config).toHaveProperty('own', 'own-value')
+    expect(inheritedCore.config).not.toHaveProperty('inherited')
+  })
+})
+
+describe('SchedulerCore.newCard', () => {
+  it('creates a new card with model defaults', () => {
+    const card = core.newCard()
+    expect(card.state).toBe(State.New)
+    expect(card.interval).toBe(0)
+    expect(card.easeFactor).toBe(SM2_DEFAULT_WEIGHTS[2])
+    expect(card.reps).toBe(0)
+    expect(card.scheduleStatus).toBe('new')
+    expect(card.scheduledDays).toBe(0)
+    expect(card.elapsedDays).toBe(0)
+    expect(card.lapses).toBe(0)
+  })
+
+  it('returns a mutable card', () => {
+    const card = core.newCard()
+    expect(Object.isFrozen(card)).toBe(false)
+  })
+
+  it('creates a fresh config-only card each time', () => {
+    const freshCore = scheduler.create({ config })
+    const firstCard = freshCore.newCard()
+    const secondCard = freshCore.newCard()
+
+    expect(secondCard).not.toBe(firstCard)
+    expect(secondCard).toStrictEqual(firstCard)
+  })
+
+  it('rejects middleware added after create()', () => {
+    const dynamicScheduler = createSM2NumericScheduler()
+    const dynamicCore = dynamicScheduler.create({ config })
+
+    expect(dynamicCore.newCard()).toHaveProperty('state', State.New)
+
+    expect(() => dynamicScheduler.use(schedulerStatsMiddleware)).toThrow(
+      SRSSchedulerError
+    )
+    expect(() => dynamicScheduler.use(schedulerStatsMiddleware)).toThrow(
+      /Cannot add middleware after scheduler\.create\(\)/
+    )
+
+    expect(dynamicCore.newCard()).toHaveProperty('state', State.New)
+  })
+
+  it('creates distinct cards for different now input', () => {
+    const dateScheduler = defineScheduler({
+      model: SM2Model,
+      chrono: dateChrono,
+    })
+    const dateCore = dateScheduler.create({ config })
+    const first = new Date('2026-01-01T00:00:00.000Z')
+    const second = new Date('2026-01-02T00:00:00.000Z')
+
+    const firstCard = dateCore.newCard({ now: first })
+    const secondCard = dateCore.newCard({ now: second })
+
+    expect(secondCard).not.toBe(firstCard)
+    expect(secondCard.dueAt).toBe(second)
+  })
+
+  it('validates now input', () => {
+    expect(() => core.newCard({ now: 'bad' as never })).toThrow(
+      'Expected finite number'
+    )
+  })
+
+  it('applies middleware card defaults', () => {
+    const card = middlewareCore.newCard()
+
+    expect(card.source).toBe('test-source')
+  })
+
+  it('applies middleware added through use()', () => {
+    const card = usedCore.newCard()
+
+    expect(card.source).toBe('used-source')
+  })
+
+  it('calls config-only middleware card defaults for each new card', () => {
+    const cachedMiddleware = {
+      name: cachedMiddlewareName,
+      schema: {
+        config: sourceConfigSchema,
+        card: sourceCardSchema,
+      },
+      defaultValue: {
+        card: vi.fn((ctx) => ({
+          source: ctx.config.source,
+        })),
+      },
+    } satisfies Middleware<
+      {
+        readonly config: typeof sourceConfigSchema
+        readonly card: typeof sourceCardSchema
+      },
+      typeof cachedMiddlewareName
+    >
+    const cachedMiddlewareScheduler = createSM2NumericScheduler().use(
+      cachedMiddleware,
+      schedulerStatsMiddleware
+    )
+    const cachedMiddlewareCore = cachedMiddlewareScheduler.create({
+      config: {
+        ...config,
+        source: 'cached-source',
+      },
+    })
+
+    const firstCard = cachedMiddlewareCore.newCard()
+    const secondCard = cachedMiddlewareCore.newCard()
+
+    expect(secondCard).not.toBe(firstCard)
+    expect(secondCard).toStrictEqual(firstCard)
+    expect(cachedMiddleware.defaultValue.card).toHaveBeenCalledTimes(2)
+  })
+
+  it('lets middleware read config fields from the top-level config', () => {
+    const trace: string[] = []
+    const firstName = 'first'
+    const secondName = 'second'
+    const firstConfigSchema = defineStringFieldConfigSchema('firstSource')
+    const secondConfigSchema = defineStringFieldConfigSchema('secondSource')
+    const firstMiddleware: Middleware<
+      {
+        readonly config: typeof firstConfigSchema
+        readonly card: typeof sourceCardSchema
+      },
+      typeof firstName
+    > = {
+      name: firstName,
+      schema: { config: firstConfigSchema, card: sourceCardSchema },
+      defaultValue: {
+        card(ctx) {
+          trace.push(`first:${ctx.config.firstSource}`)
+          return { source: 'first' }
+        },
+      },
+    }
+    const secondMiddleware: Middleware<
+      {
+        readonly config: typeof secondConfigSchema
+        readonly card: typeof sourceCardSchema
+      },
+      typeof secondName
+    > = {
+      name: secondName,
+      schema: { config: secondConfigSchema, card: sourceCardSchema },
+      defaultValue: {
+        card(ctx) {
+          trace.push(`second:${ctx.config.secondSource}`)
+          return { source: 'second' }
+        },
+      },
+    }
+    const namedScheduler = createSM2NumericScheduler().use(
+      secondMiddleware,
+      firstMiddleware,
+      schedulerStatsMiddleware
+    )
+
+    namedScheduler
+      .create({
+        config: {
+          ...config,
+          firstSource: 'first-config',
+          secondSource: 'second-config',
+        },
+      })
+      .newCard()
+
+    expect(trace).toEqual(['second:second-config', 'first:first-config'])
+  })
+
+  it('lets review middleware read and update desiredRetention', () => {
+    const seen: number[] = []
+    const retentionMiddleware = {
+      name: retentionMiddlewareName,
+      handlers: {
+        review(ctx, next) {
+          seen.push(ctx.desiredRetention)
+          ctx.desiredRetention = 0.5
+          return next()
+        },
+      },
+    } satisfies Middleware<
+      Record<PropertyKey, never>,
+      typeof retentionMiddlewareName
+    >
+    const retentionScheduler = createSM2NumericScheduler().use(
+      retentionMiddleware,
+      schedulerStatsMiddleware
+    )
+    const retentionCore = retentionScheduler.create({
+      config: { weights: SM2_DEFAULT_WEIGHTS },
+    })
+    const card = retentionCore.newCard({ now: 0 })
+    const result = retentionCore.review({
+      card,
+      grade: Rating.Good,
+      now: 0,
+    })
+
+    expect(seen).toEqual([0.9])
+    expect(result.card.scheduledDays).toBe(7)
+  })
+
+  it('lets middleware derive desiredRetention from candidate memory state', () => {
+    const seen: unknown[] = []
+    const candidateMiddleware = {
+      name: Symbol('candidate-retention'),
+      handlers: {
+        review(ctx, next) {
+          const memoryState = ctx.candidate.step(ctx.input.grade)
+          seen.push(memoryState)
+          ctx.desiredRetention =
+            (memoryState.interval as number | undefined) === 1 ? 0.5 : 0.9
+          seen.push(
+            ctx.candidate.nextInterval(memoryState, ctx.desiredRetention)
+          )
+          return next()
+        },
+      },
+    } satisfies Middleware
+    const candidateCore = createSM2NumericScheduler()
+      .use(candidateMiddleware, schedulerStatsMiddleware)
+      .create({ config: { weights: SM2_DEFAULT_WEIGHTS } })
+    const card = candidateCore.newCard({ now: 0 })
+    const result = candidateCore.review({
+      card,
+      grade: Rating.Good,
+      now: 0,
+    })
+
+    expect(seen).toEqual([
+      {
+        interval: 1,
+        easeFactor: 2.5,
+        reps: 1,
+      },
+      7,
+    ])
+    expect(result.card.scheduledDays).toBe(7)
+  })
+
+  it('lets middleware read the previous grade candidate separately', () => {
+    const seen: unknown[] = []
+    const candidateMiddleware = {
+      name: Symbol('previous-candidate'),
+      handlers: {
+        review(ctx, next) {
+          const previousMemoryState = ctx.candidate.step(Rating.Hard)
+          const hardMemoryState = ctx.candidate.step(Rating.Hard)
+          seen.push({
+            sameMemoryState: previousMemoryState === hardMemoryState,
+            previousScheduledDays: ctx.candidate.nextInterval(
+              previousMemoryState,
+              ctx.desiredRetention
+            ),
+            hardScheduledDays: ctx.candidate.nextInterval(
+              hardMemoryState,
+              ctx.desiredRetention
+            ),
+          })
+          return next()
+        },
+      },
+    } satisfies Middleware
+    const candidateCore = createSM2NumericScheduler()
+      .use(candidateMiddleware, schedulerStatsMiddleware)
+      .create({ config: { weights: SM2_DEFAULT_WEIGHTS } })
+    const card = candidateCore.newCard({ now: 0 })
+
+    candidateCore.review({
+      card,
+      grade: Rating.Good,
+      now: 0,
+    })
+
+    expect(seen).toEqual([
+      {
+        sameMemoryState: true,
+        previousScheduledDays: 1,
+        hardScheduledDays: 1,
+      },
+    ])
+  })
+
+  it('caches nextInterval across cumulative middleware calls in preview', () => {
+    type SM2Core = ReturnType<typeof SM2Model.create>
+    const nextIntervalSpy = vi.fn<SM2Core['nextInterval']>()
+
+    const SpiedSM2Model = defineModel({
+      name: 'sm2-spied',
+      schema: SM2Model.schema,
+      defaultValue: SM2Model.defaultValue,
+      create(ctx) {
+        const core = SM2Model.create(ctx)
+        nextIntervalSpy.mockImplementation((ms, dr) =>
+          core.nextInterval(ms, dr)
+        )
+        return { ...core, nextInterval: nextIntervalSpy }
+      },
+    })
+
+    const cumulativeMiddleware = {
+      name: Symbol('cumulative-candidate'),
+      handlers: {
+        review(ctx, next) {
+          const currentGrade = ctx.input.grade
+          const allGrades = [
+            Rating.Again,
+            Rating.Hard,
+            Rating.Good,
+            Rating.Easy,
+          ]
+          for (const g of allGrades) {
+            if (g > currentGrade) break
+            const ms = ctx.candidate.step(g)
+            ctx.candidate.nextInterval(ms, ctx.desiredRetention)
+          }
+          return next()
+        },
+      },
+    } satisfies Middleware
+
+    const spiedScheduler = defineScheduler({
+      model: SpiedSM2Model,
+      chrono: numericChrono,
+    }).use(cumulativeMiddleware, schedulerStatsMiddleware)
+
+    const spiedCore = spiedScheduler.create({
+      config: { weights: SM2_DEFAULT_WEIGHTS },
+    })
+
+    const card = spiedCore.newCard({ now: 0 })
+
+    nextIntervalSpy.mockClear()
+    for (const _ of spiedCore.preview({ card, now: 0 })) {
+      // consume lazy iterable to trigger all computations
+    }
+
+    // Middleware calls: Again=1, Hard=2, Good=3, Easy=4 = 10
+    // finalizeReview calls: 4 (one per grade)
+    // Total calls: 14, but only 4 unique (memoryState, desiredRetention) pairs
+    expect(nextIntervalSpy).toHaveBeenCalledTimes(4)
+  })
+})
+
+describe('SchedulerCore.review', () => {
+  it('transitions New -> Review on Good', () => {
+    const card = core.newCard()
+    const result = core.review({ card: card, grade: Rating.Good })
+
+    expect(result.card.state).toBe(State.Review)
+    expect(result.card.scheduleStatus).toBe('review')
+    expect(result.card.interval).toBeGreaterThan(0)
+    expect(result.card.reps).toBe(1)
+    expect(result.card.lapses).toBe(0)
+    expect(result.card.scheduledDays).toBeGreaterThan(0)
+  })
+
+  it('transitions New -> Review on Again by default', () => {
+    const card = core.newCard()
+    const result = core.review({ card: card, grade: Rating.Again })
+
+    expect(result.card.state).toBe(State.Review)
+    expect(result.card.reps).toBe(1)
+    expect(result.card.lapses).toBe(0)
+  })
+
+  it('keeps Review on Again and increments lapses', () => {
+    const card = core.newCard()
+    const r1 = core.review({ card: card, grade: Rating.Good, now: 0 })
+    const r2 = core.review({
+      card: r1.card,
+      grade: Rating.Again,
+      now: r1.card.scheduledDays,
+    })
+
+    expect(r2.card.state).toBe(State.Review)
+    expect(r2.card.lapses).toBe(1)
+  })
+
+  it('returns mutable card and revlog', () => {
+    const card = core.newCard()
+    const result = core.review({ card: card, grade: Rating.Good })
+
+    expect(Object.isFrozen(result.card)).toBe(false)
+    expect(Object.isFrozen(result.revlog)).toBe(false)
+  })
+
+  it('records previous state in revlog', () => {
+    const card = core.newCard()
+    const result = core.review({ card: card, grade: Rating.Good })
+
+    expect(result.revlog.rating).toBe(Rating.Good)
+    expect(result.revlog.state).toBe(State.New)
+    expect(result.revlog.scheduleStatus).toBe('new')
+    expect(result.revlog.interval).toBe(0)
+    expect(result.revlog.reps).toBe(0)
+    expect(result.revlog.scheduledDays).toBe(0)
+  })
+
+  it('records rating and state in core revlog without stats middleware', () => {
+    const baseCore = createSM2NumericScheduler().create({ config })
+    const card = baseCore.newCard()
+    const result = baseCore.review({ card, grade: Rating.Good })
+
+    expect(result.revlog.rating).toBe(Rating.Good)
+    expect(result.revlog.state).toBe(State.New)
+    expect(result.revlog.scheduledDays).toBe(0)
+  })
+
+  it('computes elapsed days from chrono', () => {
+    const card = core.newCard()
+    const r1 = core.review({ card: card, grade: Rating.Good, now: 0 })
+    const r2 = core.review({ card: r1.card, grade: Rating.Good, now: 5 })
+
+    expect(r2.revlog.elapsedDays).toBe(5)
+  })
+
+  it('chains multiple reviews correctly', () => {
+    const card = core.newCard()
+    const r1 = core.review({ card: card, grade: Rating.Good, now: 0 })
+    const r2 = core.review({
+      card: r1.card,
+      grade: Rating.Good,
+      now: r1.card.scheduledDays,
+    })
+    const r3 = core.review({
+      card: r2.card,
+      grade: Rating.Good,
+      now: r1.card.scheduledDays + r2.card.scheduledDays,
+    })
+
+    expect(r3.card.reps).toBe(3)
+    expect(r3.card.state).toBe(State.Review)
+    expect(r3.card.interval).toBeGreaterThan(0)
+  })
+
+  it('validates now input', () => {
+    const card = core.newCard()
+    expect(() =>
+      core.review({ card: card, grade: Rating.Good, now: 'bad' as never })
+    ).toThrow('Expected finite number')
+  })
+
+  it('throws chrono projection errors', () => {
+    const failingChrono = defineChrono({
+      schema: { time: numberSchema },
+      projection() {
+        return { issues: [{ message: 'projection failed' }] }
+      },
+      create() {
+        return {
+          now: () => 0,
+          difference: () => 0,
+          add: (from: number) => from,
+        }
+      },
+    })
+    const failingScheduler = defineScheduler({
+      model: SM2Model,
+      chrono: failingChrono,
+    })
+    const failingCore = failingScheduler.create({ config })
+    const card = failingCore.newCard({ now: 0 })
+
+    expect(() =>
+      failingCore.review({ card: card, grade: Rating.Good, now: 0 })
+    ).toThrow('projection failed')
+  })
+
+  it('uses middleware handlers to inject review result fields', () => {
+    const card = middlewareCore.newCard({ now: 0 })
+    const result = middlewareCore.review({
+      card: card,
+      grade: Rating.Good,
+      now: 0,
+    })
+
+    expect(result.card.source).toBe('test-source')
+    expect(result.revlog.audit).toBe('test-source')
+  })
+})
+
+describe('SchedulerCore middleware handlers', () => {
+  it('throws when review middleware mutates input fields', () => {
+    const card = core.newCard({ now: 0 })
+
+    for (const field of ['card', 'grade', 'now'] as const) {
+      const mutatingMiddleware = {
+        name: Symbol(`mutate-${field}`),
+        handlers: {
+          review(ctx, next) {
+            ;(ctx.input as Record<typeof field, unknown>)[field] = null
+            return next()
+          },
+        },
+      } satisfies Middleware
+      const mutatingCore = createSM2NumericScheduler()
+        .use(mutatingMiddleware)
+        .create({ config })
+
+      expect(() =>
+        mutatingCore.review({ card, grade: Rating.Good, now: 0 })
+      ).toThrow(`Review input ${field} cannot be changed`)
+    }
+  })
+
+  it('seeds review result with empty containers', () => {
+    const seen: unknown[] = []
+    const resultMiddleware = {
+      name: Symbol('seed-result'),
+      handlers: {
+        review(ctx, next) {
+          seen.push(structuredClone(ctx.result))
+          return next()
+        },
+      },
+    } satisfies Middleware
+    const resultCore = createSM2NumericScheduler()
+      .use(resultMiddleware, schedulerStatsMiddleware)
+      .create({ config })
+    const card = resultCore.newCard({ now: 0 })
+
+    resultCore.review({ card, grade: Rating.Good, now: 0 })
+
+    expect(seen).toEqual([
+      {
+        card: {},
+        revlog: {},
+      },
+    ])
+  })
+
+  it('validates the final review result with scheduler schemas', () => {
+    const invalidResultMiddleware = {
+      name: Symbol('invalid-result'),
+      handlers: {
+        review(ctx, next) {
+          const result = next()
+          const runtimeCtx = ctx as {
+            readonly result: {
+              readonly card: Record<string, unknown>
+            }
+          }
+          delete runtimeCtx.result.card.interval
+          return result
+        },
+      },
+    } satisfies Middleware
+    const invalidResultCore = createSM2NumericScheduler()
+      .use(invalidResultMiddleware, schedulerStatsMiddleware)
+      .create({ config })
+    const card = invalidResultCore.newCard({ now: 0 })
+
+    expect(() =>
+      invalidResultCore.review({ card, grade: Rating.Good, now: 0 })
+    ).toThrow('Expected SM2 memory state')
+  })
+
+  function traceMiddleware(name: string, trace: string[]): Middleware {
+    return {
+      name,
+      handlers: {
+        review(ctx, next) {
+          trace.push(`${name}:review:before:${ctx.input.grade}`)
+          const result = next() as { readonly card: { readonly state: State } }
+          trace.push(`${name}:review:after:${result.card.state}`)
+          return result as never
+        },
+        rollback(ctx, next) {
+          const revlog = ctx.input.revlog as { readonly rating: Rating }
+          trace.push(`${name}:rollback:before:${revlog.rating}`)
+          const result = next() as { readonly state: State }
+          trace.push(`${name}:rollback:after:${result.state}`)
+          return result as never
+        },
+      },
+    }
+  }
+
+  it('wraps review handlers in array order', () => {
+    const trace: string[] = []
+    const tracedScheduler = createSM2NumericScheduler().use(
+      traceMiddleware('outer', trace),
+      traceMiddleware('inner', trace),
+      schedulerStatsMiddleware
+    )
+    const tracedCore = tracedScheduler.create({ config })
+    const card = tracedCore.newCard({ now: 0 })
+
+    tracedCore.review({ card: card, grade: Rating.Good, now: 0 })
+
+    expect(trace).toEqual([
+      'outer:review:before:3',
+      'inner:review:before:3',
+      'inner:review:after:2',
+      'outer:review:after:2',
+    ])
+  })
+
+  it('wraps preview review handlers for each grade', () => {
+    const trace: string[] = []
+    const tracedScheduler = createSM2NumericScheduler().use(
+      traceMiddleware('mw', trace),
+      schedulerStatsMiddleware
+    )
+    const tracedCore = tracedScheduler.create({ config })
+    const card = tracedCore.newCard({ now: 0 })
+
+    const previews = tracedCore.preview({ card: card, now: 0 })
+    expect(trace).toEqual([])
+
+    const iterator = previews[Symbol.iterator]()
+    expect(iterator.next().done).toBe(false)
+    expect(trace).toEqual(['mw:review:before:1', 'mw:review:after:2'])
+
+    iterator.next()
+    iterator.next()
+    iterator.next()
+
+    expect(trace).toEqual([
+      'mw:review:before:1',
+      'mw:review:after:2',
+      'mw:review:before:2',
+      'mw:review:after:2',
+      'mw:review:before:3',
+      'mw:review:after:2',
+      'mw:review:before:4',
+      'mw:review:after:2',
+    ])
+  })
+
+  it('wraps rollback handlers in array order', () => {
+    const trace: string[] = []
+    const tracedScheduler = createSM2NumericScheduler().use(
+      traceMiddleware('outer', trace),
+      traceMiddleware('inner', trace),
+      schedulerStatsMiddleware
+    )
+    const tracedCore = tracedScheduler.create({ config })
+    const card = tracedCore.newCard({ now: 0 })
+    const first = tracedCore.review({ card: card, grade: Rating.Good, now: 0 })
+    const result = tracedCore.review({
+      card: first.card,
+      grade: Rating.Good,
+      now: first.card.scheduledDays,
+    })
+    trace.length = 0
+
+    tracedCore.rollback({ card: result.card, revlog: result.revlog })
+
+    expect(trace).toEqual([
+      'outer:rollback:before:3',
+      'inner:rollback:before:3',
+      'inner:rollback:after:2',
+      'outer:rollback:after:2',
+    ])
+  })
+
+  it('rejects calling next more than once', () => {
+    const badMiddleware = {
+      name: badMiddlewareName,
+      handlers: {
+        review(_ctx, next) {
+          next()
+          return next()
+        },
+      },
+    } satisfies Middleware
+    const badScheduler = createSM2NumericScheduler().use(
+      badMiddleware,
+      schedulerStatsMiddleware
+    )
+    const badCore = badScheduler.create({ config })
+    const card = badCore.newCard({ now: 0 })
+
+    expect(() =>
+      badCore.review({ card: card, grade: Rating.Good, now: 0 })
+    ).toThrow('Middleware next() called multiple times')
+  })
+})
+
+describe('SchedulerCore.preview', () => {
+  it('returns results for all grades', () => {
+    const card = core.newCard()
+    const previews = Array.from(core.preview({ card: card, now: 0 }))
+
+    expect(previews.map((preview) => preview.grade)).toEqual([
+      Rating.Again,
+      Rating.Hard,
+      Rating.Good,
+      Rating.Easy,
+    ])
+  })
+
+  it('returns an iterator in grade order', () => {
+    const card = core.newCard()
+    const previews = core.preview({ card: card, now: 0 })
+
+    const items = Array.from(previews)
+
+    expect((previews as never as Record<number, unknown>)[Rating.Good]).toBe(
+      undefined
+    )
+    expect(items.map((item) => item.grade)).toEqual([
+      Rating.Again,
+      Rating.Hard,
+      Rating.Good,
+      Rating.Easy,
+    ])
+    expect(items.every((item) => item.card && item.revlog)).toBe(true)
+  })
+
+  it('matches individual review calls', () => {
+    const card = core.newCard()
+    const previews = Array.from(core.preview({ card: card, now: 0 }))
+
+    for (const preview of previews) {
+      const individual = core.review({
+        card: card,
+        grade: preview.grade,
+        now: 0,
+      })
+      expect(preview.card).toEqual(individual.card)
+      expect(preview.revlog).toEqual(individual.revlog)
+    }
+  })
+
+  it('validates card once for all grades', () => {
+    const card = core.newCard()
+    expect(() => core.preview({ card: card, now: 0 })).not.toThrow()
+  })
+
+  it('extracts card memory state once for all grades', () => {
+    const validate = vi.spyOn(
+      SM2Model.schema.memoryState['~standard'],
+      'validate'
+    )
+    const card = core.newCard()
+
+    validate.mockClear()
+    core.preview({ card: card, now: 0 })
+
+    expect(validate).toHaveBeenCalledTimes(1)
+    validate.mockRestore()
+  })
+
+  it('validates now input', () => {
+    const card = core.newCard()
+    expect(() => core.preview({ card: card, now: 'bad' as never })).toThrow(
+      'Expected finite number'
+    )
+  })
+})
+
+describe('SchedulerCore.rollback', () => {
+  it('restores previous card state', () => {
+    const card = core.newCard()
+    const result = core.review({ card: card, grade: Rating.Good, now: 0 })
+    const restored = core.rollback({ card: result.card, revlog: result.revlog })
+
+    expect(restored.state).toBe(State.New)
+    expect(restored.scheduleStatus).toBe('new')
+    expect(restored.interval).toBe(0)
+    expect(restored.reps).toBe(0)
+    expect(restored.scheduledDays).toBe(0)
+  })
+
+  it('returns an empty card when revlog status is new', () => {
+    const card = core.newCard()
+    const result = core.review({ card: card, grade: Rating.Good, now: 0 })
+    const restored = core.rollback({
+      card: result.card,
+      revlog: {
+        ...result.revlog,
+        interval: 30,
+        easeFactor: 3,
+        reps: 10,
+        scheduleStatus: 'new',
+        scheduledDays: 0,
+      },
+    })
+
+    expect(restored.interval).toBe(0)
+    expect(restored.easeFactor).toBe(SM2_DEFAULT_WEIGHTS[2])
+    expect(restored.reps).toBe(0)
+    expect(restored.scheduleStatus).toBe('new')
+    expect(restored.scheduledDays).toBe(0)
+  })
+
+  it('restores lapses on lapse rollback', () => {
+    const card = core.newCard()
+    const r1 = core.review({ card: card, grade: Rating.Good, now: 0 })
+    const r2 = core.review({
+      card: r1.card,
+      grade: Rating.Again,
+      now: r1.card.scheduledDays,
+    })
+
+    expect(r2.card.lapses).toBe(1)
+
+    const restored = core.rollback({ card: r2.card, revlog: r2.revlog })
+    expect(restored.lapses).toBe(0)
+    expect(restored.state).toBe(State.Review)
+  })
+
+  it('returns a mutable card', () => {
+    const card = core.newCard()
+    const result = core.review({ card: card, grade: Rating.Good, now: 0 })
+    const restored = core.rollback({ card: result.card, revlog: result.revlog })
+
+    expect(Object.isFrozen(restored)).toBe(false)
+  })
+
+  it('restores only fields that belong to the card shape', () => {
+    const dateMiddlewareScheduler = defineScheduler({
+      model: SM2Model,
+      chrono: dateChrono,
+    }).use(sourceMiddleware, schedulerStatsMiddleware)
+    const dateMiddlewareCore = dateMiddlewareScheduler.create({
+      config: {
+        ...config,
+        source: 'test-source',
+      },
+    })
+    const card = dateMiddlewareCore.newCard({
+      now: new Date('2026-01-01T00:00:00.000Z'),
+    })
+    const result = dateMiddlewareCore.review({
+      card,
+      grade: Rating.Good,
+      now: new Date('2026-01-03T00:00:00.000Z'),
+    })
+    const revlog = {
+      ...result.revlog,
+      dueAt: new Date('2026-01-02T00:00:00.000Z'),
+      reviewTime: new Date('2026-01-03T00:00:00.000Z'),
+      audit: 'test-source',
+    }
+
+    const restored = dateMiddlewareCore.rollback({
+      card: {
+        ...card,
+        ...result.card,
+      },
+      revlog,
+    })
+    const restoredFields = restored as Record<string, unknown>
+
+    expect(restored.dueAt).toEqual(revlog.dueAt)
+    expect(restored.lastReviewAt).toBeNull()
+    expect(restored.source).toBe('test-source')
+    expect('audit' in restoredFields).toBe(false)
+  })
+
+  it('restores non-new chrono card fields from revlog projection', () => {
+    const dateCore = defineScheduler({
+      model: SM2Model,
+      chrono: dateChrono,
+    }).create({ config })
+    const card = dateCore.newCard({
+      now: new Date('2026-06-28T00:00:00.000Z'),
+    })
+    const first = dateCore.review({
+      card,
+      grade: Rating.Good,
+      now: new Date('2026-06-30T00:00:00.000Z'),
+    })
+    const second = dateCore.review({
+      card: first.card,
+      grade: Rating.Good,
+      now: first.card.dueAt,
+    })
+    const revlog = {
+      ...second.revlog,
+      dueAt: new Date('2026-06-30T00:00:00.000Z'),
+      reviewTime: new Date('2026-07-06T00:00:00.000Z'),
+    }
+
+    const restored = dateCore.rollback({
+      card: second.card,
+      revlog,
+    })
+
+    expect(restored.scheduleStatus).toBe('review')
+    expect(restored.dueAt).toEqual(revlog.reviewTime)
+    expect(restored.lastReviewAt).toEqual(revlog.dueAt)
+  })
+})
+
+describe('card schema validation', () => {
+  it('validates card input', () => {
+    expect(() =>
+      core.review({ card: {} as never, grade: Rating.Good })
+    ).toThrow()
+  })
+
+  it('validates model fields via model schema', () => {
+    const card = {
+      state: State.New,
+      interval: 'bad',
+      easeFactor: 2.5,
+      reps: 0,
+      scheduleStatus: 'new',
+      scheduledDays: 0,
+      elapsedDays: 0,
+      lapses: 0,
+    }
+    expect(() =>
+      core.review({ card: card as never, grade: Rating.Good })
+    ).toThrow()
+  })
+})

--- a/packages/srs-kit/src/scheduler/base.spec.ts
+++ b/packages/srs-kit/src/scheduler/base.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { defineChrono } from '@/chrono/define-chrono.js'
 import { dateChrono } from '@/chrono/presets/date/chrono.js'
 import { numericChrono } from '@/chrono/presets/numeric/index.js'
-import type { Middleware } from '@/middleware/index.js'
+import { defineMiddleware } from '@/middleware/index.js'
 import { schedulerStatsMiddleware } from '@/middleware/stats/index.js'
 import { defineModel } from '@/model/model.js'
 import { SM2_DEFAULT_WEIGHTS, SM2Model } from '@/model/sm2.test.js'
@@ -87,13 +87,10 @@ describe('SchedulerCore.create', () => {
 
       return { value: config }
     })
-    const inheritedMiddleware = {
+    const inheritedMiddleware = defineMiddleware({
       name: 'inheritedConfig',
       schema: { config: inheritedConfigSchema },
-    } satisfies Middleware<
-      { readonly config: typeof inheritedConfigSchema },
-      'inheritedConfig'
-    >
+    })
     const inheritedCore = createSM2NumericScheduler()
       .use(inheritedMiddleware)
       .create({
@@ -185,24 +182,21 @@ describe('SchedulerCore.newCard', () => {
   })
 
   it('calls config-only middleware card defaults for each new card', () => {
-    const cachedMiddleware = {
+    const cardDefault = vi.fn(
+      (ctx: { readonly config: { source: string } }) => ({
+        source: ctx.config.source,
+      })
+    )
+    const cachedMiddleware = defineMiddleware({
       name: cachedMiddlewareName,
       schema: {
         config: sourceConfigSchema,
         card: sourceCardSchema,
       },
       defaultValue: {
-        card: vi.fn((ctx) => ({
-          source: ctx.config.source,
-        })),
+        card: cardDefault,
       },
-    } satisfies Middleware<
-      {
-        readonly config: typeof sourceConfigSchema
-        readonly card: typeof sourceCardSchema
-      },
-      typeof cachedMiddlewareName
-    >
+    })
     const cachedMiddlewareScheduler = createSM2NumericScheduler().use(
       cachedMiddleware,
       schedulerStatsMiddleware
@@ -219,7 +213,7 @@ describe('SchedulerCore.newCard', () => {
 
     expect(secondCard).not.toBe(firstCard)
     expect(secondCard).toStrictEqual(firstCard)
-    expect(cachedMiddleware.defaultValue.card).toHaveBeenCalledTimes(2)
+    expect(cardDefault).toHaveBeenCalledTimes(2)
   })
 
   it('lets middleware read config fields from the top-level config', () => {
@@ -228,13 +222,7 @@ describe('SchedulerCore.newCard', () => {
     const secondName = 'second'
     const firstConfigSchema = defineStringFieldConfigSchema('firstSource')
     const secondConfigSchema = defineStringFieldConfigSchema('secondSource')
-    const firstMiddleware: Middleware<
-      {
-        readonly config: typeof firstConfigSchema
-        readonly card: typeof sourceCardSchema
-      },
-      typeof firstName
-    > = {
+    const firstMiddleware = defineMiddleware({
       name: firstName,
       schema: { config: firstConfigSchema, card: sourceCardSchema },
       defaultValue: {
@@ -243,14 +231,8 @@ describe('SchedulerCore.newCard', () => {
           return { source: 'first' }
         },
       },
-    }
-    const secondMiddleware: Middleware<
-      {
-        readonly config: typeof secondConfigSchema
-        readonly card: typeof sourceCardSchema
-      },
-      typeof secondName
-    > = {
+    })
+    const secondMiddleware = defineMiddleware({
       name: secondName,
       schema: { config: secondConfigSchema, card: sourceCardSchema },
       defaultValue: {
@@ -259,7 +241,7 @@ describe('SchedulerCore.newCard', () => {
           return { source: 'second' }
         },
       },
-    }
+    })
     const namedScheduler = createSM2NumericScheduler().use(
       secondMiddleware,
       firstMiddleware,
@@ -281,7 +263,7 @@ describe('SchedulerCore.newCard', () => {
 
   it('lets review middleware read and update desiredRetention', () => {
     const seen: number[] = []
-    const retentionMiddleware = {
+    const retentionMiddleware = defineMiddleware({
       name: retentionMiddlewareName,
       handlers: {
         review(ctx, next) {
@@ -295,10 +277,7 @@ describe('SchedulerCore.newCard', () => {
           return result
         },
       },
-    } satisfies Middleware<
-      Record<PropertyKey, never>,
-      typeof retentionMiddlewareName
-    >
+    })
     const retentionScheduler = createSM2NumericScheduler().use(
       retentionMiddleware,
       schedulerStatsMiddleware
@@ -319,7 +298,7 @@ describe('SchedulerCore.newCard', () => {
 
   it('lets middleware derive desiredRetention from candidate memory state', () => {
     const seen: unknown[] = []
-    const candidateMiddleware = {
+    const candidateMiddleware = defineMiddleware({
       name: Symbol('candidate-retention'),
       handlers: {
         review(ctx, next) {
@@ -333,7 +312,7 @@ describe('SchedulerCore.newCard', () => {
           return next()
         },
       },
-    } satisfies Middleware
+    })
     const candidateCore = createSM2NumericScheduler()
       .use(candidateMiddleware, schedulerStatsMiddleware)
       .create({ config: { weights: SM2_DEFAULT_WEIGHTS } })
@@ -357,7 +336,7 @@ describe('SchedulerCore.newCard', () => {
 
   it('lets middleware read the previous grade candidate separately', () => {
     const seen: unknown[] = []
-    const candidateMiddleware = {
+    const candidateMiddleware = defineMiddleware({
       name: Symbol('previous-candidate'),
       handlers: {
         review(ctx, next) {
@@ -377,7 +356,7 @@ describe('SchedulerCore.newCard', () => {
           return next()
         },
       },
-    } satisfies Middleware
+    })
     const candidateCore = createSM2NumericScheduler()
       .use(candidateMiddleware, schedulerStatsMiddleware)
       .create({ config: { weights: SM2_DEFAULT_WEIGHTS } })
@@ -415,7 +394,7 @@ describe('SchedulerCore.newCard', () => {
       },
     })
 
-    const cumulativeMiddleware = {
+    const cumulativeMiddleware = defineMiddleware({
       name: Symbol('cumulative-candidate'),
       handlers: {
         review(ctx, next) {
@@ -434,7 +413,7 @@ describe('SchedulerCore.newCard', () => {
           return next()
         },
       },
-    } satisfies Middleware
+    })
 
     const spiedScheduler = defineScheduler({
       model: SpiedSM2Model,
@@ -592,7 +571,7 @@ describe('SchedulerCore middleware handlers', () => {
     const card = core.newCard({ now: 0 })
 
     for (const field of ['card', 'grade', 'now'] as const) {
-      const mutatingMiddleware = {
+      const mutatingMiddleware = defineMiddleware({
         name: Symbol(`mutate-${field}`),
         handlers: {
           review(ctx, next) {
@@ -600,7 +579,7 @@ describe('SchedulerCore middleware handlers', () => {
             return next()
           },
         },
-      } satisfies Middleware
+      })
       const mutatingCore = createSM2NumericScheduler()
         .use(mutatingMiddleware)
         .create({ config })
@@ -613,7 +592,7 @@ describe('SchedulerCore middleware handlers', () => {
 
   it('seeds review result with empty containers', () => {
     const seen: unknown[] = []
-    const resultMiddleware = {
+    const resultMiddleware = defineMiddleware({
       name: Symbol('seed-result'),
       handlers: {
         review(ctx, next) {
@@ -621,7 +600,7 @@ describe('SchedulerCore middleware handlers', () => {
           return next()
         },
       },
-    } satisfies Middleware
+    })
     const resultCore = createSM2NumericScheduler()
       .use(resultMiddleware, schedulerStatsMiddleware)
       .create({ config })
@@ -638,7 +617,7 @@ describe('SchedulerCore middleware handlers', () => {
   })
 
   it('validates the final review result with scheduler schemas', () => {
-    const invalidResultMiddleware = {
+    const invalidResultMiddleware = defineMiddleware({
       name: Symbol('invalid-result'),
       handlers: {
         review(ctx, next) {
@@ -652,7 +631,7 @@ describe('SchedulerCore middleware handlers', () => {
           return result
         },
       },
-    } satisfies Middleware
+    })
     const invalidResultCore = createSM2NumericScheduler()
       .use(invalidResultMiddleware, schedulerStatsMiddleware)
       .create({ config })
@@ -663,8 +642,8 @@ describe('SchedulerCore middleware handlers', () => {
     ).toThrow('Expected SM2 memory state')
   })
 
-  function traceMiddleware(name: string, trace: string[]): Middleware {
-    return {
+  function traceMiddleware(name: string, trace: string[]) {
+    return defineMiddleware({
       name,
       handlers: {
         review(ctx, next) {
@@ -681,7 +660,7 @@ describe('SchedulerCore middleware handlers', () => {
           return result as never
         },
       },
-    }
+    })
   }
 
   it('wraps review handlers in array order', () => {
@@ -764,7 +743,7 @@ describe('SchedulerCore middleware handlers', () => {
   })
 
   it('rejects calling next more than once', () => {
-    const badMiddleware = {
+    const badMiddleware = defineMiddleware({
       name: badMiddlewareName,
       handlers: {
         review(_ctx, next) {
@@ -772,7 +751,7 @@ describe('SchedulerCore middleware handlers', () => {
           return next()
         },
       },
-    } satisfies Middleware
+    })
     const badScheduler = createSM2NumericScheduler().use(
       badMiddleware,
       schedulerStatsMiddleware

--- a/packages/srs-kit/src/scheduler/base.spec.ts
+++ b/packages/srs-kit/src/scheduler/base.spec.ts
@@ -3,7 +3,7 @@ import { defineChrono } from '@/chrono/define-chrono.js'
 import { dateChrono } from '@/chrono/presets/date/chrono.js'
 import { numericChrono } from '@/chrono/presets/numeric/index.js'
 import type { Middleware } from '@/middleware/index.js'
-import { schedulerStatsMiddleware } from '@/middleware/stats.js'
+import { schedulerStatsMiddleware } from '@/middleware/stats/index.js'
 import { defineModel } from '@/model/model.js'
 import { SM2_DEFAULT_WEIGHTS, SM2Model } from '@/model/sm2.test.js'
 import { Rating, State } from '@/primitives/index.js'
@@ -117,7 +117,7 @@ describe('SchedulerCore.newCard', () => {
     expect(card.reps).toBe(0)
     expect(card.scheduleStatus).toBe('new')
     expect(card.scheduledDays).toBe(0)
-    expect(card.elapsedDays).toBe(0)
+    expect(card).not.toHaveProperty('elapsedDays')
     expect(card.lapses).toBe(0)
   })
 
@@ -519,15 +519,6 @@ describe('SchedulerCore.review', () => {
     expect(result.revlog.state).toBe(State.New)
     expect(result.revlog.scheduledDays).toBe(0)
     expect(result.revlog).not.toHaveProperty('elapsedDays')
-  })
-
-  it('computes elapsed days from chrono', () => {
-    const card = core.newCard()
-    const r1 = core.review({ card: card, grade: Rating.Good, now: 0 })
-    const r2 = core.review({ card: r1.card, grade: Rating.Good, now: 5 })
-
-    expect(r2.card.elapsedDays).toBe(5)
-    expect(r2.revlog.elapsedDays).toBe(5)
   })
 
   it('chains multiple reviews correctly', () => {
@@ -1017,7 +1008,6 @@ describe('card schema validation', () => {
       reps: 0,
       scheduleStatus: 'new',
       scheduledDays: 0,
-      elapsedDays: 0,
       lapses: 0,
     }
     expect(() =>

--- a/packages/srs-kit/src/scheduler/base.spec.ts
+++ b/packages/srs-kit/src/scheduler/base.spec.ts
@@ -269,12 +269,11 @@ describe('SchedulerCore.newCard', () => {
         review(ctx, next) {
           seen.push(ctx.desiredRetention)
           ctx.desiredRetention = 0.5
-          const result = next()
+          next()
           if (ctx.scheduledDays === undefined) {
             throw new Error('Expected scheduledDays')
           }
           seen.push(ctx.scheduledDays)
-          return result
         },
       },
     })
@@ -309,7 +308,7 @@ describe('SchedulerCore.newCard', () => {
           seen.push(
             ctx.candidate.nextInterval(memoryState, ctx.desiredRetention)
           )
-          return next()
+          next()
         },
       },
     })
@@ -353,7 +352,7 @@ describe('SchedulerCore.newCard', () => {
               ctx.desiredRetention
             ),
           })
-          return next()
+          next()
         },
       },
     })
@@ -410,7 +409,7 @@ describe('SchedulerCore.newCard', () => {
             const ms = ctx.candidate.step(g)
             ctx.candidate.nextInterval(ms, ctx.desiredRetention)
           }
-          return next()
+          next()
         },
       },
     })
@@ -576,7 +575,7 @@ describe('SchedulerCore middleware handlers', () => {
         handlers: {
           review(ctx, next) {
             ;(ctx.input as Record<typeof field, unknown>)[field] = null
-            return next()
+            next()
           },
         },
       })
@@ -597,7 +596,7 @@ describe('SchedulerCore middleware handlers', () => {
       handlers: {
         review(ctx, next) {
           seen.push(structuredClone(ctx.result))
-          return next()
+          next()
         },
       },
     })
@@ -621,14 +620,13 @@ describe('SchedulerCore middleware handlers', () => {
       name: Symbol('invalid-result'),
       handlers: {
         review(ctx, next) {
-          const result = next()
+          next()
           const runtimeCtx = ctx as {
             readonly result: {
               readonly card: Record<string, unknown>
             }
           }
           delete runtimeCtx.result.card.interval
-          return result
         },
       },
     })
@@ -648,16 +646,14 @@ describe('SchedulerCore middleware handlers', () => {
       handlers: {
         review(ctx, next) {
           trace.push(`${name}:review:before:${ctx.input.grade}`)
-          const result = next() as { readonly card: { readonly state: State } }
-          trace.push(`${name}:review:after:${result.card.state}`)
-          return result as never
+          next()
+          trace.push(`${name}:review:after:${ctx.result.card.state}`)
         },
         rollback(ctx, next) {
           const revlog = ctx.input.revlog as { readonly rating: Rating }
           trace.push(`${name}:rollback:before:${revlog.rating}`)
-          const result = next() as { readonly state: State }
-          trace.push(`${name}:rollback:after:${result.state}`)
-          return result as never
+          next()
+          trace.push(`${name}:rollback:after:${ctx.result.card.state}`)
         },
       },
     })
@@ -748,7 +744,7 @@ describe('SchedulerCore middleware handlers', () => {
       handlers: {
         review(_ctx, next) {
           next()
-          return next()
+          next()
         },
       },
     })

--- a/packages/srs-kit/src/scheduler/base.spec.ts
+++ b/packages/srs-kit/src/scheduler/base.spec.ts
@@ -116,7 +116,6 @@ describe('SchedulerCore.newCard', () => {
     expect(card.easeFactor).toBe(SM2_DEFAULT_WEIGHTS[2])
     expect(card.reps).toBe(0)
     expect(card.scheduleStatus).toBe('new')
-    expect(card.scheduledDays).toBe(0)
     expect(card).not.toHaveProperty('elapsedDays')
     expect(card.lapses).toBe(0)
   })
@@ -288,7 +287,12 @@ describe('SchedulerCore.newCard', () => {
         review(ctx, next) {
           seen.push(ctx.desiredRetention)
           ctx.desiredRetention = 0.5
-          return next()
+          const result = next()
+          if (ctx.scheduledDays === undefined) {
+            throw new Error('Expected scheduledDays')
+          }
+          seen.push(ctx.scheduledDays)
+          return result
         },
       },
     } satisfies Middleware<
@@ -309,8 +313,8 @@ describe('SchedulerCore.newCard', () => {
       now: 0,
     })
 
-    expect(seen).toEqual([0.9])
-    expect(result.card.scheduledDays).toBe(7)
+    expect(seen).toEqual([0.9, 7])
+    expect(result.card.interval).toBe(1)
   })
 
   it('lets middleware derive desiredRetention from candidate memory state', () => {
@@ -348,7 +352,7 @@ describe('SchedulerCore.newCard', () => {
       },
       7,
     ])
-    expect(result.card.scheduledDays).toBe(7)
+    expect(result.card.interval).toBe(1)
   })
 
   it('lets middleware read the previous grade candidate separately', () => {
@@ -465,7 +469,6 @@ describe('SchedulerCore.review', () => {
     expect(result.card.interval).toBeGreaterThan(0)
     expect(result.card.reps).toBe(1)
     expect(result.card.lapses).toBe(0)
-    expect(result.card.scheduledDays).toBeGreaterThan(0)
   })
 
   it('transitions New -> Review on Again by default', () => {
@@ -483,7 +486,7 @@ describe('SchedulerCore.review', () => {
     const r2 = core.review({
       card: r1.card,
       grade: Rating.Again,
-      now: r1.card.scheduledDays,
+      now: r1.card.interval,
     })
 
     expect(r2.card.state).toBe(State.Review)
@@ -507,7 +510,6 @@ describe('SchedulerCore.review', () => {
     expect(result.revlog.scheduleStatus).toBe('new')
     expect(result.revlog.interval).toBe(0)
     expect(result.revlog.reps).toBe(0)
-    expect(result.revlog.scheduledDays).toBe(0)
   })
 
   it('records rating and state in core revlog without stats middleware', () => {
@@ -517,7 +519,6 @@ describe('SchedulerCore.review', () => {
 
     expect(result.revlog.rating).toBe(Rating.Good)
     expect(result.revlog.state).toBe(State.New)
-    expect(result.revlog.scheduledDays).toBe(0)
     expect(result.revlog).not.toHaveProperty('elapsedDays')
   })
 
@@ -527,12 +528,12 @@ describe('SchedulerCore.review', () => {
     const r2 = core.review({
       card: r1.card,
       grade: Rating.Good,
-      now: r1.card.scheduledDays,
+      now: r1.card.interval,
     })
     const r3 = core.review({
       card: r2.card,
       grade: Rating.Good,
-      now: r1.card.scheduledDays + r2.card.scheduledDays,
+      now: r1.card.interval + r2.card.interval,
     })
 
     expect(r3.card.reps).toBe(3)
@@ -748,7 +749,7 @@ describe('SchedulerCore middleware handlers', () => {
     const result = tracedCore.review({
       card: first.card,
       grade: Rating.Good,
-      now: first.card.scheduledDays,
+      now: first.card.interval,
     })
     trace.length = 0
 
@@ -868,7 +869,6 @@ describe('SchedulerCore.rollback', () => {
     expect(restored.scheduleStatus).toBe('new')
     expect(restored.interval).toBe(0)
     expect(restored.reps).toBe(0)
-    expect(restored.scheduledDays).toBe(0)
   })
 
   it('returns an empty card when revlog status is new', () => {
@@ -882,7 +882,6 @@ describe('SchedulerCore.rollback', () => {
         easeFactor: 3,
         reps: 10,
         scheduleStatus: 'new',
-        scheduledDays: 0,
       },
     })
 
@@ -890,7 +889,6 @@ describe('SchedulerCore.rollback', () => {
     expect(restored.easeFactor).toBe(SM2_DEFAULT_WEIGHTS[2])
     expect(restored.reps).toBe(0)
     expect(restored.scheduleStatus).toBe('new')
-    expect(restored.scheduledDays).toBe(0)
   })
 
   it('restores lapses on lapse rollback', () => {
@@ -899,7 +897,7 @@ describe('SchedulerCore.rollback', () => {
     const r2 = core.review({
       card: r1.card,
       grade: Rating.Again,
-      now: r1.card.scheduledDays,
+      now: r1.card.interval,
     })
 
     expect(r2.card.lapses).toBe(1)
@@ -1007,7 +1005,6 @@ describe('card schema validation', () => {
       easeFactor: 2.5,
       reps: 0,
       scheduleStatus: 'new',
-      scheduledDays: 0,
       lapses: 0,
     }
     expect(() =>

--- a/packages/srs-kit/src/scheduler/base.spec.ts
+++ b/packages/srs-kit/src/scheduler/base.spec.ts
@@ -518,6 +518,7 @@ describe('SchedulerCore.review', () => {
     expect(result.revlog.rating).toBe(Rating.Good)
     expect(result.revlog.state).toBe(State.New)
     expect(result.revlog.scheduledDays).toBe(0)
+    expect(result.revlog).not.toHaveProperty('elapsedDays')
   })
 
   it('computes elapsed days from chrono', () => {
@@ -525,6 +526,7 @@ describe('SchedulerCore.review', () => {
     const r1 = core.review({ card: card, grade: Rating.Good, now: 0 })
     const r2 = core.review({ card: r1.card, grade: Rating.Good, now: 5 })
 
+    expect(r2.card.elapsedDays).toBe(5)
     expect(r2.revlog.elapsedDays).toBe(5)
   })
 

--- a/packages/srs-kit/src/scheduler/base.ts
+++ b/packages/srs-kit/src/scheduler/base.ts
@@ -11,6 +11,7 @@ import type {
 } from '@/middleware/index.js'
 import type { AnyModel, AnyModelCore } from '@/model/model.js'
 import { type Grade, grades } from '@/primitives/rating.js'
+import { State } from '@/primitives/state.js'
 import type { Mutable, SchemaInput } from '@/schema/index.js'
 import {
   composeMiddleware,
@@ -273,7 +274,7 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
       if (chronoRevlogSchema) {
         time = parse(this.chrono.projection, {
           revlog: revlog,
-        }).current
+        }).previous
       } else {
         time = this.chronoCore.now()
       }
@@ -386,10 +387,13 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
     ctx.scheduledDays = scheduledDays
 
     Object.assign(result.card, newMemoryState, {
+      state: State.Review,
       scheduleStatus: 'review',
       scheduledDays,
     })
     Object.assign(result.revlog, memoryState, {
+      rating: grade,
+      state: prepared.card.state,
       scheduleStatus: prepared.card.scheduleStatus,
       scheduledDays: prepared.card.scheduledDays,
     })
@@ -406,6 +410,7 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
     const revlog = ctx.input.revlog
 
     Object.assign(result.card, parse(this.model.schema.memoryState, revlog))
+    result.card.state = revlog.state
     result.card.scheduleStatus = revlog.scheduleStatus
     result.card.scheduledDays = revlog.scheduledDays
     this.applyRollbackChronoDefaults(result, revlog)

--- a/packages/srs-kit/src/scheduler/base.ts
+++ b/packages/srs-kit/src/scheduler/base.ts
@@ -5,6 +5,10 @@ import type {
   ChronoDefaultRuntimeFn,
   ChronoProjectionRuntimeSchema,
 } from '@/chrono/chrono.js'
+import type {
+  AnyMiddleware,
+  ReviewCandidateContext,
+} from '@/middleware/index.js'
 import type { AnyModel, AnyModelCore } from '@/model/model.js'
 import { type Grade, grades } from '@/primitives/rating.js'
 import type { Mutable, SchemaInput } from '@/schema/index.js'
@@ -16,7 +20,6 @@ import {
 } from '@/schema/index.js'
 import { getParsedCardMemoryState } from './compose-schema.js'
 import type { SchedulerDefaultValueFactory } from './default-value.js'
-import type { AnyMiddleware, ReviewCandidateContext } from './middleware.js'
 import type {
   BlankSchedulerEnv,
   PreviewResult,

--- a/packages/srs-kit/src/scheduler/base.ts
+++ b/packages/srs-kit/src/scheduler/base.ts
@@ -1,0 +1,476 @@
+/** biome-ignore-all lint/suspicious/noExplicitAny: runtime generic dispatch */
+import type {
+  AnyChrono,
+  AnyChronoCore,
+  ChronoDefaultRuntimeFn,
+  ChronoProjectionRuntimeSchema,
+} from '@/chrono/chrono.js'
+import type { AnyModel, AnyModelCore } from '@/model/model.js'
+import { type Grade, grades } from '@/primitives/rating.js'
+import type { Mutable, SchemaInput } from '@/schema/index.js'
+import {
+  composeMiddleware,
+  createLazyIterable,
+  parse,
+  withCache,
+} from '@/schema/index.js'
+import { getParsedCardMemoryState } from './compose-schema.js'
+import type { SchedulerDefaultValueFactory } from './default-value.js'
+import type { AnyMiddleware, ReviewCandidateContext } from './middleware.js'
+import type {
+  BlankSchedulerEnv,
+  PreviewResult,
+  ScheduleResult,
+  SchedulerCore,
+  SchedulerCoreEnv,
+  SchedulerSchema,
+} from './scheduler.js'
+
+export interface BaseSchedulerContext<Env extends BlankSchedulerEnv> {
+  readonly model: AnyModel
+  readonly chrono: AnyChrono
+  readonly schema: SchedulerSchema<Env>
+  readonly defaultValue: SchedulerDefaultValueFactory
+  readonly middlewares?: readonly AnyMiddleware[]
+  readonly config: SchemaInput<Env['config']>
+}
+
+interface PreparedReview<Env extends BlankSchedulerEnv> {
+  readonly card: Readonly<SchedulerCoreEnv<Env>['card']['output']>
+  readonly time: {
+    readonly previous: SchedulerCoreEnv<Env>['chrono']
+    readonly current: SchedulerCoreEnv<Env>['chrono']
+  }
+  readonly elapsedDays: number
+  readonly memoryState: Record<string, unknown>
+  readonly retrievability?: number
+  readonly candidate: {
+    readonly step: (grade: Grade) => Record<string, unknown>
+    readonly nextInterval: (
+      memoryState: Readonly<Record<string, unknown>>,
+      desiredRetention: number
+    ) => number
+  }
+}
+
+type ReviewResultDraft<Env extends BlankSchedulerEnv> = {
+  readonly card: Partial<Mutable<SchedulerCoreEnv<Env>['card']['output']>> &
+    Record<string, unknown>
+  readonly revlog: Partial<Mutable<SchedulerCoreEnv<Env>['revlog']['output']>> &
+    Record<string, unknown>
+}
+
+type RollbackResultDraft<Env extends BlankSchedulerEnv> = {
+  readonly card: Partial<Mutable<SchedulerCoreEnv<Env>['card']['output']>> &
+    Record<string, unknown>
+}
+
+type ReviewMiddlewareOperationContext<Env extends BlankSchedulerEnv> = {
+  readonly config: Readonly<SchedulerCoreEnv<Env>['config']>
+  readonly input: {
+    readonly card: Readonly<SchedulerCoreEnv<Env>['card']['output']>
+    readonly grade: Grade
+    readonly now: SchedulerCoreEnv<Env>['chrono']
+  }
+  desiredRetention: number
+  readonly elapsedDays: number
+  scheduledDays?: number
+  readonly candidate: ReviewCandidateContext
+  result: ReviewResultDraft<Env>
+}
+
+type RollbackMiddlewareOperationContext<Env extends BlankSchedulerEnv> = {
+  readonly config: Readonly<SchedulerCoreEnv<Env>['config']>
+  readonly input: {
+    readonly card: Readonly<SchedulerCoreEnv<Env>['card']['output']>
+    readonly revlog: Readonly<SchedulerCoreEnv<Env>['revlog']['output']>
+  }
+  result: RollbackResultDraft<Env>
+}
+
+type ReviewRuntimeHandler<Env extends BlankSchedulerEnv> = (
+  operation: ReviewMiddlewareOperationContext<Env>,
+  next: () => ReviewResultDraft<Env>
+) => ReviewResultDraft<Env>
+
+type RollbackRuntimeHandler<Env extends BlankSchedulerEnv> = (
+  operation: RollbackMiddlewareOperationContext<Env>,
+  next: () => Readonly<Record<string, any>>
+) => Readonly<Record<string, any>>
+
+type ReviewInputContext<Env extends BlankSchedulerEnv> =
+  ReviewMiddlewareOperationContext<Env>['input']
+
+class ReviewInput<Env extends BlankSchedulerEnv>
+  implements ReviewInputContext<Env>
+{
+  constructor(private input: ReviewMiddlewareOperationContext<Env>['input']) {}
+
+  get card(): ReviewInputContext<Env>['card'] {
+    return this.input.card
+  }
+
+  set card(_value: ReviewInputContext<Env>['card']) {
+    throw new Error('Review input card cannot be changed')
+  }
+
+  get grade(): Grade {
+    return this.input.grade
+  }
+
+  set grade(_value: Grade) {
+    throw new Error('Review input grade cannot be changed')
+  }
+
+  get now(): SchedulerCoreEnv<Env>['chrono'] {
+    return this.input.now
+  }
+
+  set now(_value: SchedulerCoreEnv<Env>['chrono']) {
+    throw new Error('Review input now cannot be changed')
+  }
+}
+
+export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
+  implements SchedulerCore<SchedulerCoreEnv<Env>>
+{
+  readonly config: Readonly<SchedulerCoreEnv<Env>['config']>
+
+  private readonly model: AnyModel
+  private readonly chrono: AnyChrono
+  private readonly defaultValue: SchedulerDefaultValueFactory
+  private readonly modelCore: AnyModelCore
+  private readonly chronoCore: AnyChronoCore
+  private readonly schema: SchedulerSchema<Env>
+  private readonly reviewHandlers: readonly (
+    | ReviewRuntimeHandler<Env>
+    | undefined
+  )[]
+  private readonly rollbackHandlers: readonly (
+    | RollbackRuntimeHandler<Env>
+    | undefined
+  )[]
+
+  constructor(ctx: BaseSchedulerContext<Env>) {
+    const { model, chrono, schema, defaultValue, middlewares = [] } = ctx
+    this.model = model
+    this.chrono = chrono
+    this.schema = schema
+    this.defaultValue = defaultValue
+
+    const config = parse(schema.config, ctx.config)
+
+    this.config = config
+    this.modelCore = model.create({ config })
+    this.chronoCore = Reflect.apply(chrono.create, chrono, [
+      { config: config.chrono },
+    ])
+    this.reviewHandlers = middlewares.map(
+      (middleware) => middleware.handlers?.review
+    ) as readonly (ReviewRuntimeHandler<Env> | undefined)[]
+    this.rollbackHandlers = middlewares.map(
+      (middleware) => middleware.handlers?.rollback
+    ) as readonly (RollbackRuntimeHandler<Env> | undefined)[]
+  }
+
+  newCard = (options?: {
+    readonly now?: SchedulerCoreEnv<Env>['chrono']
+  }): SchedulerCoreEnv<Env>['card']['output'] => {
+    const now = this.parseNow(options?.now ?? this.chronoCore.now())
+    return this.defaultValue.newCard<SchedulerCoreEnv<Env>['card']['output']>({
+      config: this.config,
+      time: now,
+    })
+  }
+
+  review = (input: {
+    readonly card: SchedulerCoreEnv<Env>['card']['input']
+    readonly grade: Grade
+    readonly now?: SchedulerCoreEnv<Env>['chrono']
+  }): ScheduleResult<
+    SchedulerCoreEnv<Env>['card']['output'],
+    SchedulerCoreEnv<Env>['revlog']['output']
+  > => {
+    const { card: inputCard, grade } = input
+    const now = this.parseNow(input.now ?? this.chronoCore.now())
+    const prepared = this.prepareReview(inputCard, now)
+    const ctx: ReviewMiddlewareOperationContext<Env> = {
+      config: this.config,
+      input: new ReviewInput<Env>({ card: prepared.card, grade, now }),
+      desiredRetention: this.config.desiredRetention,
+      elapsedDays: prepared.elapsedDays,
+      candidate: prepared.candidate,
+      result: { card: {}, revlog: {} },
+    }
+
+    composeMiddleware(this.reviewHandlers, ctx, (ctx) =>
+      this.finalizeReview(prepared, ctx)
+    )
+    return {
+      card: parse(
+        this.schema.card,
+        ctx.result.card
+      ) as SchedulerCoreEnv<Env>['card']['output'],
+      revlog: parse(
+        this.schema.revlog,
+        ctx.result.revlog
+      ) as SchedulerCoreEnv<Env>['revlog']['output'],
+    }
+  }
+
+  preview = (input: {
+    readonly card: SchedulerCoreEnv<Env>['card']['input']
+    readonly now?: SchedulerCoreEnv<Env>['chrono']
+  }): PreviewResult<
+    SchedulerCoreEnv<Env>['card']['output'],
+    SchedulerCoreEnv<Env>['revlog']['output']
+  > => {
+    const inputCard = input.card
+    const now = this.parseNow(input.now ?? this.chronoCore.now())
+    const prepared = this.prepareReview(inputCard, now)
+
+    return createLazyIterable(grades, (grade) => {
+      const ctx: ReviewMiddlewareOperationContext<Env> = {
+        config: this.config,
+        input: new ReviewInput<Env>({ card: prepared.card, grade, now }),
+        desiredRetention: this.config.desiredRetention,
+        elapsedDays: prepared.elapsedDays,
+        candidate: prepared.candidate,
+        result: { card: {}, revlog: {} },
+      }
+      composeMiddleware(this.reviewHandlers, ctx, (ctx) =>
+        this.finalizeReview(prepared, ctx)
+      )
+      return {
+        grade,
+        card: parse(
+          this.schema.card,
+          ctx.result.card
+        ) as SchedulerCoreEnv<Env>['card']['output'],
+        revlog: parse(
+          this.schema.revlog,
+          ctx.result.revlog
+        ) as SchedulerCoreEnv<Env>['revlog']['output'],
+      }
+    })
+  }
+
+  rollback = (input: {
+    readonly card: SchedulerCoreEnv<Env>['card']['output']
+    readonly revlog: SchedulerCoreEnv<Env>['revlog']['output']
+  }): SchedulerCoreEnv<Env>['card']['output'] => {
+    const { card: inputCard, revlog: inputRevlog } = input
+    const revlog = parse(
+      this.schema.revlog,
+      inputRevlog
+    ) as SchedulerCoreEnv<Env>['revlog']['output']
+    if (revlog.scheduleStatus === 'new') {
+      let time = null
+      const chronoRevlogSchema = this.chrono.schema.revlog
+      if (chronoRevlogSchema) {
+        time = parse(this.chrono.projection, {
+          revlog: revlog,
+        }).current
+      } else {
+        time = this.chronoCore.now()
+      }
+
+      return parse(
+        this.schema.card,
+        this.defaultValue.newCard<SchedulerCoreEnv<Env>['card']['output']>({
+          config: this.config,
+          time,
+        })
+      ) as SchedulerCoreEnv<Env>['card']['output']
+    }
+
+    const card = parse(
+      this.schema.card,
+      inputCard
+    ) as SchedulerCoreEnv<Env>['card']['output']
+
+    const ctx: RollbackMiddlewareOperationContext<Env> = {
+      config: this.config,
+      input: {
+        card: Object.freeze(card),
+        revlog: Object.freeze(revlog),
+      },
+      result: { card: {} },
+    }
+
+    composeMiddleware(this.rollbackHandlers, ctx, (ctx) =>
+      this.finalizeRollback(ctx)
+    )
+
+    return parse(
+      this.schema.card,
+      ctx.result.card
+    ) as SchedulerCoreEnv<Env>['card']['output']
+  }
+
+  private prepareReview(
+    inputCard: SchedulerCoreEnv<Env>['card']['input'],
+    now: SchedulerCoreEnv<Env>['chrono']
+  ): PreparedReview<Env> {
+    const parsedCard = parse(
+      this.schema.card,
+      inputCard
+    ) as SchedulerCoreEnv<Env>['card']['output']
+    const memoryState = getParsedCardMemoryState(parsedCard) as
+      | Record<string, unknown>
+      | undefined
+    if (!memoryState) {
+      throw new Error('Parsed scheduler card is missing model memory state')
+    }
+
+    const card = Object.freeze(parsedCard)
+    const time = parse<ChronoProjectionRuntimeSchema>(this.chrono.projection, {
+      card,
+      time: now,
+    }) as PreparedReview<Env>['time']
+
+    const elapsedDays = this.chronoCore.difference(time.previous, time.current)
+
+    const retrievability = this.modelCore.forgettingCurve(
+      memoryState,
+      elapsedDays
+    )
+    const step = withCache(
+      (grade: Grade) =>
+        this.modelCore.step({
+          memoryState,
+          rating: grade,
+          elapsedDays,
+          retrievability,
+        }),
+      { lru: false }
+    )
+    const nextInterval = withCache(
+      ([nextMemoryState, desiredRetention]: readonly [
+        Readonly<Record<string, unknown>>,
+        number,
+      ]) => this.modelCore.nextInterval(nextMemoryState, desiredRetention),
+      { lru: false }
+    )
+
+    return {
+      card,
+      time,
+      elapsedDays,
+      memoryState,
+      retrievability,
+      candidate: {
+        step,
+        nextInterval(memoryState, desiredRetention) {
+          return nextInterval([memoryState, desiredRetention])
+        },
+      },
+    }
+  }
+
+  private finalizeReview(
+    prepared: PreparedReview<Env>,
+    ctx: ReviewMiddlewareOperationContext<Env>
+  ): ReviewResultDraft<Env> {
+    const { memoryState } = prepared
+    const { grade } = ctx.input
+    const result = ctx.result
+    const newMemoryState = ctx.candidate.step(grade)
+    const scheduledDays = ctx.candidate.nextInterval(
+      newMemoryState,
+      ctx.desiredRetention
+    )
+    ctx.scheduledDays = scheduledDays
+
+    Object.assign(result.card, newMemoryState, {
+      scheduleStatus: 'review',
+      scheduledDays,
+    })
+    Object.assign(result.revlog, memoryState, {
+      scheduleStatus: prepared.card.scheduleStatus,
+      scheduledDays: prepared.card.scheduledDays,
+    })
+    this.applyChronoDefaults(result, prepared, scheduledDays)
+
+    ctx.result = result
+    return ctx.result
+  }
+
+  private finalizeRollback(
+    ctx: RollbackMiddlewareOperationContext<Env>
+  ): Readonly<Record<string, any>> {
+    const result = ctx.result
+    const revlog = ctx.input.revlog
+
+    Object.assign(result.card, parse(this.model.schema.memoryState, revlog))
+    result.card.scheduleStatus = revlog.scheduleStatus
+    result.card.scheduledDays = revlog.scheduledDays
+    this.applyRollbackChronoDefaults(result, revlog)
+
+    ctx.result = result
+    return ctx.result.card
+  }
+
+  private applyChronoDefaults(
+    result: ReviewResultDraft<Env>,
+    prepared: PreparedReview<Env>,
+    scheduledDays: number
+  ): void {
+    const chronoCardDefault = this.chrono.defaultValue
+      ?.card as ChronoDefaultRuntimeFn
+    if (chronoCardDefault) {
+      Object.assign(
+        result.card,
+        chronoCardDefault({
+          config: this.config.chrono,
+          time: this.chronoCore.add(prepared.time.current, scheduledDays),
+          previous: prepared.time,
+        })
+      )
+    }
+
+    const chronoRevlogDefault = this.chrono.defaultValue
+      ?.revlog as ChronoDefaultRuntimeFn
+    if (chronoRevlogDefault) {
+      Object.assign(
+        result.revlog,
+        chronoRevlogDefault({
+          config: this.config.chrono,
+          time: prepared.time.current,
+          previous: prepared.time,
+        })
+      )
+    }
+  }
+
+  private applyRollbackChronoDefaults(
+    result: RollbackResultDraft<Env>,
+    revlog: Readonly<SchedulerCoreEnv<Env>['revlog']['output']>
+  ): void {
+    const chronoCardSchema = this.chrono.schema.card
+    if (!chronoCardSchema) {
+      return
+    }
+    const projection = parse<ChronoProjectionRuntimeSchema>(
+      this.chrono.projection,
+      {
+        revlog,
+      }
+    )
+    const cardFields = this.chrono.defaultValue?.card?.({
+      config: this.config.chrono,
+      previous: {
+        previous: 0,
+        current: projection.previous,
+      },
+      time: projection.current,
+    })
+    if (cardFields) {
+      Object.assign(result.card, cardFields)
+    }
+  }
+
+  private parseNow(now: unknown): SchedulerCoreEnv<Env>['chrono'] {
+    return parse(this.chrono.schema.time, now)
+  }
+}

--- a/packages/srs-kit/src/scheduler/base.ts
+++ b/packages/srs-kit/src/scheduler/base.ts
@@ -93,13 +93,13 @@ type RollbackMiddlewareOperationContext<Env extends BlankSchedulerEnv> = {
 
 type ReviewRuntimeHandler<Env extends BlankSchedulerEnv> = (
   operation: ReviewMiddlewareOperationContext<Env>,
-  next: () => ReviewResultDraft<Env>
-) => ReviewResultDraft<Env>
+  next: () => void
+) => void
 
 type RollbackRuntimeHandler<Env extends BlankSchedulerEnv> = (
   operation: RollbackMiddlewareOperationContext<Env>,
-  next: () => RollbackResultDraft<Env>['card']
-) => RollbackResultDraft<Env>['card']
+  next: () => void
+) => void
 
 type ReviewInputContext<Env extends BlankSchedulerEnv> =
   ReviewMiddlewareOperationContext<Env>['input']

--- a/packages/srs-kit/src/scheduler/base.ts
+++ b/packages/srs-kit/src/scheduler/base.ts
@@ -104,6 +104,8 @@ type RollbackRuntimeHandler<Env extends BlankSchedulerEnv> = (
 type ReviewInputContext<Env extends BlankSchedulerEnv> =
   ReviewMiddlewareOperationContext<Env>['input']
 
+const DEFAULT_DESIRED_RETENTION = 0.9
+
 class ReviewInput<Env extends BlankSchedulerEnv>
   implements ReviewInputContext<Env>
 {
@@ -200,7 +202,7 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
     const ctx: ReviewMiddlewareOperationContext<Env> = {
       config: this.config,
       input: new ReviewInput<Env>({ card: prepared.card, grade, now }),
-      desiredRetention: this.config.desiredRetention,
+      desiredRetention: DEFAULT_DESIRED_RETENTION,
       elapsedDays: prepared.elapsedDays,
       candidate: prepared.candidate,
       result: { card: {}, revlog: {} },
@@ -236,7 +238,7 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
       const ctx: ReviewMiddlewareOperationContext<Env> = {
         config: this.config,
         input: new ReviewInput<Env>({ card: prepared.card, grade, now }),
-        desiredRetention: this.config.desiredRetention,
+        desiredRetention: DEFAULT_DESIRED_RETENTION,
         elapsedDays: prepared.elapsedDays,
         candidate: prepared.candidate,
         result: { card: {}, revlog: {} },

--- a/packages/srs-kit/src/scheduler/base.ts
+++ b/packages/srs-kit/src/scheduler/base.ts
@@ -271,26 +271,6 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
       this.schema.revlog,
       inputRevlog
     ) as SchedulerCoreEnv<Env>['revlog']['output']
-    if (revlog.state === State.New) {
-      let time = null
-      const chronoRevlogSchema = this.chrono.schema.revlog
-      if (chronoRevlogSchema) {
-        time = parse(this.chrono.projection, {
-          revlog: revlog,
-        }).previous
-      } else {
-        time = this.chronoCore.now()
-      }
-
-      return parse(
-        this.schema.card,
-        this.defaultValue.newCard<SchedulerCoreEnv<Env>['card']['output']>({
-          config: this.config,
-          time,
-        })
-      ) as SchedulerCoreEnv<Env>['card']['output']
-    }
-
     const card = parse(
       this.schema.card,
       inputCard

--- a/packages/srs-kit/src/scheduler/base.ts
+++ b/packages/srs-kit/src/scheduler/base.ts
@@ -1,4 +1,3 @@
-/** biome-ignore-all lint/suspicious/noExplicitAny: runtime generic dispatch */
 import type {
   AnyChrono,
   AnyChronoCore,
@@ -99,8 +98,8 @@ type ReviewRuntimeHandler<Env extends BlankSchedulerEnv> = (
 
 type RollbackRuntimeHandler<Env extends BlankSchedulerEnv> = (
   operation: RollbackMiddlewareOperationContext<Env>,
-  next: () => Readonly<Record<string, any>>
-) => Readonly<Record<string, any>>
+  next: () => RollbackResultDraft<Env>['card']
+) => RollbackResultDraft<Env>['card']
 
 type ReviewInputContext<Env extends BlankSchedulerEnv> =
   ReviewMiddlewareOperationContext<Env>['input']
@@ -320,9 +319,7 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
       this.schema.card,
       inputCard
     ) as SchedulerCoreEnv<Env>['card']['output']
-    const memoryState = getParsedCardMemoryState(parsedCard) as
-      | Record<string, unknown>
-      | undefined
+    const memoryState = getParsedCardMemoryState(parsedCard)
     if (!memoryState) {
       throw new Error('Parsed scheduler card is missing model memory state')
     }
@@ -419,7 +416,7 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
 
   private finalizeRollback(
     ctx: RollbackMiddlewareOperationContext<Env>
-  ): Readonly<Record<string, any>> {
+  ): RollbackResultDraft<Env>['card'] {
     const result = ctx.result
     const revlog = ctx.input.revlog
 

--- a/packages/srs-kit/src/scheduler/base.ts
+++ b/packages/srs-kit/src/scheduler/base.ts
@@ -272,7 +272,7 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
       this.schema.revlog,
       inputRevlog
     ) as SchedulerCoreEnv<Env>['revlog']['output']
-    if (revlog.scheduleStatus === 'new') {
+    if (revlog.state === State.New) {
       let time = null
       const chronoRevlogSchema = this.chrono.schema.revlog
       if (chronoRevlogSchema) {

--- a/packages/srs-kit/src/scheduler/base.ts
+++ b/packages/srs-kit/src/scheduler/base.ts
@@ -77,7 +77,7 @@ type ReviewMiddlewareOperationContext<Env extends BlankSchedulerEnv> = {
   }
   desiredRetention: number
   readonly elapsedDays: number
-  scheduledDays?: number
+  scheduledDays: number | undefined
   readonly candidate: ReviewCandidateContext
   readonly result: ReviewResultDraft<Env>
 }
@@ -204,6 +204,7 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
       input: new ReviewInput<Env>({ card: prepared.card, grade, now }),
       desiredRetention: DEFAULT_DESIRED_RETENTION,
       elapsedDays: prepared.elapsedDays,
+      scheduledDays: undefined,
       candidate: prepared.candidate,
       result: { card: {}, revlog: {} },
     }
@@ -240,6 +241,7 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
         input: new ReviewInput<Env>({ card: prepared.card, grade, now }),
         desiredRetention: DEFAULT_DESIRED_RETENTION,
         elapsedDays: prepared.elapsedDays,
+        scheduledDays: undefined,
         candidate: prepared.candidate,
         result: { card: {}, revlog: {} },
       }
@@ -393,11 +395,11 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
     const { grade } = ctx.input
     const result = ctx.result
     const newMemoryState = ctx.candidate.step(grade)
-    const scheduledDays = ctx.candidate.nextInterval(
+    ctx.scheduledDays ??= ctx.candidate.nextInterval(
       newMemoryState,
       ctx.desiredRetention
     )
-    ctx.scheduledDays = scheduledDays
+    const scheduledDays = ctx.scheduledDays
 
     Object.assign(result.card, newMemoryState, {
       state: State.Review,

--- a/packages/srs-kit/src/scheduler/base.ts
+++ b/packages/srs-kit/src/scheduler/base.ts
@@ -1,7 +1,6 @@
 import type {
   AnyChrono,
   AnyChronoCore,
-  ChronoDefaultRuntimeFn,
   ChronoProjectionRuntimeSchema,
 } from '@/chrono/chrono.js'
 import type {
@@ -435,8 +434,7 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
     prepared: PreparedReview<Env>,
     scheduledDays: number
   ): void {
-    const chronoCardDefault = this.chrono.defaultValue
-      ?.card as ChronoDefaultRuntimeFn
+    const chronoCardDefault = this.chrono.defaultValue?.card
     if (chronoCardDefault) {
       Object.assign(
         result.card,
@@ -448,8 +446,7 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
       )
     }
 
-    const chronoRevlogDefault = this.chrono.defaultValue
-      ?.revlog as ChronoDefaultRuntimeFn
+    const chronoRevlogDefault = this.chrono.defaultValue?.revlog
     if (chronoRevlogDefault) {
       Object.assign(
         result.revlog,

--- a/packages/srs-kit/src/scheduler/base.ts
+++ b/packages/srs-kit/src/scheduler/base.ts
@@ -349,13 +349,29 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
         }),
       { lru: false }
     )
-    const nextInterval = withCache(
-      ([nextMemoryState, desiredRetention]: readonly [
-        Readonly<Record<string, unknown>>,
-        number,
-      ]) => this.modelCore.nextInterval(nextMemoryState, desiredRetention),
-      { lru: false }
-    )
+    const intervalCache = new Map<
+      Readonly<Record<string, unknown>>,
+      Map<number, number>
+    >()
+    const nextInterval = (
+      nextMemoryState: Readonly<Record<string, unknown>>,
+      desiredRetention: number
+    ): number => {
+      let inner = intervalCache.get(nextMemoryState)
+      if (inner) {
+        const cached = inner.get(desiredRetention)
+        if (cached !== undefined) return cached
+      } else {
+        inner = new Map()
+        intervalCache.set(nextMemoryState, inner)
+      }
+      const value = this.modelCore.nextInterval(
+        nextMemoryState,
+        desiredRetention
+      )
+      inner.set(desiredRetention, value)
+      return value
+    }
 
     return {
       card,
@@ -365,9 +381,7 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
       retrievability,
       candidate: {
         step,
-        nextInterval(memoryState, desiredRetention) {
-          return nextInterval([memoryState, desiredRetention])
-        },
+        nextInterval,
       },
     }
   }

--- a/packages/srs-kit/src/scheduler/base.ts
+++ b/packages/srs-kit/src/scheduler/base.ts
@@ -79,7 +79,7 @@ type ReviewMiddlewareOperationContext<Env extends BlankSchedulerEnv> = {
   readonly elapsedDays: number
   scheduledDays?: number
   readonly candidate: ReviewCandidateContext
-  result: ReviewResultDraft<Env>
+  readonly result: ReviewResultDraft<Env>
 }
 
 type RollbackMiddlewareOperationContext<Env extends BlankSchedulerEnv> = {
@@ -88,7 +88,7 @@ type RollbackMiddlewareOperationContext<Env extends BlankSchedulerEnv> = {
     readonly card: Readonly<SchedulerCoreEnv<Env>['card']['output']>
     readonly revlog: Readonly<SchedulerCoreEnv<Env>['revlog']['output']>
   }
-  result: RollbackResultDraft<Env>
+  readonly result: RollbackResultDraft<Env>
 }
 
 type ReviewRuntimeHandler<Env extends BlankSchedulerEnv> = (
@@ -412,8 +412,7 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
     })
     this.applyChronoDefaults(result, prepared, scheduledDays)
 
-    ctx.result = result
-    return ctx.result
+    return result
   }
 
   private finalizeRollback(
@@ -428,8 +427,7 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
     result.card.scheduledDays = revlog.scheduledDays
     this.applyRollbackChronoDefaults(result, revlog)
 
-    ctx.result = result
-    return ctx.result.card
+    return result.card
   }
 
   private applyChronoDefaults(

--- a/packages/srs-kit/src/scheduler/base.ts
+++ b/packages/srs-kit/src/scheduler/base.ts
@@ -404,13 +404,11 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
     Object.assign(result.card, newMemoryState, {
       state: State.Review,
       scheduleStatus: 'review',
-      scheduledDays,
     })
     Object.assign(result.revlog, memoryState, {
       rating: grade,
       state: prepared.card.state,
       scheduleStatus: prepared.card.scheduleStatus,
-      scheduledDays: prepared.card.scheduledDays,
     })
     this.applyChronoDefaults(result, prepared, scheduledDays)
 
@@ -426,7 +424,6 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
     Object.assign(result.card, parse(this.model.schema.memoryState, revlog))
     result.card.state = revlog.state
     result.card.scheduleStatus = revlog.scheduleStatus
-    result.card.scheduledDays = revlog.scheduledDays
     this.applyRollbackChronoDefaults(result, revlog)
 
     return result.card

--- a/packages/srs-kit/src/scheduler/base.ts
+++ b/packages/srs-kit/src/scheduler/base.ts
@@ -9,7 +9,7 @@ import type {
   ReviewCandidateContext,
 } from '@/middleware/index.js'
 import type { AnyModel, AnyModelCore } from '@/model/model.js'
-import { type Grade, grades } from '@/primitives/rating.js'
+import { type Grade, gradeSchema, grades } from '@/primitives/rating.js'
 import { State } from '@/primitives/state.js'
 import type { Mutable, SchemaInput } from '@/schema/index.js'
 import {
@@ -196,7 +196,8 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
     SchedulerCoreEnv<Env>['card']['output'],
     SchedulerCoreEnv<Env>['revlog']['output']
   > => {
-    const { card: inputCard, grade } = input
+    const { card: inputCard, grade: inputGrade } = input
+    const grade = parse(gradeSchema, inputGrade)
     const now = this.parseNow(input.now ?? this.chronoCore.now())
     const prepared = this.prepareReview(inputCard, now)
     const ctx: ReviewMiddlewareOperationContext<Env> = {

--- a/packages/srs-kit/src/scheduler/compose-schema.spec.ts
+++ b/packages/srs-kit/src/scheduler/compose-schema.spec.ts
@@ -19,7 +19,7 @@ describe('parsed card memory state', () => {
     const inputMemoryState: SM2State = {
       interval: 1,
       easeFactor: 2.5,
-      reps: 3,
+      reviewStep: 3,
     }
     const remembered = rememberParsedCardMemoryState(
       { source: 'fixture' },
@@ -31,7 +31,7 @@ describe('parsed card memory state', () => {
     expect(memoryState).toEqual({
       interval: 1,
       easeFactor: 2.5,
-      reps: 3,
+      reviewStep: 3,
     })
   })
 })

--- a/packages/srs-kit/src/scheduler/compose-schema.spec.ts
+++ b/packages/srs-kit/src/scheduler/compose-schema.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, expectTypeOf, it } from 'vitest'
+import type { SM2State } from '@/model/sm2.test.js'
+import {
+  getParsedCardMemoryState,
+  rememberParsedCardMemoryState,
+} from './compose-schema.js'
+
+describe('parsed card memory state', () => {
+  it('falls back to unknown record for unmarked cards', () => {
+    const memoryState = getParsedCardMemoryState({})
+
+    expectTypeOf(memoryState).toEqualTypeOf<
+      Record<string, unknown> | undefined
+    >()
+    expect(memoryState).toBeUndefined()
+  })
+
+  it('infers remembered memory state type from the card', () => {
+    const inputMemoryState: SM2State = {
+      interval: 1,
+      easeFactor: 2.5,
+      reps: 3,
+    }
+    const remembered = rememberParsedCardMemoryState(
+      { source: 'fixture' },
+      inputMemoryState
+    )
+    const memoryState = getParsedCardMemoryState(remembered)
+
+    expectTypeOf(memoryState).toEqualTypeOf<SM2State | undefined>()
+    expect(memoryState).toEqual({
+      interval: 1,
+      easeFactor: 2.5,
+      reps: 3,
+    })
+  })
+})

--- a/packages/srs-kit/src/scheduler/compose-schema.ts
+++ b/packages/srs-kit/src/scheduler/compose-schema.ts
@@ -1,9 +1,9 @@
 /** biome-ignore-all lint/suspicious/noExplicitAny: runtime generic dispatch */
 
 import type { AnyChrono } from '@/chrono/chrono.js'
+import type { AnyMiddleware } from '@/middleware/index.js'
 import type { AnyModel } from '@/model/model.js'
 import { defineSchema, isObject } from '@/schema/index.js'
-import type { AnyMiddleware } from './middleware.js'
 import type { SchedulerSchema } from './scheduler.js'
 
 function assignObjectFields(

--- a/packages/srs-kit/src/scheduler/compose-schema.ts
+++ b/packages/srs-kit/src/scheduler/compose-schema.ts
@@ -3,6 +3,8 @@
 import type { AnyChrono } from '@/chrono/chrono.js'
 import type { AnyMiddleware } from '@/middleware/index.js'
 import type { AnyModel } from '@/model/model.js'
+import { type Grade, gradeSchema } from '@/primitives/rating.js'
+import { type State, stateSchema } from '@/primitives/state.js'
 import { defineSchema, isObject } from '@/schema/index.js'
 import type { SchedulerSchema } from './scheduler.js'
 
@@ -19,12 +21,20 @@ function assignObjectFields(
 }
 
 const coreSchedulerFieldsSchema = defineSchema<{
+  readonly state: State
   readonly scheduleStatus: string
   readonly scheduledDays: number
 }>((value) => {
   const fields = value as Record<string, unknown> | null | undefined
-  const scheduleStatus = fields?.scheduleStatus
-  const scheduledDays = fields?.scheduledDays
+  if (!fields) {
+    return { issues: [{ message: 'Expected scheduleStatus string' }] }
+  }
+
+  const scheduleStatus = fields.scheduleStatus
+  const scheduledDays = fields.scheduledDays
+  const state = stateSchema['~standard'].validate(fields.state)
+  if (state.issues) return state
+
   if (typeof scheduleStatus !== 'string') {
     return { issues: [{ message: 'Expected scheduleStatus string' }] }
   }
@@ -32,7 +42,43 @@ const coreSchedulerFieldsSchema = defineSchema<{
     return { issues: [{ message: 'Expected finite scheduledDays' }] }
   }
 
-  return { value: { scheduleStatus, scheduledDays } }
+  return { value: { state: state.value, scheduleStatus, scheduledDays } }
+})
+
+const coreSchedulerRevlogFieldsSchema = defineSchema<{
+  readonly rating: Grade
+  readonly state: State
+  readonly scheduleStatus: string
+  readonly scheduledDays: number
+}>((value) => {
+  const fields = value as Record<string, unknown> | null | undefined
+  if (!fields) {
+    return { issues: [{ message: 'Expected scheduleStatus string' }] }
+  }
+
+  const scheduleStatus = fields.scheduleStatus
+  const scheduledDays = fields.scheduledDays
+  if (typeof scheduleStatus !== 'string') {
+    return { issues: [{ message: 'Expected scheduleStatus string' }] }
+  }
+  if (typeof scheduledDays !== 'number' || !Number.isFinite(scheduledDays)) {
+    return { issues: [{ message: 'Expected finite scheduledDays' }] }
+  }
+
+  const rating = gradeSchema['~standard'].validate(fields.rating)
+  if (rating.issues) return rating
+
+  const state = stateSchema['~standard'].validate(fields.state)
+  if (state.issues) return state
+
+  return {
+    value: {
+      scheduleStatus,
+      scheduledDays,
+      rating: rating.value,
+      state: state.value,
+    },
+  }
 })
 
 const parsedCardMemoryState = Symbol('parsedCardMemoryState')
@@ -128,6 +174,7 @@ export function composeSchema(ctx: {
     const coreFields = coreSchedulerFieldsSchema['~standard'].validate(value)
     if (coreFields.issues) return coreFields
     // Explicitly inject scheduler core fields into the parsed card.
+    card.state = coreFields.value.state
     card.scheduleStatus = coreFields.value.scheduleStatus
     card.scheduledDays = coreFields.value.scheduledDays
 
@@ -158,11 +205,14 @@ export function composeSchema(ctx: {
       Object.assign(result, chronoRevlog.value)
     }
 
-    const coreFields = coreSchedulerFieldsSchema['~standard'].validate(value)
+    const coreFields =
+      coreSchedulerRevlogFieldsSchema['~standard'].validate(value)
     if (coreFields.issues) return coreFields
     // Explicitly inject scheduler core fields into the parsed revlog.
     result.scheduleStatus = coreFields.value.scheduleStatus
     result.scheduledDays = coreFields.value.scheduledDays
+    result.rating = coreFields.value.rating
+    result.state = coreFields.value.state
 
     for (const middleware of middlewares) {
       const schema = middleware.schema?.revlog

--- a/packages/srs-kit/src/scheduler/compose-schema.ts
+++ b/packages/srs-kit/src/scheduler/compose-schema.ts
@@ -18,6 +18,23 @@ function assignObjectFields(
   }
 }
 
+const coreSchedulerFieldsSchema = defineSchema<{
+  readonly scheduleStatus: string
+  readonly scheduledDays: number
+}>((value) => {
+  const fields = value as Record<string, unknown> | null | undefined
+  const scheduleStatus = fields?.scheduleStatus
+  const scheduledDays = fields?.scheduledDays
+  if (typeof scheduleStatus !== 'string') {
+    return { issues: [{ message: 'Expected scheduleStatus string' }] }
+  }
+  if (typeof scheduledDays !== 'number' || !Number.isFinite(scheduledDays)) {
+    return { issues: [{ message: 'Expected finite scheduledDays' }] }
+  }
+
+  return { value: { scheduleStatus, scheduledDays } }
+})
+
 const parsedCardMemoryState = Symbol('parsedCardMemoryState')
 
 export function getParsedCardMemoryState(
@@ -60,7 +77,7 @@ export function composeSchema(ctx: {
     const modelResult = modelConfigSchema['~standard'].validate(value)
     if (modelResult.issues) return modelResult
 
-    let chronoValue: unknown
+    let chronoValue: unknown = {}
     if (chronoConfigSchema) {
       const chronoResult = chronoConfigSchema['~standard'].validate(
         value.chrono
@@ -72,11 +89,9 @@ export function composeSchema(ctx: {
     const result: Record<PropertyKey, unknown> = {
       // TODO: desiredRetention should be a required field in the future, but for now we will default it to 0.9 if not provided.
       desiredRetention: value.desiredRetention ?? 0.9,
+      chrono: chronoValue,
     }
     assignObjectFields(result, modelResult.value)
-    if (chronoValue !== undefined) {
-      result.chrono = chronoValue
-    }
 
     for (const middleware of middlewares) {
       const schema = middleware.schema?.config
@@ -110,6 +125,12 @@ export function composeSchema(ctx: {
       Object.assign(card, chronoCard.value)
     }
 
+    const coreFields = coreSchedulerFieldsSchema['~standard'].validate(value)
+    if (coreFields.issues) return coreFields
+    // Explicitly inject scheduler core fields into the parsed card.
+    card.scheduleStatus = coreFields.value.scheduleStatus
+    card.scheduledDays = coreFields.value.scheduledDays
+
     for (const middleware of middlewares) {
       const schema = middleware.schema?.card
       if (!schema) continue
@@ -136,6 +157,12 @@ export function composeSchema(ctx: {
       if (chronoRevlog.issues) return chronoRevlog
       Object.assign(result, chronoRevlog.value)
     }
+
+    const coreFields = coreSchedulerFieldsSchema['~standard'].validate(value)
+    if (coreFields.issues) return coreFields
+    // Explicitly inject scheduler core fields into the parsed revlog.
+    result.scheduleStatus = coreFields.value.scheduleStatus
+    result.scheduledDays = coreFields.value.scheduledDays
 
     for (const middleware of middlewares) {
       const schema = middleware.schema?.revlog

--- a/packages/srs-kit/src/scheduler/compose-schema.ts
+++ b/packages/srs-kit/src/scheduler/compose-schema.ts
@@ -18,9 +18,26 @@ function assignObjectFields(
   }
 }
 
-type ParsedSchedulerCard = {
-  readonly card: Record<string, unknown>
-  readonly memoryState: Record<string, any>
+const parsedCardMemoryState = Symbol('parsedCardMemoryState')
+
+export function getParsedCardMemoryState(
+  card: object
+): Record<string, any> | undefined {
+  return (card as Record<typeof parsedCardMemoryState, Record<string, any>>)[
+    parsedCardMemoryState
+  ]
+}
+
+function rememberParsedCardMemoryState<Card extends object>(
+  card: Card,
+  memoryState: Record<string, any>
+): Card {
+  const parsedCard = card as Record<
+    typeof parsedCardMemoryState,
+    Record<string, any>
+  >
+  parsedCard[parsedCardMemoryState] = memoryState
+  return card
 }
 
 export function composeSchema(ctx: {
@@ -35,7 +52,7 @@ export function composeSchema(ctx: {
   const chronoCardSchema = chronoSchema.card
   const chronoRevlogSchema = chronoSchema.revlog
 
-  const config = defineSchema((value: unknown) => {
+  const config = defineSchema<unknown, Record<string, unknown>>((value) => {
     if (!isObject(value)) {
       return { issues: [{ message: 'Expected scheduler config object' }] }
     }
@@ -76,7 +93,7 @@ export function composeSchema(ctx: {
     return { value: result }
   })
 
-  const card = defineSchema<unknown, ParsedSchedulerCard>((value) => {
+  const card = defineSchema<unknown, Record<string, unknown>>((value) => {
     if (!isObject(value)) {
       return { issues: [{ message: 'Expected card object' }] }
     }
@@ -101,10 +118,10 @@ export function composeSchema(ctx: {
       Object.assign(card, middlewareCard.value)
     }
 
-    return { value: { card, memoryState } }
+    return { value: rememberParsedCardMemoryState(card, memoryState) }
   })
 
-  const revlog = defineSchema((value: unknown) => {
+  const revlog = defineSchema<unknown, Record<string, unknown>>((value) => {
     if (!isObject(value)) {
       return { issues: [{ message: 'Expected revlog object' }] }
     }

--- a/packages/srs-kit/src/scheduler/compose-schema.ts
+++ b/packages/srs-kit/src/scheduler/compose-schema.ts
@@ -83,24 +83,34 @@ const coreSchedulerRevlogFieldsSchema = defineSchema<{
 
 const parsedCardMemoryState = Symbol('parsedCardMemoryState')
 
+type ParsedCardMemoryState<MemoryState extends object> = {
+  readonly [parsedCardMemoryState]: MemoryState
+}
+
+export function getParsedCardMemoryState<MemoryState extends object>(
+  card: ParsedCardMemoryState<MemoryState>
+): MemoryState | undefined
 export function getParsedCardMemoryState(
   card: object
-): Record<string, any> | undefined {
-  return (card as Record<typeof parsedCardMemoryState, Record<string, any>>)[
+): Record<string, unknown> | undefined
+export function getParsedCardMemoryState(card: object): object | undefined {
+  return (card as Partial<ParsedCardMemoryState<Record<string, unknown>>>)[
     parsedCardMemoryState
   ]
 }
 
-function rememberParsedCardMemoryState<Card extends object>(
+export function rememberParsedCardMemoryState<
+  Card extends object,
+  MemoryState extends object,
+>(
   card: Card,
-  memoryState: Record<string, any>
-): Card {
-  const parsedCard = card as Record<
-    typeof parsedCardMemoryState,
-    Record<string, any>
-  >
+  memoryState: MemoryState
+): Card & ParsedCardMemoryState<MemoryState> {
+  const parsedCard = card as Card & {
+    [parsedCardMemoryState]: MemoryState
+  }
   parsedCard[parsedCardMemoryState] = memoryState
-  return card
+  return parsedCard
 }
 
 export function composeSchema(ctx: {
@@ -110,7 +120,7 @@ export function composeSchema(ctx: {
 }): SchedulerSchema<any> {
   const { model, chrono, middlewares } = ctx
   const modelConfigSchema = model.schema.config
-  const chronoSchema = chrono.schema as any
+  const chronoSchema = chrono.schema
   const chronoConfigSchema = chronoSchema.config
   const chronoCardSchema = chronoSchema.card
   const chronoRevlogSchema = chronoSchema.revlog
@@ -162,7 +172,7 @@ export function composeSchema(ctx: {
     const modelResult = model.schema.memoryState['~standard'].validate(value)
     if (modelResult.issues) return modelResult
 
-    const memoryState = modelResult.value as Record<string, any>
+    const memoryState = modelResult.value as Record<string, unknown>
     const card: Record<string, unknown> = Object.assign({}, memoryState)
 
     if (chronoCardSchema) {

--- a/packages/srs-kit/src/scheduler/compose-schema.ts
+++ b/packages/srs-kit/src/scheduler/compose-schema.ts
@@ -80,16 +80,11 @@ export function composeSchema(ctx: {
   })
 
   const parseCoreFields = (
-    value: unknown,
+    fields: Record<string, unknown>,
     options?: { readonly rating?: boolean }
   ): StandardSchemaV1.Result<
     SchedulerCoreFields | SchedulerRevlogCoreFields
   > => {
-    const fields = value as Record<string, unknown> | null | undefined
-    if (!fields) {
-      return { issues: [{ message: 'Expected scheduleStatus string' }] }
-    }
-
     const scheduleStatus = scheduleStatusSchema['~standard'].validate(
       fields.scheduleStatus
     )

--- a/packages/srs-kit/src/scheduler/compose-schema.ts
+++ b/packages/srs-kit/src/scheduler/compose-schema.ts
@@ -1,0 +1,139 @@
+/** biome-ignore-all lint/suspicious/noExplicitAny: runtime generic dispatch */
+
+import type { AnyChrono } from '@/chrono/chrono.js'
+import type { AnyModel } from '@/model/model.js'
+import { defineSchema, isObject } from '@/schema/index.js'
+import type { AnyMiddleware } from './middleware.js'
+import type { SchedulerSchema } from './scheduler.js'
+
+function assignObjectFields(
+  target: Record<PropertyKey, unknown>,
+  source: object
+) {
+  const fields = source as Record<string, unknown>
+  for (const key in fields) {
+    if (Object.hasOwn(fields, key)) {
+      target[key] = fields[key]
+    }
+  }
+}
+
+type ParsedSchedulerCard = {
+  readonly card: Record<string, unknown>
+  readonly memoryState: Record<string, any>
+}
+
+export function composeSchema(ctx: {
+  readonly model: AnyModel
+  readonly chrono: AnyChrono
+  readonly middlewares: readonly AnyMiddleware[]
+}): SchedulerSchema<any> {
+  const { model, chrono, middlewares } = ctx
+  const modelConfigSchema = model.schema.config
+  const chronoSchema = chrono.schema as any
+  const chronoConfigSchema = chronoSchema.config
+  const chronoCardSchema = chronoSchema.card
+  const chronoRevlogSchema = chronoSchema.revlog
+
+  const config = defineSchema((value: unknown) => {
+    if (!isObject(value)) {
+      return { issues: [{ message: 'Expected scheduler config object' }] }
+    }
+
+    const modelResult = modelConfigSchema['~standard'].validate(value)
+    if (modelResult.issues) return modelResult
+
+    let chronoValue: unknown
+    if (chronoConfigSchema) {
+      const chronoResult = chronoConfigSchema['~standard'].validate(
+        value.chrono
+      )
+      if (chronoResult.issues) return chronoResult
+      chronoValue = chronoResult.value
+    }
+
+    const result: Record<PropertyKey, unknown> = {
+      // TODO: desiredRetention should be a required field in the future, but for now we will default it to 0.9 if not provided.
+      desiredRetention: value.desiredRetention ?? 0.9,
+    }
+    assignObjectFields(result, modelResult.value)
+    if (chronoValue !== undefined) {
+      result.chrono = chronoValue
+    }
+
+    for (const middleware of middlewares) {
+      const schema = middleware.schema?.config
+      if (!schema) {
+        continue
+      }
+      const middlewareResult = schema['~standard'].validate(value)
+      if (middlewareResult.issues) {
+        return middlewareResult
+      }
+      assignObjectFields(result, middlewareResult.value)
+    }
+
+    return { value: result }
+  })
+
+  const card = defineSchema<unknown, ParsedSchedulerCard>((value) => {
+    if (!isObject(value)) {
+      return { issues: [{ message: 'Expected card object' }] }
+    }
+
+    const modelResult = model.schema.memoryState['~standard'].validate(value)
+    if (modelResult.issues) return modelResult
+
+    const memoryState = modelResult.value as Record<string, any>
+    const card: Record<string, unknown> = Object.assign({}, memoryState)
+
+    if (chronoCardSchema) {
+      const chronoCard = chronoCardSchema['~standard'].validate(value)
+      if (chronoCard.issues) return chronoCard
+      Object.assign(card, chronoCard.value)
+    }
+
+    for (const middleware of middlewares) {
+      const schema = middleware.schema?.card
+      if (!schema) continue
+      const middlewareCard = schema['~standard'].validate(value)
+      if (middlewareCard.issues) return middlewareCard
+      Object.assign(card, middlewareCard.value)
+    }
+
+    return { value: { card, memoryState } }
+  })
+
+  const revlog = defineSchema((value: unknown) => {
+    if (!isObject(value)) {
+      return { issues: [{ message: 'Expected revlog object' }] }
+    }
+
+    const modelResult = model.schema.memoryState['~standard'].validate(value)
+    if (modelResult.issues) return modelResult
+
+    const result = modelResult.value as Record<string, unknown>
+
+    if (chronoRevlogSchema) {
+      const chronoRevlog = chronoRevlogSchema['~standard'].validate(value)
+      if (chronoRevlog.issues) return chronoRevlog
+      Object.assign(result, chronoRevlog.value)
+    }
+
+    for (const middleware of middlewares) {
+      const schema = middleware.schema?.revlog
+      if (!schema) continue
+      const middlewareRevlog = schema['~standard'].validate(value)
+      if (middlewareRevlog.issues) return middlewareRevlog
+      Object.assign(result, middlewareRevlog.value)
+    }
+
+    return { value: result }
+  })
+
+  return {
+    config,
+    card,
+    revlog,
+  }
+}

--- a/packages/srs-kit/src/scheduler/compose-schema.ts
+++ b/packages/srs-kit/src/scheduler/compose-schema.ts
@@ -236,5 +236,6 @@ export function composeSchema(ctx: {
     config,
     card,
     revlog,
+    scheduleStatus: scheduleStatusSchema,
   }
 }

--- a/packages/srs-kit/src/scheduler/compose-schema.ts
+++ b/packages/srs-kit/src/scheduler/compose-schema.ts
@@ -142,11 +142,7 @@ export function composeSchema(ctx: {
       chronoValue = chronoResult.value
     }
 
-    const result: Record<PropertyKey, unknown> = {
-      // TODO: desiredRetention should be a required field in the future, but for now we will default it to 0.9 if not provided.
-      desiredRetention: value.desiredRetention ?? 0.9,
-      chrono: chronoValue,
-    }
+    const result: Record<PropertyKey, unknown> = { chrono: chronoValue }
     assignObjectFields(result, modelResult.value)
 
     for (const middleware of middlewares) {

--- a/packages/srs-kit/src/scheduler/compose-schema.ts
+++ b/packages/srs-kit/src/scheduler/compose-schema.ts
@@ -3,9 +3,18 @@
 import type { AnyChrono } from '@/chrono/chrono.js'
 import type { AnyMiddleware } from '@/middleware/index.js'
 import type { AnyModel } from '@/model/model.js'
-import { type Grade, gradeSchema } from '@/primitives/rating.js'
-import { type State, stateSchema } from '@/primitives/state.js'
-import { defineSchema, isObject } from '@/schema/index.js'
+import { gradeSchema } from '@/primitives/rating.js'
+import { stateSchema } from '@/primitives/state.js'
+import { scheduleStatuses } from '@/primitives/status.js'
+import {
+  defineSchema,
+  isObject,
+  type StandardSchemaV1,
+} from '@/schema/index.js'
+import type {
+  SchedulerCoreFields,
+  SchedulerRevlogCoreFields,
+} from './fields.js'
 import type { SchedulerSchema } from './scheduler.js'
 
 function assignObjectFields(
@@ -19,67 +28,6 @@ function assignObjectFields(
     }
   }
 }
-
-const coreSchedulerFieldsSchema = defineSchema<{
-  readonly state: State
-  readonly scheduleStatus: string
-  readonly scheduledDays: number
-}>((value) => {
-  const fields = value as Record<string, unknown> | null | undefined
-  if (!fields) {
-    return { issues: [{ message: 'Expected scheduleStatus string' }] }
-  }
-
-  const scheduleStatus = fields.scheduleStatus
-  const scheduledDays = fields.scheduledDays
-  const state = stateSchema['~standard'].validate(fields.state)
-  if (state.issues) return state
-
-  if (typeof scheduleStatus !== 'string') {
-    return { issues: [{ message: 'Expected scheduleStatus string' }] }
-  }
-  if (typeof scheduledDays !== 'number' || !Number.isFinite(scheduledDays)) {
-    return { issues: [{ message: 'Expected finite scheduledDays' }] }
-  }
-
-  return { value: { state: state.value, scheduleStatus, scheduledDays } }
-})
-
-const coreSchedulerRevlogFieldsSchema = defineSchema<{
-  readonly rating: Grade
-  readonly state: State
-  readonly scheduleStatus: string
-  readonly scheduledDays: number
-}>((value) => {
-  const fields = value as Record<string, unknown> | null | undefined
-  if (!fields) {
-    return { issues: [{ message: 'Expected scheduleStatus string' }] }
-  }
-
-  const scheduleStatus = fields.scheduleStatus
-  const scheduledDays = fields.scheduledDays
-  if (typeof scheduleStatus !== 'string') {
-    return { issues: [{ message: 'Expected scheduleStatus string' }] }
-  }
-  if (typeof scheduledDays !== 'number' || !Number.isFinite(scheduledDays)) {
-    return { issues: [{ message: 'Expected finite scheduledDays' }] }
-  }
-
-  const rating = gradeSchema['~standard'].validate(fields.rating)
-  if (rating.issues) return rating
-
-  const state = stateSchema['~standard'].validate(fields.state)
-  if (state.issues) return state
-
-  return {
-    value: {
-      scheduleStatus,
-      scheduledDays,
-      rating: rating.value,
-      state: state.value,
-    },
-  }
-})
 
 const parsedCardMemoryState = Symbol('parsedCardMemoryState')
 
@@ -124,6 +72,60 @@ export function composeSchema(ctx: {
   const chronoConfigSchema = chronoSchema.config
   const chronoCardSchema = chronoSchema.card
   const chronoRevlogSchema = chronoSchema.revlog
+
+  const scheduleStatusSchema = defineSchema<string>((value) => {
+    if (typeof value !== 'string') {
+      return { issues: [{ message: 'Expected scheduleStatus string' }] }
+    }
+
+    let isKnownStatus = scheduleStatuses.includes(value as any)
+    for (const middleware of middlewares) {
+      if (isKnownStatus) break
+      isKnownStatus = middleware.scheduleStatus?.includes(value) === true
+    }
+    if (!isKnownStatus) {
+      return { issues: [{ message: 'Expected known scheduleStatus' }] }
+    }
+
+    return { value }
+  })
+
+  const parseCoreFields = (
+    value: unknown,
+    options?: { readonly rating?: boolean }
+  ): StandardSchemaV1.Result<
+    SchedulerCoreFields | SchedulerRevlogCoreFields
+  > => {
+    const fields = value as Record<string, unknown> | null | undefined
+    if (!fields) {
+      return { issues: [{ message: 'Expected scheduleStatus string' }] }
+    }
+
+    const scheduleStatus = scheduleStatusSchema['~standard'].validate(
+      fields.scheduleStatus
+    )
+    if (scheduleStatus.issues) return scheduleStatus
+
+    const state = stateSchema['~standard'].validate(fields.state)
+    if (state.issues) return state
+
+    if (!options?.rating) {
+      return {
+        value: { state: state.value, scheduleStatus: scheduleStatus.value },
+      }
+    }
+
+    const rating = gradeSchema['~standard'].validate(fields.rating)
+    if (rating.issues) return rating
+
+    return {
+      value: {
+        state: state.value,
+        scheduleStatus: scheduleStatus.value,
+        rating: rating.value,
+      },
+    }
+  }
 
   const config = defineSchema<unknown, Record<string, unknown>>((value) => {
     if (!isObject(value)) {
@@ -177,12 +179,11 @@ export function composeSchema(ctx: {
       Object.assign(card, chronoCard.value)
     }
 
-    const coreFields = coreSchedulerFieldsSchema['~standard'].validate(value)
+    const coreFields = parseCoreFields(value)
     if (coreFields.issues) return coreFields
     // Explicitly inject scheduler core fields into the parsed card.
     card.state = coreFields.value.state
     card.scheduleStatus = coreFields.value.scheduleStatus
-    card.scheduledDays = coreFields.value.scheduledDays
 
     for (const middleware of middlewares) {
       const schema = middleware.schema?.card
@@ -211,12 +212,12 @@ export function composeSchema(ctx: {
       Object.assign(result, chronoRevlog.value)
     }
 
-    const coreFields =
-      coreSchedulerRevlogFieldsSchema['~standard'].validate(value)
+    const coreFields = parseCoreFields(value, {
+      rating: true,
+    }) as StandardSchemaV1.Result<SchedulerRevlogCoreFields>
     if (coreFields.issues) return coreFields
     // Explicitly inject scheduler core fields into the parsed revlog.
     result.scheduleStatus = coreFields.value.scheduleStatus
-    result.scheduledDays = coreFields.value.scheduledDays
     result.rating = coreFields.value.rating
     result.state = coreFields.value.state
 

--- a/packages/srs-kit/src/scheduler/compose-schema.ts
+++ b/packages/srs-kit/src/scheduler/compose-schema.ts
@@ -7,6 +7,7 @@ import { gradeSchema } from '@/primitives/rating.js'
 import { stateSchema } from '@/primitives/state.js'
 import { scheduleStatuses } from '@/primitives/status.js'
 import {
+  assignObjectFields,
   defineSchema,
   isObject,
   type StandardSchemaV1,
@@ -16,18 +17,6 @@ import type {
   SchedulerRevlogCoreFields,
 } from './fields.js'
 import type { SchedulerSchema } from './scheduler.js'
-
-function assignObjectFields(
-  target: Record<PropertyKey, unknown>,
-  source: object
-) {
-  const fields = source as Record<string, unknown>
-  for (const key in fields) {
-    if (Object.hasOwn(fields, key)) {
-      target[key] = fields[key]
-    }
-  }
-}
 
 const parsedCardMemoryState = Symbol('parsedCardMemoryState')
 

--- a/packages/srs-kit/src/scheduler/compose-schema.ts
+++ b/packages/srs-kit/src/scheduler/compose-schema.ts
@@ -188,6 +188,7 @@ export function composeSchema(ctx: {
     const modelResult = model.schema.memoryState['~standard'].validate(value)
     if (modelResult.issues) return modelResult
 
+    // Reuse the parsed memory state for revlog hot paths to avoid another allocation.
     const result = modelResult.value as Record<string, unknown>
 
     if (chronoRevlogSchema) {

--- a/packages/srs-kit/src/scheduler/default-value.ts
+++ b/packages/srs-kit/src/scheduler/default-value.ts
@@ -3,9 +3,9 @@ import type {
   ChronoDefaultCtx,
   ChronoDefaultRuntimeFn,
 } from '@/chrono/chrono.js'
+import type { AnyMiddleware } from '@/middleware/index.js'
 import type { AnyModel } from '@/model/model.js'
 import { isFunction } from '@/schema/index.js'
-import type { AnyMiddleware } from './middleware.js'
 
 type DefaultValueConfig = Record<PropertyKey, unknown>
 

--- a/packages/srs-kit/src/scheduler/default-value.ts
+++ b/packages/srs-kit/src/scheduler/default-value.ts
@@ -5,6 +5,7 @@ import type {
 } from '@/chrono/chrono.js'
 import type { AnyMiddleware } from '@/middleware/index.js'
 import type { AnyModel } from '@/model/model.js'
+import { State } from '@/primitives/state.js'
 import { isFunction } from '@/schema/index.js'
 
 type DefaultValueConfig = Record<PropertyKey, unknown>
@@ -100,6 +101,7 @@ export function useComposeDefaultValue(ctx: {
       const card: Record<string, unknown> = model.defaultValue.memoryState({
         config,
       })
+      card.state = State.New
       card.scheduleStatus = 'new'
       card.scheduledDays = 0
       applyFieldDefaults({

--- a/packages/srs-kit/src/scheduler/default-value.ts
+++ b/packages/srs-kit/src/scheduler/default-value.ts
@@ -73,7 +73,7 @@ function applyFieldDefaults(ctx: {
     Object.assign(
       target,
       chronoDefault({
-        config: config.chrono ?? {},
+        config: config.chrono as Readonly<unknown>,
         time,
         previous,
       })
@@ -100,6 +100,8 @@ export function useComposeDefaultValue(ctx: {
       const card: Record<string, unknown> = model.defaultValue.memoryState({
         config,
       })
+      card.scheduleStatus = 'new'
+      card.scheduledDays = 0
       applyFieldDefaults({
         target: card,
         config,

--- a/packages/srs-kit/src/scheduler/default-value.ts
+++ b/packages/srs-kit/src/scheduler/default-value.ts
@@ -19,11 +19,17 @@ type DefaultValueTimeContext = DefaultValueContext & {
 }
 
 export type SchedulerDefaultValueFactory = {
-  readonly newCard: (ctx: DefaultValueContext & {
-    readonly time: unknown
-  }) => Record<string, unknown>
-  readonly card: (ctx: DefaultValueTimeContext) => Record<string, unknown>
-  readonly revlog: (ctx: DefaultValueTimeContext) => Record<string, unknown>
+  readonly newCard: <Card extends object = Record<string, unknown>>(
+    ctx: DefaultValueContext & {
+      readonly time: unknown
+    }
+  ) => Card
+  readonly card: <Card extends object = Record<string, unknown>>(
+    ctx: DefaultValueTimeContext
+  ) => Card
+  readonly revlog: <Revlog extends object = Record<string, unknown>>(
+    ctx: DefaultValueTimeContext
+  ) => Revlog
 }
 
 function applyMiddlewareDefaults(
@@ -87,7 +93,10 @@ export function useComposeDefaultValue(ctx: {
   const chronoRevlogDefault = resolveChronoDefault(chrono.defaultValue?.revlog)
 
   return {
-    newCard({ config, time }) {
+    newCard<Card extends object = Record<string, unknown>>({
+      config,
+      time,
+    }: DefaultValueContext & { readonly time: unknown }) {
       const card: Record<string, unknown> = model.defaultValue.memoryState({
         config,
       })
@@ -100,9 +109,13 @@ export function useComposeDefaultValue(ctx: {
         time,
       })
 
-      return card
+      return card as Card
     },
-    card({ config, time, previous }) {
+    card<Card extends object = Record<string, unknown>>({
+      config,
+      time,
+      previous,
+    }: DefaultValueTimeContext) {
       const card: Record<string, unknown> = {}
       applyFieldDefaults({
         target: card,
@@ -114,9 +127,13 @@ export function useComposeDefaultValue(ctx: {
         previous,
       })
 
-      return card
+      return card as Card
     },
-    revlog({ config, time, previous }) {
+    revlog<Revlog extends object = Record<string, unknown>>({
+      config,
+      time,
+      previous,
+    }: DefaultValueTimeContext) {
       const revlog: Record<string, unknown> = {}
       applyFieldDefaults({
         target: revlog,
@@ -128,7 +145,7 @@ export function useComposeDefaultValue(ctx: {
         previous,
       })
 
-      return revlog
+      return revlog as Revlog
     },
   }
 }

--- a/packages/srs-kit/src/scheduler/default-value.ts
+++ b/packages/srs-kit/src/scheduler/default-value.ts
@@ -1,0 +1,134 @@
+import type {
+  AnyChrono,
+  ChronoDefaultCtx,
+  ChronoDefaultRuntimeFn,
+} from '@/chrono/chrono.js'
+import type { AnyModel } from '@/model/model.js'
+import { isFunction } from '@/schema/index.js'
+import type { AnyMiddleware } from './middleware.js'
+
+type DefaultValueConfig = Record<PropertyKey, unknown>
+
+type DefaultValueContext = {
+  readonly config: DefaultValueConfig
+}
+
+type DefaultValueTimeContext = DefaultValueContext & {
+  readonly time: ChronoDefaultCtx<unknown, unknown>['time']
+  readonly previous?: ChronoDefaultCtx<unknown, unknown>['previous']
+}
+
+export type SchedulerDefaultValueFactory = {
+  readonly newCard: (ctx: DefaultValueContext & {
+    readonly time: unknown
+  }) => Record<string, unknown>
+  readonly card: (ctx: DefaultValueTimeContext) => Record<string, unknown>
+  readonly revlog: (ctx: DefaultValueTimeContext) => Record<string, unknown>
+}
+
+function applyMiddlewareDefaults(
+  target: Record<string, unknown>,
+  middlewares: readonly AnyMiddleware[],
+  key: 'card' | 'revlog',
+  config: DefaultValueConfig
+) {
+  for (const middleware of middlewares) {
+    const defaultValue = middleware.defaultValue?.[key]
+    if (isFunction(defaultValue)) {
+      Object.assign(
+        target,
+        defaultValue({
+          config,
+        })
+      )
+    }
+  }
+}
+
+function resolveChronoDefault(
+  value: unknown
+): ChronoDefaultRuntimeFn | undefined {
+  return isFunction(value) ? (value as ChronoDefaultRuntimeFn) : undefined
+}
+
+function applyFieldDefaults(ctx: {
+  readonly target: Record<string, unknown>
+  readonly config: DefaultValueConfig
+  readonly middlewares: readonly AnyMiddleware[]
+  readonly key: 'card' | 'revlog'
+  readonly chronoDefault?: ChronoDefaultRuntimeFn
+  readonly time: ChronoDefaultCtx<unknown, unknown>['time']
+  readonly previous?: ChronoDefaultCtx<unknown, unknown>['previous']
+}) {
+  const { target, config, middlewares, key, chronoDefault, time, previous } =
+    ctx
+
+  if (chronoDefault) {
+    Object.assign(
+      target,
+      chronoDefault({
+        config: config.chrono ?? {},
+        time,
+        previous,
+      })
+    )
+  }
+
+  applyMiddlewareDefaults(target, middlewares, key, config)
+}
+
+export function useComposeDefaultValue(ctx: {
+  readonly model: AnyModel
+  readonly chrono: AnyChrono
+  readonly middlewares: readonly AnyMiddleware[]
+}): SchedulerDefaultValueFactory {
+  const { model, chrono, middlewares } = ctx
+  const chronoCardDefault = resolveChronoDefault(chrono.defaultValue?.card)
+  const chronoRevlogDefault = resolveChronoDefault(chrono.defaultValue?.revlog)
+
+  return {
+    newCard({ config, time }) {
+      const card: Record<string, unknown> = model.defaultValue.memoryState({
+        config,
+      })
+      applyFieldDefaults({
+        target: card,
+        config,
+        middlewares,
+        key: 'card',
+        chronoDefault: chronoCardDefault,
+        time,
+      })
+
+      return card
+    },
+    card({ config, time, previous }) {
+      const card: Record<string, unknown> = {}
+      applyFieldDefaults({
+        target: card,
+        config,
+        middlewares,
+        key: 'card',
+        chronoDefault: chronoCardDefault,
+        time,
+        previous,
+      })
+
+      return card
+    },
+    revlog({ config, time, previous }) {
+      const revlog: Record<string, unknown> = {}
+      applyFieldDefaults({
+        target: revlog,
+        config,
+        middlewares,
+        key: 'revlog',
+        chronoDefault: chronoRevlogDefault,
+        time,
+        previous,
+      })
+
+      return revlog
+    },
+  }
+}

--- a/packages/srs-kit/src/scheduler/default-value.ts
+++ b/packages/srs-kit/src/scheduler/default-value.ts
@@ -103,7 +103,6 @@ export function useComposeDefaultValue(ctx: {
       })
       card.state = State.New
       card.scheduleStatus = 'new'
-      card.scheduledDays = 0
       applyFieldDefaults({
         target: card,
         config,

--- a/packages/srs-kit/src/scheduler/default-value.ts
+++ b/packages/srs-kit/src/scheduler/default-value.ts
@@ -14,33 +14,21 @@ type DefaultValueContext = {
   readonly config: DefaultValueConfig
 }
 
-type DefaultValueTimeContext = DefaultValueContext & {
-  readonly time: ChronoDefaultCtx<unknown, unknown>['time']
-  readonly previous?: ChronoDefaultCtx<unknown, unknown>['previous']
-}
-
 export type SchedulerDefaultValueFactory = {
   readonly newCard: <Card extends object = Record<string, unknown>>(
     ctx: DefaultValueContext & {
       readonly time: unknown
     }
   ) => Card
-  readonly card: <Card extends object = Record<string, unknown>>(
-    ctx: DefaultValueTimeContext
-  ) => Card
-  readonly revlog: <Revlog extends object = Record<string, unknown>>(
-    ctx: DefaultValueTimeContext
-  ) => Revlog
 }
 
-function applyMiddlewareDefaults(
+function applyMiddlewareCardDefaults(
   target: Record<string, unknown>,
   middlewares: readonly AnyMiddleware[],
-  key: 'card' | 'revlog',
   config: DefaultValueConfig
 ) {
   for (const middleware of middlewares) {
-    const defaultValue = middleware.defaultValue?.[key]
+    const defaultValue = middleware.defaultValue?.card
     if (isFunction(defaultValue)) {
       Object.assign(
         target,
@@ -58,17 +46,14 @@ function resolveChronoDefault(
   return isFunction(value) ? (value as ChronoDefaultRuntimeFn) : undefined
 }
 
-function applyFieldDefaults(ctx: {
+function applyNewCardDefaults(ctx: {
   readonly target: Record<string, unknown>
   readonly config: DefaultValueConfig
   readonly middlewares: readonly AnyMiddleware[]
-  readonly key: 'card' | 'revlog'
   readonly chronoDefault?: ChronoDefaultRuntimeFn
   readonly time: ChronoDefaultCtx<unknown, unknown>['time']
-  readonly previous?: ChronoDefaultCtx<unknown, unknown>['previous']
 }) {
-  const { target, config, middlewares, key, chronoDefault, time, previous } =
-    ctx
+  const { target, config, middlewares, chronoDefault, time } = ctx
 
   if (chronoDefault) {
     Object.assign(
@@ -76,12 +61,11 @@ function applyFieldDefaults(ctx: {
       chronoDefault({
         config: config.chrono as Readonly<unknown>,
         time,
-        previous,
       })
     )
   }
 
-  applyMiddlewareDefaults(target, middlewares, key, config)
+  applyMiddlewareCardDefaults(target, middlewares, config)
 }
 
 export function useComposeDefaultValue(ctx: {
@@ -91,7 +75,6 @@ export function useComposeDefaultValue(ctx: {
 }): SchedulerDefaultValueFactory {
   const { model, chrono, middlewares } = ctx
   const chronoCardDefault = resolveChronoDefault(chrono.defaultValue?.card)
-  const chronoRevlogDefault = resolveChronoDefault(chrono.defaultValue?.revlog)
 
   return {
     newCard<Card extends object = Record<string, unknown>>({
@@ -103,52 +86,15 @@ export function useComposeDefaultValue(ctx: {
       })
       card.state = State.New
       card.scheduleStatus = 'new'
-      applyFieldDefaults({
+      applyNewCardDefaults({
         target: card,
         config,
         middlewares,
-        key: 'card',
         chronoDefault: chronoCardDefault,
         time,
       })
 
       return card as Card
-    },
-    card<Card extends object = Record<string, unknown>>({
-      config,
-      time,
-      previous,
-    }: DefaultValueTimeContext) {
-      const card: Record<string, unknown> = {}
-      applyFieldDefaults({
-        target: card,
-        config,
-        middlewares,
-        key: 'card',
-        chronoDefault: chronoCardDefault,
-        time,
-        previous,
-      })
-
-      return card as Card
-    },
-    revlog<Revlog extends object = Record<string, unknown>>({
-      config,
-      time,
-      previous,
-    }: DefaultValueTimeContext) {
-      const revlog: Record<string, unknown> = {}
-      applyFieldDefaults({
-        target: revlog,
-        config,
-        middlewares,
-        key: 'revlog',
-        chronoDefault: chronoRevlogDefault,
-        time,
-        previous,
-      })
-
-      return revlog as Revlog
     },
   }
 }

--- a/packages/srs-kit/src/scheduler/define-scheduler.ts
+++ b/packages/srs-kit/src/scheduler/define-scheduler.ts
@@ -1,0 +1,78 @@
+/** biome-ignore-all lint/suspicious/noExplicitAny: runtime generic dispatch */
+
+import type { AnyChrono } from '@/chrono/chrono.js'
+import type { AnyModel } from '@/model/model.js'
+import { BaseScheduler } from './base.js'
+import { composeSchema } from './compose-schema.js'
+import { useComposeDefaultValue } from './default-value.js'
+import { SRSSchedulerError } from './error.js'
+import type { SchedulerEnvFor, SchedulerNameOf } from './infer.js'
+import type { AnyMiddleware } from './middleware.js'
+import type { ComposableScheduler } from './scheduler.js'
+
+type InitialSchedulerEnv<M extends AnyModel, C extends AnyChrono> = {
+  readonly [K in keyof SchedulerEnvFor<M, C, readonly []>]: SchedulerEnvFor<
+    M,
+    C,
+    readonly []
+  >[K]
+}
+
+// ============
+// defineScheduler
+// ============
+
+export function defineScheduler<
+  const M extends AnyModel,
+  const C extends AnyChrono,
+>(definition: {
+  readonly model: M
+  readonly chrono: C
+}): ComposableScheduler<SchedulerNameOf<M>, InitialSchedulerEnv<M, C>> {
+  const { model, chrono } = definition
+
+  /**
+   * Shared middleware pointer used by schema/core/defaultValue composition.
+   * use() mutates this array so existing composed runtime objects can observe
+   * newly registered middleware without rebuilding schemas or core factories.
+   */
+  const middlewares: AnyMiddleware[] = []
+
+  const defaultValue = useComposeDefaultValue({
+    model,
+    chrono,
+    middlewares,
+  })
+
+  const schedulerSchema = composeSchema({ model, chrono, middlewares })
+  let locked = false
+  const scheduler: ComposableScheduler<
+    SchedulerNameOf<M>,
+    InitialSchedulerEnv<M, C>
+  > = {
+    name: model.name,
+    schema: schedulerSchema,
+    create(ctx) {
+      locked = true
+      return new BaseScheduler<InitialSchedulerEnv<M, C>>({
+        model,
+        chrono,
+        schema: schedulerSchema,
+        defaultValue,
+        middlewares,
+        config: ctx.config,
+      })
+    },
+    use(...added) {
+      if (locked) {
+        throw new SRSSchedulerError(
+          'Cannot add middleware after scheduler.create()'
+        )
+      }
+      middlewares.push(...added)
+      return scheduler as never
+    },
+  }
+
+  return scheduler
+}

--- a/packages/srs-kit/src/scheduler/define-scheduler.ts
+++ b/packages/srs-kit/src/scheduler/define-scheduler.ts
@@ -1,13 +1,13 @@
 /** biome-ignore-all lint/suspicious/noExplicitAny: runtime generic dispatch */
 
 import type { AnyChrono } from '@/chrono/chrono.js'
+import type { AnyMiddleware } from '@/middleware/index.js'
 import type { AnyModel } from '@/model/model.js'
 import { BaseScheduler } from './base.js'
 import { composeSchema } from './compose-schema.js'
 import { useComposeDefaultValue } from './default-value.js'
 import { SRSSchedulerError } from './error.js'
 import type { SchedulerEnvFor, SchedulerNameOf } from './infer.js'
-import type { AnyMiddleware } from './middleware.js'
 import type { ComposableScheduler } from './scheduler.js'
 
 type InitialSchedulerEnv<M extends AnyModel, C extends AnyChrono> = {

--- a/packages/srs-kit/src/scheduler/define-scheduler.ts
+++ b/packages/srs-kit/src/scheduler/define-scheduler.ts
@@ -3,6 +3,7 @@
 import type { AnyChrono } from '@/chrono/chrono.js'
 import type { AnyMiddleware } from '@/middleware/index.js'
 import type { AnyModel } from '@/model/model.js'
+import type { Prettify } from '@/schema/index.js'
 import { BaseScheduler } from './base.js'
 import { composeSchema } from './compose-schema.js'
 import { useComposeDefaultValue } from './default-value.js'
@@ -10,13 +11,9 @@ import { SRSSchedulerError } from './error.js'
 import type { SchedulerEnvFor, SchedulerNameOf } from './infer.js'
 import type { ComposableScheduler } from './scheduler.js'
 
-type InitialSchedulerEnv<M extends AnyModel, C extends AnyChrono> = {
-  readonly [K in keyof SchedulerEnvFor<M, C, readonly []>]: SchedulerEnvFor<
-    M,
-    C,
-    readonly []
-  >[K]
-}
+type InitialSchedulerEnv<M extends AnyModel, C extends AnyChrono> = Prettify<
+  SchedulerEnvFor<M, C, readonly []>
+>
 
 // ============
 // defineScheduler

--- a/packages/srs-kit/src/scheduler/error.ts
+++ b/packages/srs-kit/src/scheduler/error.ts
@@ -1,0 +1,7 @@
+export class SRSSchedulerError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'SRSSchedulerError'
+    Error?.captureStackTrace?.(this, SRSSchedulerError)
+  }
+}

--- a/packages/srs-kit/src/scheduler/fields.ts
+++ b/packages/srs-kit/src/scheduler/fields.ts
@@ -1,0 +1,14 @@
+import type { Grade } from '@/primitives/rating.js'
+import type { State } from '@/primitives/state.js'
+
+export type SchedulerCoreFields<ScheduleStatus extends string = string> = {
+  readonly state: State
+  readonly scheduleStatus: ScheduleStatus
+  readonly scheduledDays: number
+}
+
+export type SchedulerRevlogCoreFields<
+  ScheduleStatus extends string = string,
+> = SchedulerCoreFields<ScheduleStatus> & {
+  readonly rating: Grade
+}

--- a/packages/srs-kit/src/scheduler/fields.ts
+++ b/packages/srs-kit/src/scheduler/fields.ts
@@ -4,11 +4,9 @@ import type { State } from '@/primitives/state.js'
 export type SchedulerCoreFields<ScheduleStatus extends string = string> = {
   readonly state: State
   readonly scheduleStatus: ScheduleStatus
-  readonly scheduledDays: number
 }
 
-export type SchedulerRevlogCoreFields<
-  ScheduleStatus extends string = string,
-> = SchedulerCoreFields<ScheduleStatus> & {
-  readonly rating: Grade
-}
+export type SchedulerRevlogCoreFields<ScheduleStatus extends string = string> =
+  SchedulerCoreFields<ScheduleStatus> & {
+    readonly rating: Grade
+  }

--- a/packages/srs-kit/src/scheduler/index.ts
+++ b/packages/srs-kit/src/scheduler/index.ts
@@ -1,0 +1,5 @@
+export * from './base.js'
+export * from './define-scheduler.js'
+export * from './error.js'
+export * from './infer.js'
+export * from './scheduler.js'

--- a/packages/srs-kit/src/scheduler/index.ts
+++ b/packages/srs-kit/src/scheduler/index.ts
@@ -1,5 +1,3 @@
-export * from './base.js'
-export * from './define-scheduler.js'
-export * from './error.js'
-export * from './infer.js'
-export * from './scheduler.js'
+export { defineScheduler } from './define-scheduler.js'
+export type * from './infer.js'
+export type * from './scheduler.js'

--- a/packages/srs-kit/src/scheduler/infer.ts
+++ b/packages/srs-kit/src/scheduler/infer.ts
@@ -77,18 +77,38 @@ type MiddlewareCardFields<MWs extends readonly AnyMiddleware[]> = MergePart<
   MergeAllObjects<MiddlewareCardOf<MWs[number]>>
 >
 
+type SchedulerScheduleStatus<MWs extends readonly AnyMiddleware[]> =
+  | ScheduleStatus
+  | Extract<MiddlewareStatusOf<MWs[number]>, string>
+
+type SchedulerScheduleFields<Status extends string> = {
+  readonly scheduleStatus: Status
+  readonly scheduledDays: number
+}
+
 type ExtendSchedulerCard<
   Env extends BlankSchedulerEnv,
   AddedMWs extends readonly AnyMiddleware[],
-> = Prettify<Assign<SchemaOutput<Env['card']>, MiddlewareCardFields<AddedMWs>>>
+> = Prettify<
+  Assign<
+    Assign<SchemaOutput<Env['card']>, MiddlewareCardFields<AddedMWs>>,
+    SchedulerScheduleFields<
+      | Extract<Env['scheduleStatus'], string>
+      | Extract<MiddlewareStatusOf<AddedMWs[number]>, string>
+    >
+  >
+>
 
 export type SchedulerCardFields<
   M extends AnyModel,
   C extends AnyChrono,
   MWs extends readonly AnyMiddleware[],
 > = Assign<
-  Assign<ModelMemoryOf<M>, MergePart<ChronoCardOf<C>>>,
-  MiddlewareCardFields<MWs>
+  Assign<
+    Assign<ModelMemoryOf<M>, MergePart<ChronoCardOf<C>>>,
+    MiddlewareCardFields<MWs>
+  >,
+  SchedulerScheduleFields<SchedulerScheduleStatus<MWs>>
 >
 
 type MiddlewareRevlogFields<MWs extends readonly AnyMiddleware[]> = MergePart<
@@ -99,7 +119,13 @@ type ExtendSchedulerRevlog<
   Env extends BlankSchedulerEnv,
   AddedMWs extends readonly AnyMiddleware[],
 > = Prettify<
-  Assign<SchemaOutput<Env['revlog']>, MiddlewareRevlogFields<AddedMWs>>
+  Assign<
+    Assign<SchemaOutput<Env['revlog']>, MiddlewareRevlogFields<AddedMWs>>,
+    SchedulerScheduleFields<
+      | Extract<Env['scheduleStatus'], string>
+      | Extract<MiddlewareStatusOf<AddedMWs[number]>, string>
+    >
+  >
 >
 
 export type SchedulerRevlogFields<
@@ -107,8 +133,11 @@ export type SchedulerRevlogFields<
   C extends AnyChrono,
   MWs extends readonly AnyMiddleware[],
 > = Assign<
-  Assign<ModelMemoryOf<M>, MergePart<ChronoRevlogOf<C>>>,
-  MiddlewareRevlogFields<MWs>
+  Assign<
+    Assign<ModelMemoryOf<M>, MergePart<ChronoRevlogOf<C>>>,
+    MiddlewareRevlogFields<MWs>
+  >,
+  SchedulerScheduleFields<SchedulerScheduleStatus<MWs>>
 >
 
 export type SchedulerNameOf<M extends AnyModel> = M extends {
@@ -123,9 +152,7 @@ export type SchedulerEnvFor<
   MWs extends readonly AnyMiddleware[],
 > = {
   readonly chrono: ChronoTimeOf<C>
-  readonly scheduleStatus:
-    | ScheduleStatus
-    | Extract<MiddlewareStatusOf<MWs[number]>, string>
+  readonly scheduleStatus: SchedulerScheduleStatus<MWs>
   readonly config: SRSSchema<{
     input: Prettify<SchedulerConfigInput<M, C, MWs>>
     output: Prettify<SchedulerConfigOutput<M, C, MWs>>

--- a/packages/srs-kit/src/scheduler/infer.ts
+++ b/packages/srs-kit/src/scheduler/infer.ts
@@ -5,6 +5,13 @@ import type {
   ChronoRevlogOf,
   ChronoTimeOf,
 } from '@/chrono/infer.js'
+import type { MiddlewareConfigPart } from '@/middleware/config.js'
+import type {
+  AnyMiddleware,
+  MiddlewareCardOf,
+  MiddlewareRevlogOf,
+  MiddlewareStatusOf,
+} from '@/middleware/index.js'
 import type {
   ModelConfigInputOf,
   ModelConfigOf,
@@ -22,13 +29,6 @@ import type {
   SchemaOutputOf,
   SRSSchema,
 } from '@/schema/index.js'
-import type {
-  AnyMiddleware,
-  MiddlewareCardOf,
-  MiddlewareRevlogOf,
-  MiddlewareStatusOf,
-} from './middleware.js'
-import type { MiddlewareConfigPart } from './middleware-config.js'
 import type {
   AnyScheduler,
   BlankSchedulerEnv,

--- a/packages/srs-kit/src/scheduler/infer.ts
+++ b/packages/srs-kit/src/scheduler/infer.ts
@@ -1,0 +1,176 @@
+import type { AnyChrono } from '@/chrono/chrono.js'
+import type {
+  ChronoCardOf,
+  ChronoConfigPart,
+  ChronoRevlogOf,
+  ChronoTimeOf,
+} from '@/chrono/infer.js'
+import type {
+  ModelConfigInputOf,
+  ModelConfigOf,
+  ModelMemoryOf,
+} from '@/model/infer.js'
+import type { AnyModel } from '@/model/model.js'
+import type { ScheduleStatus } from '@/primitives/status.js'
+import type {
+  Assign,
+  MergeAllObjects,
+  MergePart,
+  Prettify,
+  SchemaInput,
+  SchemaOutput,
+  SchemaOutputOf,
+  SRSSchema,
+} from '@/schema/index.js'
+import type {
+  AnyMiddleware,
+  MiddlewareCardOf,
+  MiddlewareRevlogOf,
+  MiddlewareStatusOf,
+} from './middleware.js'
+import type { MiddlewareConfigPart } from './middleware-config.js'
+import type {
+  AnyScheduler,
+  BlankSchedulerEnv,
+  ComposableScheduler,
+} from './scheduler.js'
+
+type SchedulerEnvOf<T extends AnyScheduler> =
+  T extends ComposableScheduler<infer _Name, infer Env> ? Env : never
+
+export type SchedulerConfigOf<T extends AnyScheduler> = SchemaOutputOf<
+  T,
+  'config'
+>
+
+export type SchedulerConfigInput<
+  M extends AnyModel,
+  C extends AnyChrono,
+  MWs extends readonly AnyMiddleware[],
+> = ModelConfigInputOf<M> &
+  ChronoConfigPart<C, 'input'> &
+  MiddlewareConfigPart<MWs, 'input'>
+
+export type SchedulerConfigOutput<
+  M extends AnyModel,
+  C extends AnyChrono,
+  MWs extends readonly AnyMiddleware[],
+> = ModelConfigOf<M> &
+  ChronoConfigPart<C, 'output'> &
+  MiddlewareConfigPart<MWs, 'output'>
+
+type ExtendSchedulerConfigInput<
+  Env extends BlankSchedulerEnv,
+  AddedMWs extends readonly AnyMiddleware[],
+> = Prettify<
+  Assign<SchemaInput<Env['config']>, MiddlewareConfigPart<AddedMWs, 'input'>>
+>
+
+type ExtendSchedulerConfigOutput<
+  Env extends BlankSchedulerEnv,
+  AddedMWs extends readonly AnyMiddleware[],
+> = Prettify<
+  Assign<SchemaOutput<Env['config']>, MiddlewareConfigPart<AddedMWs, 'output'>>
+>
+
+type MiddlewareCardFields<MWs extends readonly AnyMiddleware[]> = MergePart<
+  MergeAllObjects<MiddlewareCardOf<MWs[number]>>
+>
+
+type ExtendSchedulerCard<
+  Env extends BlankSchedulerEnv,
+  AddedMWs extends readonly AnyMiddleware[],
+> = Prettify<Assign<SchemaOutput<Env['card']>, MiddlewareCardFields<AddedMWs>>>
+
+export type SchedulerCardFields<
+  M extends AnyModel,
+  C extends AnyChrono,
+  MWs extends readonly AnyMiddleware[],
+> = Assign<
+  Assign<ModelMemoryOf<M>, MergePart<ChronoCardOf<C>>>,
+  MiddlewareCardFields<MWs>
+>
+
+type MiddlewareRevlogFields<MWs extends readonly AnyMiddleware[]> = MergePart<
+  MergeAllObjects<MiddlewareRevlogOf<MWs[number]>>
+>
+
+type ExtendSchedulerRevlog<
+  Env extends BlankSchedulerEnv,
+  AddedMWs extends readonly AnyMiddleware[],
+> = Prettify<
+  Assign<SchemaOutput<Env['revlog']>, MiddlewareRevlogFields<AddedMWs>>
+>
+
+export type SchedulerRevlogFields<
+  M extends AnyModel,
+  C extends AnyChrono,
+  MWs extends readonly AnyMiddleware[],
+> = Assign<
+  Assign<ModelMemoryOf<M>, MergePart<ChronoRevlogOf<C>>>,
+  MiddlewareRevlogFields<MWs>
+>
+
+export type SchedulerNameOf<M extends AnyModel> = M extends {
+  readonly name: infer Name
+}
+  ? Extract<Name, string | symbol>
+  : never
+
+export type SchedulerEnvFor<
+  M extends AnyModel,
+  C extends AnyChrono,
+  MWs extends readonly AnyMiddleware[],
+> = {
+  readonly chrono: ChronoTimeOf<C>
+  readonly scheduleStatus:
+    | ScheduleStatus
+    | Extract<MiddlewareStatusOf<MWs[number]>, string>
+  readonly config: SRSSchema<{
+    input: Prettify<SchedulerConfigInput<M, C, MWs>>
+    output: Prettify<SchedulerConfigOutput<M, C, MWs>>
+  }>
+  readonly card: SRSSchema<{
+    input: Prettify<SchedulerCardFields<M, C, MWs>>
+    output: Prettify<SchedulerCardFields<M, C, MWs>>
+  }>
+  readonly revlog: SRSSchema<{
+    input: Prettify<SchedulerRevlogFields<M, C, MWs>>
+    output: Prettify<SchedulerRevlogFields<M, C, MWs>>
+  }>
+}
+
+export type ExtendSchedulerEnv<
+  Env extends BlankSchedulerEnv,
+  AddedMWs extends readonly AnyMiddleware[],
+> = {
+  readonly chrono: Env['chrono']
+  readonly scheduleStatus:
+    | Extract<Env['scheduleStatus'], string>
+    | Extract<MiddlewareStatusOf<AddedMWs[number]>, string>
+  readonly config: SRSSchema<{
+    input: ExtendSchedulerConfigInput<Env, AddedMWs>
+    output: ExtendSchedulerConfigOutput<Env, AddedMWs>
+  }>
+  readonly card: SRSSchema<{
+    input: ExtendSchedulerCard<Env, AddedMWs>
+    output: ExtendSchedulerCard<Env, AddedMWs>
+  }>
+  readonly revlog: SRSSchema<{
+    input: ExtendSchedulerRevlog<Env, AddedMWs>
+    output: ExtendSchedulerRevlog<Env, AddedMWs>
+  }>
+}
+
+export type SchedulerCardOf<T extends AnyScheduler> = SchemaOutputOf<T, 'card'>
+
+export type SchedulerRevlogOf<T extends AnyScheduler> = SchemaOutputOf<
+  T,
+  'revlog'
+>
+
+export type SchedulerTimeOf<T extends AnyScheduler> =
+  SchedulerEnvOf<T>['chrono']
+
+export type SchedulerStatusOf<T extends AnyScheduler> =
+  SchedulerEnvOf<T>['scheduleStatus']

--- a/packages/srs-kit/src/scheduler/infer.ts
+++ b/packages/srs-kit/src/scheduler/infer.ts
@@ -18,6 +18,8 @@ import type {
   ModelMemoryOf,
 } from '@/model/infer.js'
 import type { AnyModel } from '@/model/model.js'
+import type { Grade } from '@/primitives/rating.js'
+import type { State } from '@/primitives/state.js'
 import type { ScheduleStatus } from '@/primitives/status.js'
 import type {
   Assign,
@@ -82,9 +84,15 @@ type SchedulerScheduleStatus<MWs extends readonly AnyMiddleware[]> =
   | Extract<MiddlewareStatusOf<MWs[number]>, string>
 
 type SchedulerScheduleFields<Status extends string> = {
+  readonly state: State
   readonly scheduleStatus: Status
   readonly scheduledDays: number
 }
+
+type SchedulerRevlogCoreFields<Status extends string> =
+  SchedulerScheduleFields<Status> & {
+    readonly rating: Grade
+  }
 
 type ExtendSchedulerCard<
   Env extends BlankSchedulerEnv,
@@ -121,7 +129,7 @@ type ExtendSchedulerRevlog<
 > = Prettify<
   Assign<
     Assign<SchemaOutput<Env['revlog']>, MiddlewareRevlogFields<AddedMWs>>,
-    SchedulerScheduleFields<
+    SchedulerRevlogCoreFields<
       | Extract<Env['scheduleStatus'], string>
       | Extract<MiddlewareStatusOf<AddedMWs[number]>, string>
     >
@@ -137,7 +145,7 @@ export type SchedulerRevlogFields<
     Assign<ModelMemoryOf<M>, MergePart<ChronoRevlogOf<C>>>,
     MiddlewareRevlogFields<MWs>
   >,
-  SchedulerScheduleFields<SchedulerScheduleStatus<MWs>>
+  SchedulerRevlogCoreFields<SchedulerScheduleStatus<MWs>>
 >
 
 export type SchedulerNameOf<M extends AnyModel> = M extends {

--- a/packages/srs-kit/src/scheduler/infer.ts
+++ b/packages/srs-kit/src/scheduler/infer.ts
@@ -162,7 +162,9 @@ export type ExtendSchedulerEnv<
   }>
 }
 
-export type SchedulerCardOf<T extends AnyScheduler> = SchemaOutputOf<T, 'card'>
+export type SchedulerCardOf<T extends AnyScheduler> = SchemaOutput<
+  SchedulerEnvOf<T>['card']
+>
 
 export type SchedulerRevlogOf<T extends AnyScheduler> = SchemaOutputOf<
   T,

--- a/packages/srs-kit/src/scheduler/infer.ts
+++ b/packages/srs-kit/src/scheduler/infer.ts
@@ -18,8 +18,6 @@ import type {
   ModelMemoryOf,
 } from '@/model/infer.js'
 import type { AnyModel } from '@/model/model.js'
-import type { Grade } from '@/primitives/rating.js'
-import type { State } from '@/primitives/state.js'
 import type { ScheduleStatus } from '@/primitives/status.js'
 import type {
   Assign,
@@ -31,6 +29,10 @@ import type {
   SchemaOutputOf,
   SRSSchema,
 } from '@/schema/index.js'
+import type {
+  SchedulerCoreFields,
+  SchedulerRevlogCoreFields,
+} from './fields.js'
 import type {
   AnyScheduler,
   BlankSchedulerEnv,
@@ -83,24 +85,13 @@ type SchedulerScheduleStatus<MWs extends readonly AnyMiddleware[]> =
   | ScheduleStatus
   | Extract<MiddlewareStatusOf<MWs[number]>, string>
 
-type SchedulerScheduleFields<Status extends string> = {
-  readonly state: State
-  readonly scheduleStatus: Status
-  readonly scheduledDays: number
-}
-
-type SchedulerRevlogCoreFields<Status extends string> =
-  SchedulerScheduleFields<Status> & {
-    readonly rating: Grade
-  }
-
 type ExtendSchedulerCard<
   Env extends BlankSchedulerEnv,
   AddedMWs extends readonly AnyMiddleware[],
 > = Prettify<
   Assign<
     Assign<SchemaOutput<Env['card']>, MiddlewareCardFields<AddedMWs>>,
-    SchedulerScheduleFields<
+    SchedulerCoreFields<
       | Extract<Env['scheduleStatus'], string>
       | Extract<MiddlewareStatusOf<AddedMWs[number]>, string>
     >
@@ -116,7 +107,7 @@ export type SchedulerCardFields<
     Assign<ModelMemoryOf<M>, MergePart<ChronoCardOf<C>>>,
     MiddlewareCardFields<MWs>
   >,
-  SchedulerScheduleFields<SchedulerScheduleStatus<MWs>>
+  SchedulerCoreFields<SchedulerScheduleStatus<MWs>>
 >
 
 type MiddlewareRevlogFields<MWs extends readonly AnyMiddleware[]> = MergePart<

--- a/packages/srs-kit/src/scheduler/infer.ts
+++ b/packages/srs-kit/src/scheduler/infer.ts
@@ -103,7 +103,9 @@ export type SchedulerCardFields<
     Assign<ModelMemoryOf<M>, MergePart<ChronoCardOf<C>>>,
     MiddlewareCardFields<MWs>
   >,
-  SchedulerCoreFields<ScheduleStatus | Extract<MiddlewareStatusOf<MWs[number]>, string>>
+  SchedulerCoreFields<
+    ScheduleStatus | Extract<MiddlewareStatusOf<MWs[number]>, string>
+  >
 >
 
 type MiddlewareRevlogFields<MWs extends readonly AnyMiddleware[]> = MergePart<
@@ -132,7 +134,9 @@ export type SchedulerRevlogFields<
     Assign<ModelMemoryOf<M>, MergePart<ChronoRevlogOf<C>>>,
     MiddlewareRevlogFields<MWs>
   >,
-  SchedulerRevlogCoreFields<ScheduleStatus | Extract<MiddlewareStatusOf<MWs[number]>, string>>
+  SchedulerRevlogCoreFields<
+    ScheduleStatus | Extract<MiddlewareStatusOf<MWs[number]>, string>
+  >
 >
 
 export type SchedulerNameOf<M extends AnyModel> = M extends {
@@ -147,7 +151,9 @@ export type SchedulerEnvFor<
   MWs extends readonly AnyMiddleware[],
 > = {
   readonly chrono: ChronoTimeOf<C>
-  readonly scheduleStatus: ScheduleStatus | Extract<MiddlewareStatusOf<MWs[number]>, string>
+  readonly scheduleStatus:
+    | ScheduleStatus
+    | Extract<MiddlewareStatusOf<MWs[number]>, string>
   readonly config: SRSSchema<{
     input: Prettify<SchedulerConfigInput<M, C, MWs>>
     output: Prettify<SchedulerConfigOutput<M, C, MWs>>

--- a/packages/srs-kit/src/scheduler/infer.ts
+++ b/packages/srs-kit/src/scheduler/infer.ts
@@ -77,67 +77,75 @@ type ExtendSchedulerConfigOutput<
   Assign<SchemaOutput<Env['config']>, MiddlewareConfigPart<AddedMWs, 'output'>>
 >
 
-type MiddlewareCardFields<MWs extends readonly AnyMiddleware[]> = MergePart<
-  MergeAllObjects<MiddlewareCardOf<MWs[number]>>
+type SchedulerObjectKey = 'card' | 'revlog'
+
+type MiddlewareObjectFields<
+  MWs extends readonly AnyMiddleware[],
+  Key extends SchedulerObjectKey,
+> = MergePart<
+  MergeAllObjects<
+    Key extends 'card'
+      ? MiddlewareCardOf<MWs[number]>
+      : MiddlewareRevlogOf<MWs[number]>
+  >
 >
 
-type ExtendSchedulerCard<
+type SchedulerCoreFieldsFor<
+  Key extends SchedulerObjectKey,
+  Status extends string,
+> = Key extends 'card'
+  ? SchedulerCoreFields<Status>
+  : SchedulerRevlogCoreFields<Status>
+
+type MiddlewareScheduleStatus<MWs extends readonly AnyMiddleware[]> = Extract<
+  MiddlewareStatusOf<MWs[number]>,
+  string
+>
+
+type ExtendSchedulerObject<
   Env extends BlankSchedulerEnv,
   AddedMWs extends readonly AnyMiddleware[],
+  Key extends SchedulerObjectKey,
 > = Prettify<
   Assign<
-    Assign<SchemaOutput<Env['card']>, MiddlewareCardFields<AddedMWs>>,
-    SchedulerCoreFields<
+    Assign<SchemaOutput<Env[Key]>, MiddlewareObjectFields<AddedMWs, Key>>,
+    SchedulerCoreFieldsFor<
+      Key,
       | Extract<Env['scheduleStatus'], string>
-      | Extract<MiddlewareStatusOf<AddedMWs[number]>, string>
+      | MiddlewareScheduleStatus<AddedMWs>
     >
   >
+>
+
+type ChronoObjectFields<
+  C extends AnyChrono,
+  Key extends SchedulerObjectKey,
+> = Key extends 'card' ? ChronoCardOf<C> : ChronoRevlogOf<C>
+
+type SchedulerObjectFields<
+  M extends AnyModel,
+  C extends AnyChrono,
+  MWs extends readonly AnyMiddleware[],
+  Key extends SchedulerObjectKey,
+> = Assign<
+  Assign<
+    Assign<ModelMemoryOf<M>, MergePart<ChronoObjectFields<C, Key>>>,
+    MiddlewareObjectFields<MWs, Key>
+  >,
+  SchedulerCoreFieldsFor<Key, ScheduleStatus | MiddlewareScheduleStatus<MWs>>
 >
 
 export type SchedulerCardFields<
   M extends AnyModel,
   C extends AnyChrono,
   MWs extends readonly AnyMiddleware[],
-> = Assign<
-  Assign<
-    Assign<ModelMemoryOf<M>, MergePart<ChronoCardOf<C>>>,
-    MiddlewareCardFields<MWs>
-  >,
-  SchedulerCoreFields<
-    ScheduleStatus | Extract<MiddlewareStatusOf<MWs[number]>, string>
-  >
->
-
-type MiddlewareRevlogFields<MWs extends readonly AnyMiddleware[]> = MergePart<
-  MergeAllObjects<MiddlewareRevlogOf<MWs[number]>>
->
-
-type ExtendSchedulerRevlog<
-  Env extends BlankSchedulerEnv,
-  AddedMWs extends readonly AnyMiddleware[],
-> = Prettify<
-  Assign<
-    Assign<SchemaOutput<Env['revlog']>, MiddlewareRevlogFields<AddedMWs>>,
-    SchedulerRevlogCoreFields<
-      | Extract<Env['scheduleStatus'], string>
-      | Extract<MiddlewareStatusOf<AddedMWs[number]>, string>
-    >
-  >
->
+> = SchedulerObjectFields<M, C, MWs, 'card'>
 
 export type SchedulerRevlogFields<
   M extends AnyModel,
   C extends AnyChrono,
   MWs extends readonly AnyMiddleware[],
-> = Assign<
-  Assign<
-    Assign<ModelMemoryOf<M>, MergePart<ChronoRevlogOf<C>>>,
-    MiddlewareRevlogFields<MWs>
-  >,
-  SchedulerRevlogCoreFields<
-    ScheduleStatus | Extract<MiddlewareStatusOf<MWs[number]>, string>
-  >
->
+> = SchedulerObjectFields<M, C, MWs, 'revlog'>
 
 export type SchedulerNameOf<M extends AnyModel> = M extends {
   readonly name: infer Name
@@ -175,18 +183,18 @@ export type ExtendSchedulerEnv<
   readonly chrono: Env['chrono']
   readonly scheduleStatus:
     | Extract<Env['scheduleStatus'], string>
-    | Extract<MiddlewareStatusOf<AddedMWs[number]>, string>
+    | MiddlewareScheduleStatus<AddedMWs>
   readonly config: SRSSchema<{
     input: ExtendSchedulerConfigInput<Env, AddedMWs>
     output: ExtendSchedulerConfigOutput<Env, AddedMWs>
   }>
   readonly card: SRSSchema<{
-    input: ExtendSchedulerCard<Env, AddedMWs>
-    output: ExtendSchedulerCard<Env, AddedMWs>
+    input: ExtendSchedulerObject<Env, AddedMWs, 'card'>
+    output: ExtendSchedulerObject<Env, AddedMWs, 'card'>
   }>
   readonly revlog: SRSSchema<{
-    input: ExtendSchedulerRevlog<Env, AddedMWs>
-    output: ExtendSchedulerRevlog<Env, AddedMWs>
+    input: ExtendSchedulerObject<Env, AddedMWs, 'revlog'>
+    output: ExtendSchedulerObject<Env, AddedMWs, 'revlog'>
   }>
 }
 

--- a/packages/srs-kit/src/scheduler/infer.ts
+++ b/packages/srs-kit/src/scheduler/infer.ts
@@ -81,10 +81,6 @@ type MiddlewareCardFields<MWs extends readonly AnyMiddleware[]> = MergePart<
   MergeAllObjects<MiddlewareCardOf<MWs[number]>>
 >
 
-type SchedulerScheduleStatus<MWs extends readonly AnyMiddleware[]> =
-  | ScheduleStatus
-  | Extract<MiddlewareStatusOf<MWs[number]>, string>
-
 type ExtendSchedulerCard<
   Env extends BlankSchedulerEnv,
   AddedMWs extends readonly AnyMiddleware[],
@@ -107,7 +103,7 @@ export type SchedulerCardFields<
     Assign<ModelMemoryOf<M>, MergePart<ChronoCardOf<C>>>,
     MiddlewareCardFields<MWs>
   >,
-  SchedulerCoreFields<SchedulerScheduleStatus<MWs>>
+  SchedulerCoreFields<ScheduleStatus | Extract<MiddlewareStatusOf<MWs[number]>, string>>
 >
 
 type MiddlewareRevlogFields<MWs extends readonly AnyMiddleware[]> = MergePart<
@@ -136,7 +132,7 @@ export type SchedulerRevlogFields<
     Assign<ModelMemoryOf<M>, MergePart<ChronoRevlogOf<C>>>,
     MiddlewareRevlogFields<MWs>
   >,
-  SchedulerRevlogCoreFields<SchedulerScheduleStatus<MWs>>
+  SchedulerRevlogCoreFields<ScheduleStatus | Extract<MiddlewareStatusOf<MWs[number]>, string>>
 >
 
 export type SchedulerNameOf<M extends AnyModel> = M extends {
@@ -151,7 +147,7 @@ export type SchedulerEnvFor<
   MWs extends readonly AnyMiddleware[],
 > = {
   readonly chrono: ChronoTimeOf<C>
-  readonly scheduleStatus: SchedulerScheduleStatus<MWs>
+  readonly scheduleStatus: ScheduleStatus | Extract<MiddlewareStatusOf<MWs[number]>, string>
   readonly config: SRSSchema<{
     input: Prettify<SchedulerConfigInput<M, C, MWs>>
     output: Prettify<SchedulerConfigOutput<M, C, MWs>>

--- a/packages/srs-kit/src/scheduler/scheduler.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.spec.ts
@@ -1,6 +1,11 @@
 import { describe, expect, expectTypeOf, it } from 'vitest'
+import { defineChrono } from '@/chrono/define-chrono.js'
+import { dateChrono } from '@/chrono/presets/date/chrono.js'
 import { schedulerStatsMiddleware } from '@/middleware/stats/index.js'
-import { type Grade, Rating, type State } from '@/primitives/index.js'
+import { SM2Model } from '@/model/sm2.test.js'
+import { type Grade, Rating, State } from '@/primitives/index.js'
+import { defineSchema, numberSchema } from '@/schema/index.js'
+import { defineScheduler } from './define-scheduler.js'
 import type {
   SchedulerCardOf,
   SchedulerConfigOf,
@@ -85,6 +90,145 @@ describe('defineScheduler', () => {
         audit: 'schema-source',
       }).audit
     ).toBe('schema-source')
+  })
+
+  it('validates scheduler config input before composing config fields', () => {
+    expect(() => scheduler.schema.config.parse(null)).toThrow(
+      'Expected scheduler config object'
+    )
+  })
+
+  it('validates chrono config while composing scheduler config', () => {
+    const offsetSchema = defineSchema<{ readonly offset: number }>((value) => {
+      if (
+        value &&
+        typeof value === 'object' &&
+        !Array.isArray(value) &&
+        typeof (value as { readonly offset?: unknown }).offset === 'number'
+      ) {
+        return {
+          value: {
+            offset: (value as { readonly offset: number }).offset,
+          },
+        }
+      }
+
+      return { issues: [{ message: 'Expected offset config' }] }
+    })
+    const offsetChrono = defineChrono({
+      schema: {
+        config: offsetSchema,
+        time: numberSchema,
+      },
+      projection(value) {
+        if (
+          value &&
+          typeof value === 'object' &&
+          !Array.isArray(value) &&
+          typeof (value as { readonly time?: unknown }).time === 'number'
+        ) {
+          const time = (value as { readonly time: number }).time
+          return { value: { previous: time, current: time } }
+        }
+
+        return { issues: [{ message: 'Expected offset time' }] }
+      },
+      create() {
+        return {
+          now: () => 0,
+          difference: (from: number, to: number) => to - from,
+          add: (from: number, days: number) => from + days,
+        }
+      },
+    })
+    const chronoScheduler = defineScheduler({
+      model: SM2Model,
+      chrono: offsetChrono,
+    })
+
+    expect(
+      chronoScheduler.schema.config.parse({
+        ...config,
+        chrono: { offset: 9 },
+      }).chrono
+    ).toEqual({ offset: 9 })
+    expect(() =>
+      chronoScheduler.schema.config.parse({
+        ...config,
+        chrono: { offset: 'bad' },
+      })
+    ).toThrow('Expected offset config')
+  })
+
+  it('validates middleware config while composing scheduler config', () => {
+    expect(() => middlewareScheduler.schema.config.parse(config)).toThrow(
+      'Expected source config'
+    )
+  })
+
+  it('validates card and revlog object inputs', () => {
+    expect(() => scheduler.schema.card.parse(null)).toThrow(
+      'Expected card object'
+    )
+    expect(() => scheduler.schema.revlog.parse(null)).toThrow(
+      'Expected revlog object'
+    )
+  })
+
+  it('validates composed chrono and model revlog fields', () => {
+    const dateScheduler = defineScheduler({
+      model: SM2Model,
+      chrono: dateChrono,
+    })
+    const dueAt = new Date('2026-01-02T00:00:00.000Z')
+    const reviewTime = new Date('2026-01-03T00:00:00.000Z')
+    const fields = {
+      interval: 1,
+      easeFactor: 2.5,
+      reps: 1,
+      state: State.Review,
+      scheduleStatus: 'review' as const,
+    }
+
+    expect(() =>
+      dateScheduler.schema.card.parse({
+        ...fields,
+        dueAt: new Date(0),
+      })
+    ).toThrow('Expected valid Date fields')
+    expect(() =>
+      dateScheduler.schema.revlog.parse({
+        ...fields,
+        interval: 'bad',
+        rating: Rating.Good,
+        dueAt,
+        reviewTime,
+      })
+    ).toThrow('Expected SM2 memory state')
+    expect(() =>
+      dateScheduler.schema.revlog.parse({
+        ...fields,
+        rating: Rating.Good,
+        dueAt: new Date(0),
+        reviewTime,
+      })
+    ).toThrow('Expected valid Date fields')
+    expect(() =>
+      dateScheduler.schema.revlog.parse({
+        ...fields,
+        rating: Rating.Manual,
+        dueAt,
+        reviewTime,
+      })
+    ).toThrow('Expected grade')
+    expect(
+      dateScheduler.schema.revlog.parse({
+        ...fields,
+        rating: Rating.Good,
+        dueAt,
+        reviewTime,
+      }).reviewTime
+    ).toBe(reviewTime)
   })
 
   it('infers composed config type', () => {
@@ -236,6 +380,9 @@ describe('defineScheduler', () => {
     const card = core.newCard()
 
     expect(scheduler.schema.scheduleStatus.parse('new')).toBe('new')
+    expect(() => scheduler.schema.scheduleStatus.parse(1 as never)).toThrow(
+      'Expected scheduleStatus string'
+    )
     expect(() => scheduler.schema.scheduleStatus.parse('suspend')).toThrow(
       'Expected known scheduleStatus'
     )
@@ -246,6 +393,12 @@ describe('defineScheduler', () => {
       'Expected known scheduleStatus'
     )
 
+    expect(() =>
+      scheduler.schema.card.parse({
+        ...card,
+        state: 'bad',
+      })
+    ).toThrow('Expected state')
     expect(() =>
       scheduler.schema.card.parse({
         ...card,

--- a/packages/srs-kit/src/scheduler/scheduler.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.spec.ts
@@ -235,6 +235,17 @@ describe('defineScheduler', () => {
   it('validates scheduleStatus against default and middleware keys', () => {
     const card = core.newCard()
 
+    expect(scheduler.schema.scheduleStatus.parse('new')).toBe('new')
+    expect(() => scheduler.schema.scheduleStatus.parse('suspend')).toThrow(
+      'Expected known scheduleStatus'
+    )
+    expect(statusScheduler.schema.scheduleStatus.parse('suspend')).toBe(
+      'suspend'
+    )
+    expect(() => statusScheduler.schema.scheduleStatus.parse('typo')).toThrow(
+      'Expected known scheduleStatus'
+    )
+
     expect(() =>
       scheduler.schema.card.parse({
         ...card,

--- a/packages/srs-kit/src/scheduler/scheduler.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, expectTypeOf, it } from 'vitest'
-import { schedulerStatsMiddleware } from '@/middleware/stats.js'
+import { schedulerStatsMiddleware } from '@/middleware/stats/index.js'
 import { type Grade, Rating, type State } from '@/primitives/index.js'
 import type {
   SchedulerCardOf,
@@ -128,7 +128,6 @@ describe('defineScheduler', () => {
       readonly scheduleStatus: 'new' | 'learning' | 'review'
       readonly state: State
       readonly scheduledDays: number
-      readonly elapsedDays: number
       readonly lapses: number
     }>()
   })
@@ -141,7 +140,6 @@ describe('defineScheduler', () => {
       readonly scheduleStatus: 'new' | 'learning' | 'review'
       readonly state: State
       readonly scheduledDays: number
-      readonly elapsedDays: number
       readonly lapses: number
       readonly source: string
     }>()
@@ -155,7 +153,6 @@ describe('defineScheduler', () => {
       readonly scheduleStatus: 'new' | 'learning' | 'review'
       readonly state: State
       readonly scheduledDays: number
-      readonly elapsedDays: number
       readonly lapses: number
       readonly source: string
     }>()
@@ -170,7 +167,6 @@ describe('defineScheduler', () => {
       readonly scheduleStatus: 'new' | 'learning' | 'review'
       readonly state: State
       readonly scheduledDays: number
-      readonly elapsedDays: number
       readonly lapses: number
     }>()
   })
@@ -184,7 +180,6 @@ describe('defineScheduler', () => {
       readonly rating: 1 | 2 | 3 | 4
       readonly state: State
       readonly scheduledDays: number
-      readonly elapsedDays: number
     }>()
   })
 
@@ -199,7 +194,6 @@ describe('defineScheduler', () => {
       readonly rating: 1 | 2 | 3 | 4
       readonly state: State
       readonly scheduledDays: number
-      readonly elapsedDays: number
       readonly audit: string
     }>()
   })
@@ -213,7 +207,6 @@ describe('defineScheduler', () => {
       readonly rating: 1 | 2 | 3 | 4
       readonly state: State
       readonly scheduledDays: number
-      readonly elapsedDays: number
       readonly audit: string
     }>()
   })
@@ -228,7 +221,6 @@ describe('defineScheduler', () => {
       readonly rating: 1 | 2 | 3 | 4
       readonly state: State
       readonly scheduledDays: number
-      readonly elapsedDays: number
     }>()
   })
 

--- a/packages/srs-kit/src/scheduler/scheduler.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.spec.ts
@@ -185,7 +185,6 @@ describe('defineScheduler', () => {
       readonly state: State
       readonly scheduledDays: number
       readonly elapsedDays: number
-      readonly lapses: number
     }>()
   })
 
@@ -201,7 +200,6 @@ describe('defineScheduler', () => {
       readonly state: State
       readonly scheduledDays: number
       readonly elapsedDays: number
-      readonly lapses: number
       readonly audit: string
     }>()
   })
@@ -216,7 +214,6 @@ describe('defineScheduler', () => {
       readonly state: State
       readonly scheduledDays: number
       readonly elapsedDays: number
-      readonly lapses: number
       readonly audit: string
     }>()
   })
@@ -232,7 +229,6 @@ describe('defineScheduler', () => {
       readonly state: State
       readonly scheduledDays: number
       readonly elapsedDays: number
-      readonly lapses: number
     }>()
   })
 

--- a/packages/srs-kit/src/scheduler/scheduler.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.spec.ts
@@ -1,0 +1,276 @@
+import { describe, expect, expectTypeOf, it } from 'vitest'
+import { schedulerStatsMiddleware } from '@/middleware/stats.js'
+import { type Grade, Rating, type State } from '@/primitives/index.js'
+import type {
+  SchedulerCardOf,
+  SchedulerConfigOf,
+  SchedulerRevlogOf,
+  SchedulerStatusOf,
+  SchedulerTimeOf,
+} from './infer.js'
+import {
+  config,
+  createSM2NumericScheduler,
+  sourceMiddleware,
+  statusMiddleware,
+} from './scheduler.test.js'
+
+const scheduler = createSM2NumericScheduler().use(schedulerStatsMiddleware)
+const core = scheduler.create({ config })
+const middlewareScheduler = createSM2NumericScheduler().use(
+  sourceMiddleware,
+  schedulerStatsMiddleware
+)
+const usedScheduler = createSM2NumericScheduler().use(
+  sourceMiddleware,
+  schedulerStatsMiddleware
+)
+const chainedScheduler = createSM2NumericScheduler()
+  .use(sourceMiddleware)
+  .use(schedulerStatsMiddleware)
+const statusScheduler = createSM2NumericScheduler().use(statusMiddleware)
+
+const usedCore = usedScheduler.create({
+  config: {
+    ...config,
+    source: 'used-source',
+  },
+})
+
+describe('defineScheduler', () => {
+  it('preserves model name', () => {
+    expect(scheduler.name).toBe('sm2')
+    expectTypeOf(scheduler.name).toEqualTypeOf<'sm2'>()
+  })
+
+  it('exposes composed schemas', () => {
+    expect(scheduler.schema.config).toBeDefined()
+    expect(scheduler.schema.card).toBeDefined()
+    expect(scheduler.schema.revlog).toBeDefined()
+  })
+
+  it('uses middleware references from use() when schemas parse', () => {
+    const dynamicScheduler = createSM2NumericScheduler()
+    const schema = dynamicScheduler.schema
+
+    const dynamicSchedulerWithMiddleware = dynamicScheduler.use(
+      sourceMiddleware,
+      schedulerStatsMiddleware
+    )
+    const usedSchema = dynamicSchedulerWithMiddleware.schema
+
+    expect(dynamicSchedulerWithMiddleware).toBe(dynamicScheduler)
+    expect(usedSchema).toBe(schema)
+    expect(() => usedSchema.card.parse(core.newCard())).toThrow(
+      'Expected source card field'
+    )
+    expect(() =>
+      usedSchema.revlog.parse({
+        ...core.newCard(),
+        rating: Rating.Good,
+      })
+    ).toThrow('Expected audit revlog field')
+
+    expect(
+      usedSchema.config.parse({
+        ...config,
+        source: 'schema-source',
+      }).source
+    ).toBe('schema-source')
+    expect(usedSchema.card.parse(usedCore.newCard()).source).toBe('used-source')
+    expect(
+      usedSchema.revlog.parse({
+        ...usedCore.newCard(),
+        rating: Rating.Good,
+        audit: 'schema-source',
+      }).audit
+    ).toBe('schema-source')
+  })
+
+  it('infers composed config type', () => {
+    expectTypeOf<SchedulerConfigOf<typeof scheduler>>().toEqualTypeOf<{
+      readonly weights: readonly number[]
+      readonly chrono: Record<string, never>
+    }>()
+  })
+
+  it('infers middleware config type', () => {
+    expectTypeOf<
+      SchedulerConfigOf<typeof middlewareScheduler>
+    >().toEqualTypeOf<{
+      readonly weights: readonly number[]
+      readonly chrono: Record<string, never>
+      readonly source: string
+    }>()
+  })
+
+  it('preserves middleware config type through use()', () => {
+    expectTypeOf<SchedulerConfigOf<typeof usedScheduler>>().toEqualTypeOf<{
+      readonly weights: readonly number[]
+      readonly chrono: Record<string, never>
+      readonly source: string
+    }>()
+  })
+
+  it('preserves prior config type through chained use()', () => {
+    expectTypeOf<SchedulerConfigOf<typeof chainedScheduler>>().toEqualTypeOf<{
+      readonly weights: readonly number[]
+      readonly chrono: Record<string, never>
+      readonly source: string
+    }>()
+  })
+
+  it('infers composed card type with flattened model fields', () => {
+    expectTypeOf<SchedulerCardOf<typeof scheduler>>().toEqualTypeOf<{
+      readonly interval: number
+      readonly easeFactor: number
+      readonly reps: number
+      readonly scheduleStatus: 'new' | 'learning' | 'review'
+      readonly state: State
+      readonly scheduledDays: number
+      readonly elapsedDays: number
+      readonly lapses: number
+    }>()
+  })
+
+  it('infers middleware card fields', () => {
+    expectTypeOf<SchedulerCardOf<typeof middlewareScheduler>>().toEqualTypeOf<{
+      readonly interval: number
+      readonly easeFactor: number
+      readonly reps: number
+      readonly scheduleStatus: 'new' | 'learning' | 'review'
+      readonly state: State
+      readonly scheduledDays: number
+      readonly elapsedDays: number
+      readonly lapses: number
+      readonly source: string
+    }>()
+  })
+
+  it('preserves middleware card fields through use()', () => {
+    expectTypeOf<SchedulerCardOf<typeof usedScheduler>>().toEqualTypeOf<{
+      readonly interval: number
+      readonly easeFactor: number
+      readonly reps: number
+      readonly scheduleStatus: 'new' | 'learning' | 'review'
+      readonly state: State
+      readonly scheduledDays: number
+      readonly elapsedDays: number
+      readonly lapses: number
+      readonly source: string
+    }>()
+  })
+
+  it('preserves prior card fields through chained use()', () => {
+    expectTypeOf<SchedulerCardOf<typeof chainedScheduler>>().toEqualTypeOf<{
+      readonly interval: number
+      readonly easeFactor: number
+      readonly reps: number
+      readonly source: string
+      readonly scheduleStatus: 'new' | 'learning' | 'review'
+      readonly state: State
+      readonly scheduledDays: number
+      readonly elapsedDays: number
+      readonly lapses: number
+    }>()
+  })
+
+  it('infers composed revlog type with flattened model fields', () => {
+    expectTypeOf<SchedulerRevlogOf<typeof scheduler>>().toEqualTypeOf<{
+      readonly interval: number
+      readonly easeFactor: number
+      readonly reps: number
+      readonly scheduleStatus: 'new' | 'learning' | 'review'
+      readonly rating: 1 | 2 | 3 | 4
+      readonly state: State
+      readonly scheduledDays: number
+      readonly elapsedDays: number
+      readonly lapses: number
+    }>()
+  })
+
+  it('infers middleware revlog fields', () => {
+    expectTypeOf<
+      SchedulerRevlogOf<typeof middlewareScheduler>
+    >().toEqualTypeOf<{
+      readonly interval: number
+      readonly easeFactor: number
+      readonly reps: number
+      readonly scheduleStatus: 'new' | 'learning' | 'review'
+      readonly rating: 1 | 2 | 3 | 4
+      readonly state: State
+      readonly scheduledDays: number
+      readonly elapsedDays: number
+      readonly lapses: number
+      readonly audit: string
+    }>()
+  })
+
+  it('preserves middleware revlog fields through use()', () => {
+    expectTypeOf<SchedulerRevlogOf<typeof usedScheduler>>().toEqualTypeOf<{
+      readonly interval: number
+      readonly easeFactor: number
+      readonly reps: number
+      readonly scheduleStatus: 'new' | 'learning' | 'review'
+      readonly rating: 1 | 2 | 3 | 4
+      readonly state: State
+      readonly scheduledDays: number
+      readonly elapsedDays: number
+      readonly lapses: number
+      readonly audit: string
+    }>()
+  })
+
+  it('preserves prior revlog fields through chained use()', () => {
+    expectTypeOf<SchedulerRevlogOf<typeof chainedScheduler>>().toEqualTypeOf<{
+      readonly interval: number
+      readonly easeFactor: number
+      readonly reps: number
+      readonly audit: string
+      readonly scheduleStatus: 'new' | 'learning' | 'review'
+      readonly rating: 1 | 2 | 3 | 4
+      readonly state: State
+      readonly scheduledDays: number
+      readonly elapsedDays: number
+      readonly lapses: number
+    }>()
+  })
+
+  it('infers time type from chrono', () => {
+    expectTypeOf<SchedulerTimeOf<typeof scheduler>>().toEqualTypeOf<number>()
+  })
+
+  it('infers default scheduler status type', () => {
+    expectTypeOf<SchedulerStatusOf<typeof scheduler>>().toEqualTypeOf<
+      'new' | 'learning' | 'review'
+    >()
+  })
+
+  it('extends scheduler status via use()', () => {
+    expectTypeOf<SchedulerStatusOf<typeof statusScheduler>>().toEqualTypeOf<
+      'new' | 'learning' | 'review' | 'suspend' | 'buried'
+    >()
+  })
+
+  it('extends card and revlog schedule status via use()', () => {
+    type ExtendedStatus = 'new' | 'learning' | 'review' | 'suspend' | 'buried'
+
+    expectTypeOf<SchedulerCardOf<typeof statusScheduler>>().toEqualTypeOf<{
+      readonly interval: number
+      readonly easeFactor: number
+      readonly reps: number
+      readonly state: State
+      readonly scheduleStatus: ExtendedStatus
+      readonly scheduledDays: number
+    }>()
+    expectTypeOf<SchedulerRevlogOf<typeof statusScheduler>>().toEqualTypeOf<{
+      readonly interval: number
+      readonly easeFactor: number
+      readonly reps: number
+      readonly scheduleStatus: ExtendedStatus
+      readonly scheduledDays: number
+      readonly rating: Grade
+      readonly state: State
+    }>()
+  })
+})

--- a/packages/srs-kit/src/scheduler/scheduler.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.spec.ts
@@ -127,7 +127,6 @@ describe('defineScheduler', () => {
       readonly reps: number
       readonly scheduleStatus: 'new' | 'learning' | 'review'
       readonly state: State
-      readonly scheduledDays: number
       readonly lapses: number
     }>()
   })
@@ -139,7 +138,6 @@ describe('defineScheduler', () => {
       readonly reps: number
       readonly scheduleStatus: 'new' | 'learning' | 'review'
       readonly state: State
-      readonly scheduledDays: number
       readonly lapses: number
       readonly source: string
     }>()
@@ -152,7 +150,6 @@ describe('defineScheduler', () => {
       readonly reps: number
       readonly scheduleStatus: 'new' | 'learning' | 'review'
       readonly state: State
-      readonly scheduledDays: number
       readonly lapses: number
       readonly source: string
     }>()
@@ -166,7 +163,6 @@ describe('defineScheduler', () => {
       readonly source: string
       readonly scheduleStatus: 'new' | 'learning' | 'review'
       readonly state: State
-      readonly scheduledDays: number
       readonly lapses: number
     }>()
   })
@@ -179,7 +175,6 @@ describe('defineScheduler', () => {
       readonly scheduleStatus: 'new' | 'learning' | 'review'
       readonly rating: 1 | 2 | 3 | 4
       readonly state: State
-      readonly scheduledDays: number
     }>()
   })
 
@@ -193,7 +188,6 @@ describe('defineScheduler', () => {
       readonly scheduleStatus: 'new' | 'learning' | 'review'
       readonly rating: 1 | 2 | 3 | 4
       readonly state: State
-      readonly scheduledDays: number
       readonly audit: string
     }>()
   })
@@ -206,7 +200,6 @@ describe('defineScheduler', () => {
       readonly scheduleStatus: 'new' | 'learning' | 'review'
       readonly rating: 1 | 2 | 3 | 4
       readonly state: State
-      readonly scheduledDays: number
       readonly audit: string
     }>()
   })
@@ -220,7 +213,6 @@ describe('defineScheduler', () => {
       readonly scheduleStatus: 'new' | 'learning' | 'review'
       readonly rating: 1 | 2 | 3 | 4
       readonly state: State
-      readonly scheduledDays: number
     }>()
   })
 
@@ -240,6 +232,36 @@ describe('defineScheduler', () => {
     >()
   })
 
+  it('validates scheduleStatus against default and middleware keys', () => {
+    const card = core.newCard()
+
+    expect(() =>
+      scheduler.schema.card.parse({
+        ...card,
+        scheduleStatus: 'suspend',
+      })
+    ).toThrow('Expected known scheduleStatus')
+    expect(
+      statusScheduler.schema.card.parse({
+        ...card,
+        scheduleStatus: 'suspend',
+      }).scheduleStatus
+    ).toBe('suspend')
+    expect(() =>
+      statusScheduler.schema.card.parse({
+        ...card,
+        scheduleStatus: 'typo',
+      })
+    ).toThrow('Expected known scheduleStatus')
+    expect(
+      statusScheduler.schema.revlog.parse({
+        ...card,
+        rating: Rating.Good,
+        scheduleStatus: 'buried',
+      }).scheduleStatus
+    ).toBe('buried')
+  })
+
   it('extends card and revlog schedule status via use()', () => {
     type ExtendedStatus = 'new' | 'learning' | 'review' | 'suspend' | 'buried'
 
@@ -249,14 +271,12 @@ describe('defineScheduler', () => {
       readonly reps: number
       readonly state: State
       readonly scheduleStatus: ExtendedStatus
-      readonly scheduledDays: number
     }>()
     expectTypeOf<SchedulerRevlogOf<typeof statusScheduler>>().toEqualTypeOf<{
       readonly interval: number
       readonly easeFactor: number
       readonly reps: number
       readonly scheduleStatus: ExtendedStatus
-      readonly scheduledDays: number
       readonly rating: Grade
       readonly state: State
     }>()

--- a/packages/srs-kit/src/scheduler/scheduler.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.spec.ts
@@ -185,7 +185,7 @@ describe('defineScheduler', () => {
     const fields = {
       interval: 1,
       easeFactor: 2.5,
-      reps: 1,
+      reviewStep: 1,
       state: State.Review,
       scheduleStatus: 'review' as const,
     }
@@ -268,6 +268,7 @@ describe('defineScheduler', () => {
     expectTypeOf<SchedulerCardOf<typeof scheduler>>().toEqualTypeOf<{
       readonly interval: number
       readonly easeFactor: number
+      readonly reviewStep: number
       readonly reps: number
       readonly scheduleStatus: 'new' | 'learning' | 'review'
       readonly state: State
@@ -279,6 +280,7 @@ describe('defineScheduler', () => {
     expectTypeOf<SchedulerCardOf<typeof middlewareScheduler>>().toEqualTypeOf<{
       readonly interval: number
       readonly easeFactor: number
+      readonly reviewStep: number
       readonly reps: number
       readonly scheduleStatus: 'new' | 'learning' | 'review'
       readonly state: State
@@ -291,6 +293,7 @@ describe('defineScheduler', () => {
     expectTypeOf<SchedulerCardOf<typeof usedScheduler>>().toEqualTypeOf<{
       readonly interval: number
       readonly easeFactor: number
+      readonly reviewStep: number
       readonly reps: number
       readonly scheduleStatus: 'new' | 'learning' | 'review'
       readonly state: State
@@ -303,6 +306,7 @@ describe('defineScheduler', () => {
     expectTypeOf<SchedulerCardOf<typeof chainedScheduler>>().toEqualTypeOf<{
       readonly interval: number
       readonly easeFactor: number
+      readonly reviewStep: number
       readonly reps: number
       readonly source: string
       readonly scheduleStatus: 'new' | 'learning' | 'review'
@@ -315,7 +319,7 @@ describe('defineScheduler', () => {
     expectTypeOf<SchedulerRevlogOf<typeof scheduler>>().toEqualTypeOf<{
       readonly interval: number
       readonly easeFactor: number
-      readonly reps: number
+      readonly reviewStep: number
       readonly scheduleStatus: 'new' | 'learning' | 'review'
       readonly rating: 1 | 2 | 3 | 4
       readonly state: State
@@ -328,7 +332,7 @@ describe('defineScheduler', () => {
     >().toEqualTypeOf<{
       readonly interval: number
       readonly easeFactor: number
-      readonly reps: number
+      readonly reviewStep: number
       readonly scheduleStatus: 'new' | 'learning' | 'review'
       readonly rating: 1 | 2 | 3 | 4
       readonly state: State
@@ -340,7 +344,7 @@ describe('defineScheduler', () => {
     expectTypeOf<SchedulerRevlogOf<typeof usedScheduler>>().toEqualTypeOf<{
       readonly interval: number
       readonly easeFactor: number
-      readonly reps: number
+      readonly reviewStep: number
       readonly scheduleStatus: 'new' | 'learning' | 'review'
       readonly rating: 1 | 2 | 3 | 4
       readonly state: State
@@ -352,7 +356,7 @@ describe('defineScheduler', () => {
     expectTypeOf<SchedulerRevlogOf<typeof chainedScheduler>>().toEqualTypeOf<{
       readonly interval: number
       readonly easeFactor: number
-      readonly reps: number
+      readonly reviewStep: number
       readonly audit: string
       readonly scheduleStatus: 'new' | 'learning' | 'review'
       readonly rating: 1 | 2 | 3 | 4
@@ -432,14 +436,14 @@ describe('defineScheduler', () => {
     expectTypeOf<SchedulerCardOf<typeof statusScheduler>>().toEqualTypeOf<{
       readonly interval: number
       readonly easeFactor: number
-      readonly reps: number
+      readonly reviewStep: number
       readonly state: State
       readonly scheduleStatus: ExtendedStatus
     }>()
     expectTypeOf<SchedulerRevlogOf<typeof statusScheduler>>().toEqualTypeOf<{
       readonly interval: number
       readonly easeFactor: number
-      readonly reps: number
+      readonly reviewStep: number
       readonly scheduleStatus: ExtendedStatus
       readonly rating: Grade
       readonly state: State

--- a/packages/srs-kit/src/scheduler/scheduler.test.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.test.ts
@@ -1,13 +1,13 @@
 import { numericChrono } from '@/chrono/presets/numeric/chrono.js'
-import { SM2_DEFAULT_WEIGHTS, SM2Model } from '@/model/sm2.test.js'
-import { defineSchema, isObject } from '@/schema/index.js'
-import { defineScheduler } from './define-scheduler.js'
 import type {
   Middleware,
   MiddlewareNext,
   ReviewMiddlewareContext,
   RollbackMiddlewareContext,
-} from './middleware.js'
+} from '@/middleware/index.js'
+import { SM2_DEFAULT_WEIGHTS, SM2Model } from '@/model/sm2.test.js'
+import { defineSchema, isObject } from '@/schema/index.js'
+import { defineScheduler } from './define-scheduler.js'
 
 export const createSM2NumericScheduler = () =>
   defineScheduler({

--- a/packages/srs-kit/src/scheduler/scheduler.test.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.test.ts
@@ -2,7 +2,12 @@ import { numericChrono } from '@/chrono/presets/numeric/chrono.js'
 import { SM2_DEFAULT_WEIGHTS, SM2Model } from '@/model/sm2.test.js'
 import { defineSchema, isObject } from '@/schema/index.js'
 import { defineScheduler } from './define-scheduler.js'
-import type { Middleware } from './middleware.js'
+import type {
+  Middleware,
+  MiddlewareNext,
+  ReviewMiddlewareContext,
+  RollbackMiddlewareContext,
+} from './middleware.js'
 
 export const createSM2NumericScheduler = () =>
   defineScheduler({
@@ -60,12 +65,14 @@ export const auditRevlogSchema = defineSchema<
 export const sourceMiddlewareName = 'sourceMiddleware'
 export const statusMiddlewareName = Symbol('statusMiddleware')
 
+type SourceMiddlewareEnv = {
+  readonly config: typeof sourceConfigSchema
+  readonly card: typeof sourceCardSchema
+  readonly revlog: typeof auditRevlogSchema
+}
+
 export const sourceMiddleware: Middleware<
-  {
-    readonly config: typeof sourceConfigSchema
-    readonly card: typeof sourceCardSchema
-    readonly revlog: typeof auditRevlogSchema
-  },
+  SourceMiddlewareEnv,
   typeof sourceMiddlewareName
 > = {
   name: sourceMiddlewareName,
@@ -80,6 +87,33 @@ export const sourceMiddleware: Middleware<
     },
     revlog(ctx) {
       return { audit: ctx.config.source }
+    },
+  },
+  handlers: {
+    review<Result>(
+      ctx: ReviewMiddlewareContext<SourceMiddlewareEnv>,
+      next: MiddlewareNext<Result>
+    ): Result {
+      const result = next() as {
+        readonly card: Record<string, unknown>
+        readonly revlog: Record<string, unknown>
+      }
+      result.card.source = ctx.config.source
+      result.revlog.audit = ctx.config.source
+      ctx.result = result
+      return result as Result
+    },
+    rollback<Result>(
+      ctx: RollbackMiddlewareContext<SourceMiddlewareEnv>,
+      next: MiddlewareNext<Result>
+    ): Result {
+      const restored = next() as Readonly<Record<string, unknown>>
+      const resultCard = {
+        ...restored,
+        source: ctx.config.source,
+      }
+      ctx.result = { card: resultCard }
+      return ctx.result.card as Result
     },
   },
 }

--- a/packages/srs-kit/src/scheduler/scheduler.test.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.test.ts
@@ -1,0 +1,94 @@
+import { numericChrono } from '@/chrono/presets/numeric/chrono.js'
+import { SM2_DEFAULT_WEIGHTS, SM2Model } from '@/model/sm2.test.js'
+import { defineSchema, isObject } from '@/schema/index.js'
+import { defineScheduler } from './define-scheduler.js'
+import type { Middleware } from './middleware.js'
+
+export const createSM2NumericScheduler = () =>
+  defineScheduler({
+    model: SM2Model,
+    chrono: numericChrono,
+  })
+
+export const config = {
+  weights: SM2_DEFAULT_WEIGHTS,
+  desiredRetention: 0.9,
+}
+
+export const sourceConfigSchema = defineSchema<{ readonly source: string }>(
+  (value) => {
+    if (isObject(value) && typeof value.source === 'string') {
+      return { value: { source: value.source } }
+    }
+    return { issues: [{ message: 'Expected source config' }] }
+  }
+)
+
+export function defineStringFieldConfigSchema<const Field extends string>(
+  field: Field
+) {
+  return defineSchema<{ readonly [K in Field]: string }>((value) => {
+    if (isObject(value) && typeof value[field] === 'string') {
+      return {
+        value: { [field]: value[field] } as { readonly [K in Field]: string },
+      }
+    }
+    return { issues: [{ message: `Expected ${field} config` }] }
+  })
+}
+
+export const sourceCardSchema = defineSchema<
+  unknown,
+  { readonly source: string }
+>((value) => {
+  if (isObject(value) && typeof value.source === 'string') {
+    return { value: { source: value.source } }
+  }
+  return { issues: [{ message: 'Expected source card field' }] }
+})
+
+export const auditRevlogSchema = defineSchema<
+  unknown,
+  { readonly audit: string }
+>((value) => {
+  if (isObject(value) && typeof value.audit === 'string') {
+    return { value: { audit: value.audit } }
+  }
+  return { issues: [{ message: 'Expected audit revlog field' }] }
+})
+
+export const sourceMiddlewareName = 'sourceMiddleware'
+export const statusMiddlewareName = Symbol('statusMiddleware')
+
+export const sourceMiddleware: Middleware<
+  {
+    readonly config: typeof sourceConfigSchema
+    readonly card: typeof sourceCardSchema
+    readonly revlog: typeof auditRevlogSchema
+  },
+  typeof sourceMiddlewareName
+> = {
+  name: sourceMiddlewareName,
+  schema: {
+    config: sourceConfigSchema,
+    card: sourceCardSchema,
+    revlog: auditRevlogSchema,
+  },
+  defaultValue: {
+    card(ctx) {
+      return { source: ctx.config.source }
+    },
+    revlog(ctx) {
+      return { audit: ctx.config.source }
+    },
+  },
+}
+
+export const statusMiddleware: Middleware<
+  {
+    readonly scheduleStatus: 'suspend' | 'buried'
+  },
+  typeof statusMiddlewareName
+> = {
+  name: statusMiddlewareName,
+}

--- a/packages/srs-kit/src/scheduler/scheduler.test.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.test.ts
@@ -1,10 +1,5 @@
 import { numericChrono } from '@/chrono/presets/numeric/chrono.js'
-import type {
-  Middleware,
-  MiddlewareNext,
-  ReviewMiddlewareContext,
-  RollbackMiddlewareContext,
-} from '@/middleware/index.js'
+import { defineMiddleware } from '@/middleware/index.js'
 import { SM2_DEFAULT_WEIGHTS, SM2Model } from '@/model/sm2.test.js'
 import { defineSchema, isObject } from '@/schema/index.js'
 import { defineScheduler } from './define-scheduler.js'
@@ -64,16 +59,7 @@ export const auditRevlogSchema = defineSchema<
 export const sourceMiddlewareName = 'sourceMiddleware'
 export const statusMiddlewareName = Symbol('statusMiddleware')
 
-type SourceMiddlewareEnv = {
-  readonly config: typeof sourceConfigSchema
-  readonly card: typeof sourceCardSchema
-  readonly revlog: typeof auditRevlogSchema
-}
-
-export const sourceMiddleware: Middleware<
-  SourceMiddlewareEnv,
-  typeof sourceMiddlewareName
-> = {
+export const sourceMiddleware = defineMiddleware({
   name: sourceMiddlewareName,
   schema: {
     config: sourceConfigSchema,
@@ -89,32 +75,21 @@ export const sourceMiddleware: Middleware<
     },
   },
   handlers: {
-    review<Result>(
-      ctx: ReviewMiddlewareContext<SourceMiddlewareEnv>,
-      next: MiddlewareNext<Result>
-    ): Result {
+    review(ctx, next) {
       next()
       ctx.result.card.source = ctx.config.source
       ctx.result.revlog.audit = ctx.config.source
-      return ctx.result as Result
+      return ctx.result
     },
-    rollback<Result>(
-      ctx: RollbackMiddlewareContext<SourceMiddlewareEnv>,
-      next: MiddlewareNext<Result>
-    ): Result {
+    rollback(ctx, next) {
       next()
       ctx.result.card.source = ctx.config.source
-      return ctx.result.card as Result
+      return ctx.result.card
     },
   },
-}
+})
 
-export const statusMiddleware: Middleware<
-  {
-    readonly scheduleStatus: 'suspend' | 'buried'
-  },
-  typeof statusMiddlewareName
-> = {
+export const statusMiddleware = defineMiddleware({
   name: statusMiddlewareName,
   scheduleStatus: ['suspend', 'buried'],
-}
+})

--- a/packages/srs-kit/src/scheduler/scheduler.test.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.test.ts
@@ -1,7 +1,10 @@
 import { numericChrono } from '@/chrono/presets/numeric/chrono.js'
 import { defineMiddleware } from '@/middleware/index.js'
 import { SM2_DEFAULT_WEIGHTS, SM2Model } from '@/model/sm2.test.js'
-import { defineSchema, isObject } from '@/schema/index.js'
+import {
+  defineStringFieldOutputSchema,
+  defineStringFieldSchema,
+} from '@/schema/string-field.test.js'
 import { defineScheduler } from './define-scheduler.js'
 
 export const createSM2NumericScheduler = () =>
@@ -14,46 +17,28 @@ export const config = {
   weights: SM2_DEFAULT_WEIGHTS,
 }
 
-export const sourceConfigSchema = defineSchema<{ readonly source: string }>(
-  (value) => {
-    if (isObject(value) && typeof value.source === 'string') {
-      return { value: { source: value.source } }
-    }
-    return { issues: [{ message: 'Expected source config' }] }
-  }
-)
+export const sourceConfigSchema = defineStringFieldSchema({
+  field: 'source',
+  message: 'Expected source config',
+})
 
 export function defineStringFieldConfigSchema<const Field extends string>(
   field: Field
 ) {
-  return defineSchema<{ readonly [K in Field]: string }>((value) => {
-    if (isObject(value) && typeof value[field] === 'string') {
-      return {
-        value: { [field]: value[field] } as { readonly [K in Field]: string },
-      }
-    }
-    return { issues: [{ message: `Expected ${field} config` }] }
+  return defineStringFieldSchema({
+    field,
+    message: `Expected ${field} config`,
   })
 }
 
-export const sourceCardSchema = defineSchema<
-  unknown,
-  { readonly source: string }
->((value) => {
-  if (isObject(value) && typeof value.source === 'string') {
-    return { value: { source: value.source } }
-  }
-  return { issues: [{ message: 'Expected source card field' }] }
+export const sourceCardSchema = defineStringFieldOutputSchema({
+  field: 'source',
+  message: 'Expected source card field',
 })
 
-export const auditRevlogSchema = defineSchema<
-  unknown,
-  { readonly audit: string }
->((value) => {
-  if (isObject(value) && typeof value.audit === 'string') {
-    return { value: { audit: value.audit } }
-  }
-  return { issues: [{ message: 'Expected audit revlog field' }] }
+export const auditRevlogSchema = defineStringFieldOutputSchema({
+  field: 'audit',
+  message: 'Expected audit revlog field',
 })
 
 export const sourceMiddlewareName = 'sourceMiddleware'

--- a/packages/srs-kit/src/scheduler/scheduler.test.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.test.ts
@@ -79,12 +79,10 @@ export const sourceMiddleware = defineMiddleware({
       next()
       ctx.result.card.source = ctx.config.source
       ctx.result.revlog.audit = ctx.config.source
-      return ctx.result
     },
     rollback(ctx, next) {
       next()
       ctx.result.card.source = ctx.config.source
-      return ctx.result.card
     },
   },
 })

--- a/packages/srs-kit/src/scheduler/scheduler.test.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.test.ts
@@ -17,7 +17,6 @@ export const createSM2NumericScheduler = () =>
 
 export const config = {
   weights: SM2_DEFAULT_WEIGHTS,
-  desiredRetention: 0.9,
 }
 
 export const sourceConfigSchema = defineSchema<{ readonly source: string }>(

--- a/packages/srs-kit/src/scheduler/scheduler.test.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.test.ts
@@ -116,4 +116,5 @@ export const statusMiddleware: Middleware<
   typeof statusMiddlewareName
 > = {
   name: statusMiddlewareName,
+  scheduleStatus: ['suspend', 'buried'],
 }

--- a/packages/srs-kit/src/scheduler/scheduler.test.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.test.ts
@@ -93,25 +93,17 @@ export const sourceMiddleware: Middleware<
       ctx: ReviewMiddlewareContext<SourceMiddlewareEnv>,
       next: MiddlewareNext<Result>
     ): Result {
-      const result = next() as {
-        readonly card: Record<string, unknown>
-        readonly revlog: Record<string, unknown>
-      }
-      result.card.source = ctx.config.source
-      result.revlog.audit = ctx.config.source
-      ctx.result = result
-      return result as Result
+      next()
+      ctx.result.card.source = ctx.config.source
+      ctx.result.revlog.audit = ctx.config.source
+      return ctx.result as Result
     },
     rollback<Result>(
       ctx: RollbackMiddlewareContext<SourceMiddlewareEnv>,
       next: MiddlewareNext<Result>
     ): Result {
-      const restored = next() as Readonly<Record<string, unknown>>
-      const resultCard = {
-        ...restored,
-        source: ctx.config.source,
-      }
-      ctx.result = { card: resultCard }
+      next()
+      ctx.result.card.source = ctx.config.source
       return ctx.result.card as Result
     },
   },

--- a/packages/srs-kit/src/scheduler/scheduler.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.ts
@@ -2,6 +2,7 @@
 
 import type { AnyMiddleware } from '@/middleware/index.js'
 import type { Grade } from '@/primitives/rating.js'
+import type { State } from '@/primitives/state.js'
 import type {
   AnyObjectSchema,
   AnySchema,
@@ -85,9 +86,18 @@ export type BlankSchedulerEnv = {
 }
 
 export type SchedulerCoreFields<Env extends BlankSchedulerEnv> = {
+  readonly state: State
   readonly scheduleStatus: Env['scheduleStatus']
   readonly scheduledDays: number
 }
+
+export type SchedulerCardCoreFields<Env extends BlankSchedulerEnv> =
+  SchedulerCoreFields<Env>
+
+export type SchedulerRevlogCoreFields<Env extends BlankSchedulerEnv> =
+  SchedulerCoreFields<Env> & {
+    readonly rating: Grade
+  }
 
 type SchedulerCoreFieldSchemaPart<
   Env extends BlankSchedulerEnv,
@@ -96,7 +106,9 @@ type SchedulerCoreFieldSchemaPart<
 > = Prettify<
   Assign<
     Direction extends 'input' ? SchemaInput<Env[Key]> : SchemaOutput<Env[Key]>,
-    SchedulerCoreFields<Env>
+    Key extends 'card'
+      ? SchedulerCardCoreFields<Env>
+      : SchedulerRevlogCoreFields<Env>
   >
 >
 

--- a/packages/srs-kit/src/scheduler/scheduler.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.ts
@@ -51,7 +51,7 @@ export interface SchedulerCore<
   readonly config: Readonly<Env['config']>
   readonly newCard: (options?: {
     readonly now?: Env['chrono']
-  }) => Readonly<Env['card']['output']>
+  }) => Env['card']['output']
   readonly review: (input: {
     readonly card: Env['card']['input']
     readonly grade: Grade

--- a/packages/srs-kit/src/scheduler/scheduler.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.ts
@@ -3,6 +3,8 @@ import type { Grade } from '@/primitives/rating.js'
 import type {
   AnyObjectSchema,
   AnySchema,
+  Assign,
+  Prettify,
   SchemaInput,
   SchemaOutput,
 } from '@/schema/index.js'
@@ -64,7 +66,7 @@ export interface SchedulerCore<
   readonly rollback: (input: {
     readonly card: Env['card']['output']
     readonly revlog: Env['revlog']['output']
-  }) => Readonly<Env['card']['output']>
+  }) => Env['card']['output']
 }
 
 export type AnySchedulerCore = SchedulerCore<any>
@@ -80,6 +82,22 @@ export type BlankSchedulerEnv = {
   readonly revlog: AnyObjectSchema
   readonly scheduleStatus: string
 }
+
+export type SchedulerCoreFields<Env extends BlankSchedulerEnv> = {
+  readonly scheduleStatus: Env['scheduleStatus']
+  readonly scheduledDays: number
+}
+
+type SchedulerCoreFieldSchemaPart<
+  Env extends BlankSchedulerEnv,
+  Key extends 'card' | 'revlog',
+  Direction extends 'input' | 'output',
+> = Prettify<
+  Assign<
+    Direction extends 'input' ? SchemaInput<Env[Key]> : SchemaOutput<Env[Key]>,
+    SchedulerCoreFields<Env>
+  >
+>
 
 export interface SchedulerSchema<
   Env extends BlankSchedulerEnv = BlankSchedulerEnv,
@@ -107,12 +125,12 @@ export type SchedulerUseFn<
 export type SchedulerCoreEnv<Env extends BlankSchedulerEnv> = {
   readonly config: SchemaOutput<Env['config']>
   readonly card: {
-    readonly input: SchemaInput<Env['card']>
-    readonly output: SchemaOutput<Env['card']>
+    readonly input: SchedulerCoreFieldSchemaPart<Env, 'card', 'input'>
+    readonly output: SchedulerCoreFieldSchemaPart<Env, 'card', 'output'>
   }
   readonly revlog: {
-    readonly input: SchemaInput<Env['revlog']>
-    readonly output: SchemaOutput<Env['revlog']>
+    readonly input: SchedulerCoreFieldSchemaPart<Env, 'revlog', 'input'>
+    readonly output: SchedulerCoreFieldSchemaPart<Env, 'revlog', 'output'>
   }
   readonly chrono: Env['chrono']
   readonly scheduleStatus: Env['scheduleStatus']
@@ -122,12 +140,12 @@ export type SchedulerCreate<Env extends BlankSchedulerEnv = BlankSchedulerEnv> =
   (ctx: { readonly config: SchemaInput<Env['config']> }) => SchedulerCore<{
     readonly config: SchemaOutput<Env['config']>
     readonly card: {
-      readonly input: SchemaInput<Env['card']>
-      readonly output: SchemaOutput<Env['card']>
+      readonly input: SchedulerCoreFieldSchemaPart<Env, 'card', 'input'>
+      readonly output: SchedulerCoreFieldSchemaPart<Env, 'card', 'output'>
     }
     readonly revlog: {
-      readonly input: SchemaInput<Env['revlog']>
-      readonly output: SchemaOutput<Env['revlog']>
+      readonly input: SchedulerCoreFieldSchemaPart<Env, 'revlog', 'input'>
+      readonly output: SchedulerCoreFieldSchemaPart<Env, 'revlog', 'output'>
     }
     readonly chrono: Env['chrono']
     readonly scheduleStatus: Env['scheduleStatus']

--- a/packages/srs-kit/src/scheduler/scheduler.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.ts
@@ -1,0 +1,157 @@
+/** biome-ignore-all lint/suspicious/noExplicitAny: type-level widening for AnyScheduler */
+import type { Grade } from '@/primitives/rating.js'
+import type {
+  AnyObjectSchema,
+  AnySchema,
+  SchemaInput,
+  SchemaOutput,
+} from '@/schema/index.js'
+import type { ExtendSchedulerEnv } from './infer.js'
+import type { AnyMiddleware } from './middleware.js'
+
+// ==========
+// Schedule Result
+// ==========
+
+export interface ScheduleResult<Card, Revlog> {
+  readonly card: Readonly<Card>
+  readonly revlog: Readonly<Revlog>
+}
+
+export interface PreviewItem<Card, Revlog>
+  extends ScheduleResult<Card, Revlog> {
+  readonly grade: Grade
+}
+
+export interface PreviewResult<Card, Revlog> {
+  [Symbol.iterator](): IterableIterator<PreviewItem<Card, Revlog>>
+}
+
+// ==========
+// Scheduler Core
+// ==========
+
+export type BlankSchedulerCoreEnv = {
+  readonly config: object
+  readonly card: {
+    readonly input: object
+    readonly output: object
+  }
+  readonly revlog: {
+    readonly input: object
+    readonly output: object
+  }
+  readonly chrono: unknown
+  readonly scheduleStatus: string
+}
+
+export interface SchedulerCore<
+  Env extends BlankSchedulerCoreEnv = BlankSchedulerCoreEnv,
+> {
+  readonly config: Readonly<Env['config']>
+  readonly newCard: (options?: {
+    readonly now?: Env['chrono']
+  }) => Readonly<Env['card']['output']>
+  readonly review: (input: {
+    readonly card: Env['card']['input']
+    readonly grade: Grade
+    readonly now?: Env['chrono']
+  }) => ScheduleResult<Env['card']['output'], Env['revlog']['output']>
+  readonly preview: (input: {
+    readonly card: Env['card']['input']
+    readonly now?: Env['chrono']
+  }) => PreviewResult<Env['card']['output'], Env['revlog']['output']>
+  readonly rollback: (input: {
+    readonly card: Env['card']['output']
+    readonly revlog: Env['revlog']['output']
+  }) => Readonly<Env['card']['output']>
+}
+
+export type AnySchedulerCore = SchedulerCore<any>
+
+// ==========
+// Scheduler
+// ==========
+
+export type BlankSchedulerEnv = {
+  readonly chrono: unknown
+  readonly config: AnySchema
+  readonly card: AnyObjectSchema
+  readonly revlog: AnyObjectSchema
+  readonly scheduleStatus: string
+}
+
+export interface SchedulerSchema<
+  Env extends BlankSchedulerEnv = BlankSchedulerEnv,
+> {
+  readonly config: Env['config']
+  readonly card: Env['card']
+  readonly revlog: Env['revlog']
+}
+
+export type SchedulerUseFn<
+  Name extends string | symbol,
+  Env extends BlankSchedulerEnv,
+> = <const AddedMWs extends readonly AnyMiddleware[]>(
+  ...middlewares: AddedMWs
+) => ComposableScheduler<
+  Name,
+  {
+    readonly [K in keyof ExtendSchedulerEnv<Env, AddedMWs>]: ExtendSchedulerEnv<
+      Env,
+      AddedMWs
+    >[K]
+  }
+>
+
+export type SchedulerCoreEnv<Env extends BlankSchedulerEnv> = {
+  readonly config: SchemaOutput<Env['config']>
+  readonly card: {
+    readonly input: SchemaInput<Env['card']>
+    readonly output: SchemaOutput<Env['card']>
+  }
+  readonly revlog: {
+    readonly input: SchemaInput<Env['revlog']>
+    readonly output: SchemaOutput<Env['revlog']>
+  }
+  readonly chrono: Env['chrono']
+  readonly scheduleStatus: Env['scheduleStatus']
+}
+
+export type SchedulerCreate<Env extends BlankSchedulerEnv = BlankSchedulerEnv> =
+  (ctx: { readonly config: SchemaInput<Env['config']> }) => SchedulerCore<{
+    readonly config: SchemaOutput<Env['config']>
+    readonly card: {
+      readonly input: SchemaInput<Env['card']>
+      readonly output: SchemaOutput<Env['card']>
+    }
+    readonly revlog: {
+      readonly input: SchemaInput<Env['revlog']>
+      readonly output: SchemaOutput<Env['revlog']>
+    }
+    readonly chrono: Env['chrono']
+    readonly scheduleStatus: Env['scheduleStatus']
+  }>
+
+/**
+ * Scheduler definition that can be extended with middleware before it is
+ * materialized with create().
+ */
+export interface ComposableScheduler<
+  Name extends string | symbol = string | symbol,
+  Env extends BlankSchedulerEnv = BlankSchedulerEnv,
+> {
+  readonly name: Name
+  readonly schema: SchedulerSchema<Env>
+  readonly create: SchedulerCreate<Env>
+
+  /**
+   * Adds middleware to this scheduler instance.
+   *
+   * Must be called before the first create() call. Once create() has been
+   * called, the scheduler is locked and use() throws SRSSchedulerError.
+   */
+  readonly use: SchedulerUseFn<Name, Env>
+}
+
+export type AnyScheduler = ComposableScheduler<any, any>

--- a/packages/srs-kit/src/scheduler/scheduler.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.ts
@@ -1,4 +1,6 @@
 /** biome-ignore-all lint/suspicious/noExplicitAny: type-level widening for AnyScheduler */
+
+import type { AnyMiddleware } from '@/middleware/index.js'
 import type { Grade } from '@/primitives/rating.js'
 import type {
   AnyObjectSchema,
@@ -9,7 +11,6 @@ import type {
   SchemaOutput,
 } from '@/schema/index.js'
 import type { ExtendSchedulerEnv } from './infer.js'
-import type { AnyMiddleware } from './middleware.js'
 
 // ==========
 // Schedule Result

--- a/packages/srs-kit/src/scheduler/scheduler.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.ts
@@ -156,7 +156,7 @@ export interface ComposableScheduler<
    * Adds middleware to this scheduler instance.
    *
    * Must be called before the first create() call. Once create() has been
-   * called, the scheduler is locked and use() throws SRSSchedulerError.
+   * called, the scheduler is locked and use() throws.
    */
   readonly use: SchedulerUseFn<Name, Env>
 }

--- a/packages/srs-kit/src/scheduler/scheduler.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.ts
@@ -1,8 +1,6 @@
 /** biome-ignore-all lint/suspicious/noExplicitAny: type-level widening for AnyScheduler */
 
 import type { AnyMiddleware } from '@/middleware/index.js'
-import type { Grade } from '@/primitives/rating.js'
-import type { State } from '@/primitives/state.js'
 import type {
   AnyObjectSchema,
   AnySchema,
@@ -11,6 +9,10 @@ import type {
   SchemaInput,
   SchemaOutput,
 } from '@/schema/index.js'
+import type {
+  SchedulerCoreFields,
+  SchedulerRevlogCoreFields,
+} from './fields.js'
 import type { ExtendSchedulerEnv } from './infer.js'
 
 // ==========
@@ -85,20 +87,6 @@ export type BlankSchedulerEnv = {
   readonly scheduleStatus: string
 }
 
-export type SchedulerCoreFields<Env extends BlankSchedulerEnv> = {
-  readonly state: State
-  readonly scheduleStatus: Env['scheduleStatus']
-  readonly scheduledDays: number
-}
-
-export type SchedulerCardCoreFields<Env extends BlankSchedulerEnv> =
-  SchedulerCoreFields<Env>
-
-export type SchedulerRevlogCoreFields<Env extends BlankSchedulerEnv> =
-  SchedulerCoreFields<Env> & {
-    readonly rating: Grade
-  }
-
 type SchedulerCoreFieldSchemaPart<
   Env extends BlankSchedulerEnv,
   Key extends 'card' | 'revlog',
@@ -107,8 +95,8 @@ type SchedulerCoreFieldSchemaPart<
   Assign<
     Direction extends 'input' ? SchemaInput<Env[Key]> : SchemaOutput<Env[Key]>,
     Key extends 'card'
-      ? SchedulerCardCoreFields<Env>
-      : SchedulerRevlogCoreFields<Env>
+      ? SchedulerCoreFields<Env['scheduleStatus']>
+      : SchedulerRevlogCoreFields<Env['scheduleStatus']>
   >
 >
 

--- a/packages/srs-kit/src/scheduler/scheduler.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.ts
@@ -9,6 +9,7 @@ import type {
   Prettify,
   SchemaInput,
   SchemaOutput,
+  SRSSchema,
 } from '@/schema/index.js'
 import type {
   SchedulerCoreFields,
@@ -107,6 +108,10 @@ export interface SchedulerSchema<
   readonly config: Env['config']
   readonly card: Env['card']
   readonly revlog: Env['revlog']
+  readonly scheduleStatus: SRSSchema<{
+    input: Env['scheduleStatus']
+    output: Env['scheduleStatus']
+  }>
 }
 
 export type SchedulerUseFn<

--- a/packages/srs-kit/src/scheduler/scheduler.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.ts
@@ -1,6 +1,7 @@
 /** biome-ignore-all lint/suspicious/noExplicitAny: type-level widening for AnyScheduler */
 
 import type { AnyMiddleware } from '@/middleware/index.js'
+import type { Grade } from '@/primitives/rating.js'
 import type {
   AnyObjectSchema,
   AnySchema,
@@ -113,15 +114,7 @@ export type SchedulerUseFn<
   Env extends BlankSchedulerEnv,
 > = <const AddedMWs extends readonly AnyMiddleware[]>(
   ...middlewares: AddedMWs
-) => ComposableScheduler<
-  Name,
-  {
-    readonly [K in keyof ExtendSchedulerEnv<Env, AddedMWs>]: ExtendSchedulerEnv<
-      Env,
-      AddedMWs
-    >[K]
-  }
->
+) => ComposableScheduler<Name, Prettify<ExtendSchedulerEnv<Env, AddedMWs>>>
 
 export type SchedulerCoreEnv<Env extends BlankSchedulerEnv> = {
   readonly config: SchemaOutput<Env['config']>
@@ -138,19 +131,9 @@ export type SchedulerCoreEnv<Env extends BlankSchedulerEnv> = {
 }
 
 export type SchedulerCreate<Env extends BlankSchedulerEnv = BlankSchedulerEnv> =
-  (ctx: { readonly config: SchemaInput<Env['config']> }) => SchedulerCore<{
-    readonly config: SchemaOutput<Env['config']>
-    readonly card: {
-      readonly input: SchedulerCoreFieldSchemaPart<Env, 'card', 'input'>
-      readonly output: SchedulerCoreFieldSchemaPart<Env, 'card', 'output'>
-    }
-    readonly revlog: {
-      readonly input: SchedulerCoreFieldSchemaPart<Env, 'revlog', 'input'>
-      readonly output: SchedulerCoreFieldSchemaPart<Env, 'revlog', 'output'>
-    }
-    readonly chrono: Env['chrono']
-    readonly scheduleStatus: Env['scheduleStatus']
-  }>
+  (ctx: {
+    readonly config: SchemaInput<Env['config']>
+  }) => SchedulerCore<Prettify<SchedulerCoreEnv<Env>>>
 
 /**
  * Scheduler definition that can be extended with middleware before it is

--- a/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
@@ -1,0 +1,352 @@
+/** biome-ignore-all lint/correctness/noUnusedVariables: type-display fixtures read by LanguageService */
+import { describe, expect, it } from 'vitest'
+import { numericChrono } from '@/chrono/presets/numeric/chrono.js'
+import { SM2_DEFAULT_WEIGHTS, SM2Model } from '@/model/sm2.test.js'
+import { defineSchema, isObject } from '@/schema/index.js'
+import { schedulerStatsMiddleware } from '../middleware/stats.js'
+import { defineScheduler } from './define-scheduler.js'
+import type { Middleware } from './middleware.js'
+
+const sm2NumericScheduler = defineScheduler({
+  model: SM2Model,
+  chrono: numericChrono,
+}).use(schedulerStatsMiddleware)
+
+const baseSm2NumericScheduler = defineScheduler({
+  model: SM2Model,
+  chrono: numericChrono,
+})
+
+const sm2NumericCore = sm2NumericScheduler.create({
+  config: { weights: SM2_DEFAULT_WEIGHTS },
+})
+
+const sourceCardSchema = defineSchema<unknown, { readonly source: string }>(
+  (value) => {
+    if (isObject(value) && typeof value.source === 'string') {
+      return { value: { source: value.source } }
+    }
+    return { issues: [{ message: 'Expected source' }] }
+  }
+)
+
+const auditRevlogSchema = defineSchema<unknown, { readonly audit: string }>(
+  (value) => {
+    if (isObject(value) && typeof value.audit === 'string') {
+      return { value: { audit: value.audit } }
+    }
+    return { issues: [{ message: 'Expected audit' }] }
+  }
+)
+
+const auditMiddlewareName = Symbol('auditMiddleware')
+
+const auditMiddleware: Middleware<
+  {
+    readonly card: typeof sourceCardSchema
+    readonly revlog: typeof auditRevlogSchema
+  },
+  typeof auditMiddlewareName
+> = {
+  name: auditMiddlewareName,
+  schema: {
+    card: sourceCardSchema,
+    revlog: auditRevlogSchema,
+  },
+  defaultValue: {
+    card() {
+      return { source: 'default' }
+    },
+    revlog() {
+      return { audit: 'default' }
+    },
+  },
+  on: {
+    review(_ctx, next) {
+      return next()
+    },
+  },
+}
+
+const sm2NumericSchedulerWithMiddleware = defineScheduler({
+  model: SM2Model,
+  chrono: numericChrono,
+}).use(auditMiddleware, schedulerStatsMiddleware)
+
+const sm2NumericCoreWithMiddleware = sm2NumericSchedulerWithMiddleware.create({
+  config: { weights: SM2_DEFAULT_WEIGHTS },
+})
+
+const SELF = 'src/scheduler/scheduler.type-display.spec.ts'
+
+describe('defineScheduler type display', () => {
+  const service = getTypeDisplayService()
+
+  const expectedSchedulers = {
+    baseSm2NumericScheduler: `const baseSm2NumericScheduler: ComposableScheduler<"sm2", {
+    readonly chrono: number;
+    readonly scheduleStatus: "new" | "learning" | "review";
+    readonly config: SRSSchema<{
+        input: {
+            readonly weights: readonly number[];
+        };
+        output: {
+            readonly weights: readonly number[];
+        };
+    }>;
+    readonly card: SRSSchema<{
+        input: {
+            readonly interval: number;
+            readonly easeFactor: number;
+            readonly reps: number;
+        };
+        output: {
+            readonly interval: number;
+            readonly easeFactor: number;
+            readonly reps: number;
+        };
+    }>;
+    readonly revlog: SRSSchema<{
+        input: {
+            readonly interval: number;
+            readonly easeFactor: number;
+            readonly reps: number;
+        };
+        output: {
+            readonly interval: number;
+            readonly easeFactor: number;
+            readonly reps: number;
+        };
+    }>;
+}>`,
+    sm2NumericScheduler: `const sm2NumericScheduler: ComposableScheduler<"sm2", {
+    readonly chrono: number;
+    readonly scheduleStatus: "new" | "learning" | "review";
+    readonly config: SRSSchema<{
+        input: {
+            readonly weights: readonly number[];
+        };
+        output: {
+            readonly weights: readonly number[];
+        };
+    }>;
+    readonly card: SRSSchema<{
+        input: {
+            readonly interval: number;
+            readonly easeFactor: number;
+            readonly reps: number;
+            readonly state: State;
+            readonly scheduledDays: number;
+            readonly elapsedDays: number;
+            readonly lapses: number;
+        };
+        output: {
+            readonly interval: number;
+            readonly easeFactor: number;
+            readonly reps: number;
+            readonly state: State;
+            readonly scheduledDays: number;
+            readonly elapsedDays: number;
+            readonly lapses: number;
+        };
+    }>;
+    readonly revlog: SRSSchema<{
+        input: {
+            readonly interval: number;
+            readonly easeFactor: number;
+            readonly reps: number;
+            readonly rating: Grade;
+            readonly state: State;
+            readonly scheduledDays: number;
+            readonly elapsedDays: number;
+            readonly lapses: number;
+        };
+        output: {
+            readonly interval: number;
+            readonly easeFactor: number;
+            readonly reps: number;
+            readonly rating: Grade;
+            readonly state: State;
+            readonly scheduledDays: number;
+            readonly elapsedDays: number;
+            readonly lapses: number;
+        };
+    }>;
+}>`,
+    sm2NumericSchedulerWithMiddleware: `const sm2NumericSchedulerWithMiddleware: ComposableScheduler<"sm2", {
+    readonly chrono: number;
+    readonly scheduleStatus: "new" | "learning" | "review";
+    readonly config: SRSSchema<{
+        input: {
+            readonly weights: readonly number[];
+        };
+        output: {
+            readonly weights: readonly number[];
+        };
+    }>;
+    readonly card: SRSSchema<{
+        input: {
+            readonly interval: number;
+            readonly easeFactor: number;
+            readonly reps: number;
+            readonly state: State;
+            readonly scheduledDays: number;
+            readonly elapsedDays: number;
+            readonly lapses: number;
+            readonly source: string;
+        };
+        output: {
+            readonly interval: number;
+            readonly easeFactor: number;
+            readonly reps: number;
+            readonly state: State;
+            readonly scheduledDays: number;
+            readonly elapsedDays: number;
+            readonly lapses: number;
+            readonly source: string;
+        };
+    }>;
+    readonly revlog: SRSSchema<{
+        input: {
+            readonly interval: number;
+            readonly easeFactor: number;
+            readonly reps: number;
+            readonly rating: Grade;
+            readonly state: State;
+            readonly scheduledDays: number;
+            readonly elapsedDays: number;
+            readonly lapses: number;
+            readonly audit: string;
+        };
+        output: {
+            readonly interval: number;
+            readonly easeFactor: number;
+            readonly reps: number;
+            readonly rating: Grade;
+            readonly state: State;
+            readonly scheduledDays: number;
+            readonly elapsedDays: number;
+            readonly lapses: number;
+            readonly audit: string;
+        };
+    }>;
+}>`,
+  }
+
+  const expectedCores = {
+    sm2NumericCoreWithMiddleware: `const sm2NumericCoreWithMiddleware: SchedulerCore<{
+    readonly config: {
+        readonly weights: readonly number[];
+    };
+    readonly card: {
+        readonly input: {
+            readonly interval: number;
+            readonly easeFactor: number;
+            readonly reps: number;
+            readonly state: State;
+            readonly scheduledDays: number;
+            readonly elapsedDays: number;
+            readonly lapses: number;
+            readonly source: string;
+        };
+        readonly output: {
+            readonly interval: number;
+            readonly easeFactor: number;
+            readonly reps: number;
+            readonly state: State;
+            readonly scheduledDays: number;
+            readonly elapsedDays: number;
+            readonly lapses: number;
+            readonly source: string;
+        };
+    };
+    readonly revlog: {
+        readonly input: {
+            readonly interval: number;
+            readonly easeFactor: number;
+            readonly reps: number;
+            readonly rating: Grade;
+            readonly state: State;
+            readonly scheduledDays: number;
+            readonly elapsedDays: number;
+            readonly lapses: number;
+            readonly audit: string;
+        };
+        readonly output: {
+            readonly interval: number;
+            readonly easeFactor: number;
+            readonly reps: number;
+            readonly rating: Grade;
+            readonly state: State;
+            readonly scheduledDays: number;
+            readonly elapsedDays: number;
+            readonly lapses: number;
+            readonly audit: string;
+        };
+    };
+    readonly chrono: number;
+    readonly scheduleStatus: "new" | "learning" | "review";
+}>`,
+    sm2NumericCore: `const sm2NumericCore: SchedulerCore<{
+    readonly config: {
+        readonly weights: readonly number[];
+    };
+    readonly card: {
+        readonly input: {
+            readonly interval: number;
+            readonly easeFactor: number;
+            readonly reps: number;
+            readonly state: State;
+            readonly scheduledDays: number;
+            readonly elapsedDays: number;
+            readonly lapses: number;
+        };
+        readonly output: {
+            readonly interval: number;
+            readonly easeFactor: number;
+            readonly reps: number;
+            readonly state: State;
+            readonly scheduledDays: number;
+            readonly elapsedDays: number;
+            readonly lapses: number;
+        };
+    };
+    readonly revlog: {
+        readonly input: {
+            readonly interval: number;
+            readonly easeFactor: number;
+            readonly reps: number;
+            readonly rating: Grade;
+            readonly state: State;
+            readonly scheduledDays: number;
+            readonly elapsedDays: number;
+            readonly lapses: number;
+        };
+        readonly output: {
+            readonly interval: number;
+            readonly easeFactor: number;
+            readonly reps: number;
+            readonly rating: Grade;
+            readonly state: State;
+            readonly scheduledDays: number;
+            readonly elapsedDays: number;
+            readonly lapses: number;
+        };
+    };
+    readonly chrono: number;
+    readonly scheduleStatus: "new" | "learning" | "review";
+}>`,
+  }
+
+  it('keeps scheduler hovers readable with composed env', () => {
+    for (const [marker, expected] of Object.entries(expectedSchedulers)) {
+      expect(quickInfoAt(service, SELF, marker)).toBe(expected)
+    }
+  })
+
+  it('shows SchedulerCore<T> for scheduler.create()', () => {
+    for (const [marker, expected] of Object.entries(expectedCores)) {
+      expect(quickInfoAt(service, SELF, marker)).toBe(expected)
+    }
+  })
+}, 20_000)

--- a/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
@@ -61,12 +61,14 @@ const auditMiddleware: Middleware<
       return { audit: 'default' }
     },
   },
-  on: {
+  handlers: {
     review(_ctx, next) {
       return next()
     },
   },
 }
+
+const symbolNamedMiddleware = auditMiddleware
 
 const sm2NumericSchedulerWithMiddleware = defineScheduler({
   model: SM2Model,
@@ -338,6 +340,13 @@ describe('defineScheduler type display', () => {
 }>`,
   }
 
+  const expectedMiddlewares = {
+    symbolNamedMiddleware: `const symbolNamedMiddleware: Middleware<{
+    readonly card: typeof sourceCardSchema;
+    readonly revlog: typeof auditRevlogSchema;
+}, typeof auditMiddlewareName>`,
+  }
+
   it('keeps scheduler hovers readable with composed env', () => {
     for (const [marker, expected] of Object.entries(expectedSchedulers)) {
       expect(quickInfoAt(service, SELF, marker)).toBe(expected)
@@ -346,6 +355,12 @@ describe('defineScheduler type display', () => {
 
   it('shows SchedulerCore<T> for scheduler.create()', () => {
     for (const [marker, expected] of Object.entries(expectedCores)) {
+      expect(quickInfoAt(service, SELF, marker)).toBe(expected)
+    }
+  })
+
+  it('keeps symbol middleware names readable', () => {
+    for (const [marker, expected] of Object.entries(expectedMiddlewares)) {
       expect(quickInfoAt(service, SELF, marker)).toBe(expected)
     }
   })

--- a/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
@@ -102,6 +102,7 @@ describe('defineScheduler type display', () => {
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
+            readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
             readonly scheduledDays: number;
         };
@@ -109,6 +110,7 @@ describe('defineScheduler type display', () => {
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
+            readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
             readonly scheduledDays: number;
         };
@@ -119,14 +121,18 @@ describe('defineScheduler type display', () => {
             readonly easeFactor: number;
             readonly reps: number;
             readonly scheduleStatus: "new" | "learning" | "review";
+            readonly state: State;
             readonly scheduledDays: number;
+            readonly rating: Grade;
         };
         output: {
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
             readonly scheduleStatus: "new" | "learning" | "review";
+            readonly state: State;
             readonly scheduledDays: number;
+            readonly rating: Grade;
         };
     }>;
 }>`,
@@ -171,10 +177,10 @@ describe('defineScheduler type display', () => {
             readonly reps: number;
             readonly elapsedDays: number;
             readonly lapses: number;
-            readonly state: State;
-            readonly rating: Grade;
             readonly scheduleStatus: "new" | "learning" | "review";
+            readonly state: State;
             readonly scheduledDays: number;
+            readonly rating: Grade;
         };
         output: {
             readonly interval: number;
@@ -182,10 +188,10 @@ describe('defineScheduler type display', () => {
             readonly reps: number;
             readonly elapsedDays: number;
             readonly lapses: number;
-            readonly state: State;
-            readonly rating: Grade;
             readonly scheduleStatus: "new" | "learning" | "review";
+            readonly state: State;
             readonly scheduledDays: number;
+            readonly rating: Grade;
         };
     }>;
 }>`,
@@ -232,11 +238,11 @@ describe('defineScheduler type display', () => {
             readonly reps: number;
             readonly elapsedDays: number;
             readonly lapses: number;
-            readonly state: State;
-            readonly rating: Grade;
             readonly audit: string;
             readonly scheduleStatus: "new" | "learning" | "review";
+            readonly state: State;
             readonly scheduledDays: number;
+            readonly rating: Grade;
         };
         output: {
             readonly interval: number;
@@ -244,11 +250,11 @@ describe('defineScheduler type display', () => {
             readonly reps: number;
             readonly elapsedDays: number;
             readonly lapses: number;
-            readonly state: State;
-            readonly rating: Grade;
             readonly audit: string;
             readonly scheduleStatus: "new" | "learning" | "review";
+            readonly state: State;
             readonly scheduledDays: number;
+            readonly rating: Grade;
         };
     }>;
 }>`,
@@ -291,11 +297,11 @@ describe('defineScheduler type display', () => {
             readonly reps: number;
             readonly elapsedDays: number;
             readonly lapses: number;
-            readonly state: State;
-            readonly rating: Grade;
             readonly audit: string;
+            readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
             readonly scheduledDays: number;
+            readonly rating: Grade;
         };
         readonly output: {
             readonly interval: number;
@@ -303,11 +309,11 @@ describe('defineScheduler type display', () => {
             readonly reps: number;
             readonly elapsedDays: number;
             readonly lapses: number;
-            readonly state: State;
-            readonly rating: Grade;
             readonly audit: string;
+            readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
             readonly scheduledDays: number;
+            readonly rating: Grade;
         };
     };
     readonly chrono: number;
@@ -348,9 +354,9 @@ describe('defineScheduler type display', () => {
             readonly elapsedDays: number;
             readonly lapses: number;
             readonly state: State;
-            readonly rating: Grade;
             readonly scheduleStatus: "new" | "learning" | "review";
             readonly scheduledDays: number;
+            readonly rating: Grade;
         };
         readonly output: {
             readonly interval: number;
@@ -359,9 +365,9 @@ describe('defineScheduler type display', () => {
             readonly elapsedDays: number;
             readonly lapses: number;
             readonly state: State;
-            readonly rating: Grade;
             readonly scheduleStatus: "new" | "learning" | "review";
             readonly scheduledDays: number;
+            readonly rating: Grade;
         };
     };
     readonly chrono: number;

--- a/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
@@ -94,6 +94,7 @@ describe('defineScheduler type display', () => {
         };
         output: {
             readonly weights: readonly number[];
+            readonly chrono: Record<string, never>;
         };
     }>;
     readonly card: SRSSchema<{
@@ -101,11 +102,15 @@ describe('defineScheduler type display', () => {
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
+            readonly scheduleStatus: "new" | "learning" | "review";
+            readonly scheduledDays: number;
         };
         output: {
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
+            readonly scheduleStatus: "new" | "learning" | "review";
+            readonly scheduledDays: number;
         };
     }>;
     readonly revlog: SRSSchema<{
@@ -113,11 +118,15 @@ describe('defineScheduler type display', () => {
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
+            readonly scheduleStatus: "new" | "learning" | "review";
+            readonly scheduledDays: number;
         };
         output: {
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
+            readonly scheduleStatus: "new" | "learning" | "review";
+            readonly scheduledDays: number;
         };
     }>;
 }>`,
@@ -130,6 +139,7 @@ describe('defineScheduler type display', () => {
         };
         output: {
             readonly weights: readonly number[];
+            readonly chrono: Record<string, never>;
         };
     }>;
     readonly card: SRSSchema<{
@@ -137,19 +147,21 @@ describe('defineScheduler type display', () => {
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
-            readonly state: State;
-            readonly scheduledDays: number;
             readonly elapsedDays: number;
             readonly lapses: number;
+            readonly state: State;
+            readonly scheduleStatus: "new" | "learning" | "review";
+            readonly scheduledDays: number;
         };
         output: {
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
-            readonly state: State;
-            readonly scheduledDays: number;
             readonly elapsedDays: number;
             readonly lapses: number;
+            readonly state: State;
+            readonly scheduleStatus: "new" | "learning" | "review";
+            readonly scheduledDays: number;
         };
     }>;
     readonly revlog: SRSSchema<{
@@ -157,21 +169,23 @@ describe('defineScheduler type display', () => {
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
-            readonly rating: Grade;
-            readonly state: State;
-            readonly scheduledDays: number;
             readonly elapsedDays: number;
             readonly lapses: number;
+            readonly state: State;
+            readonly rating: Grade;
+            readonly scheduleStatus: "new" | "learning" | "review";
+            readonly scheduledDays: number;
         };
         output: {
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
-            readonly rating: Grade;
-            readonly state: State;
-            readonly scheduledDays: number;
             readonly elapsedDays: number;
             readonly lapses: number;
+            readonly state: State;
+            readonly rating: Grade;
+            readonly scheduleStatus: "new" | "learning" | "review";
+            readonly scheduledDays: number;
         };
     }>;
 }>`,
@@ -184,28 +198,31 @@ describe('defineScheduler type display', () => {
         };
         output: {
             readonly weights: readonly number[];
+            readonly chrono: Record<string, never>;
         };
     }>;
     readonly card: SRSSchema<{
         input: {
+            readonly source: string;
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
-            readonly state: State;
-            readonly scheduledDays: number;
             readonly elapsedDays: number;
             readonly lapses: number;
-            readonly source: string;
+            readonly state: State;
+            readonly scheduleStatus: "new" | "learning" | "review";
+            readonly scheduledDays: number;
         };
         output: {
+            readonly source: string;
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
-            readonly state: State;
-            readonly scheduledDays: number;
             readonly elapsedDays: number;
             readonly lapses: number;
-            readonly source: string;
+            readonly state: State;
+            readonly scheduleStatus: "new" | "learning" | "review";
+            readonly scheduledDays: number;
         };
     }>;
     readonly revlog: SRSSchema<{
@@ -213,23 +230,25 @@ describe('defineScheduler type display', () => {
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
-            readonly rating: Grade;
-            readonly state: State;
-            readonly scheduledDays: number;
             readonly elapsedDays: number;
             readonly lapses: number;
+            readonly state: State;
+            readonly rating: Grade;
             readonly audit: string;
+            readonly scheduleStatus: "new" | "learning" | "review";
+            readonly scheduledDays: number;
         };
         output: {
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
-            readonly rating: Grade;
-            readonly state: State;
-            readonly scheduledDays: number;
             readonly elapsedDays: number;
             readonly lapses: number;
+            readonly state: State;
+            readonly rating: Grade;
             readonly audit: string;
+            readonly scheduleStatus: "new" | "learning" | "review";
+            readonly scheduledDays: number;
         };
     }>;
 }>`,
@@ -239,27 +258,30 @@ describe('defineScheduler type display', () => {
     sm2NumericCoreWithMiddleware: `const sm2NumericCoreWithMiddleware: SchedulerCore<{
     readonly config: {
         readonly weights: readonly number[];
+        readonly chrono: Record<string, never>;
     };
     readonly card: {
         readonly input: {
+            readonly source: string;
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
-            readonly state: State;
-            readonly scheduledDays: number;
             readonly elapsedDays: number;
             readonly lapses: number;
-            readonly source: string;
+            readonly state: State;
+            readonly scheduleStatus: "new" | "learning" | "review";
+            readonly scheduledDays: number;
         };
         readonly output: {
+            readonly source: string;
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
-            readonly state: State;
-            readonly scheduledDays: number;
             readonly elapsedDays: number;
             readonly lapses: number;
-            readonly source: string;
+            readonly state: State;
+            readonly scheduleStatus: "new" | "learning" | "review";
+            readonly scheduledDays: number;
         };
     };
     readonly revlog: {
@@ -267,23 +289,25 @@ describe('defineScheduler type display', () => {
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
-            readonly rating: Grade;
-            readonly state: State;
-            readonly scheduledDays: number;
             readonly elapsedDays: number;
             readonly lapses: number;
+            readonly state: State;
+            readonly rating: Grade;
             readonly audit: string;
+            readonly scheduleStatus: "new" | "learning" | "review";
+            readonly scheduledDays: number;
         };
         readonly output: {
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
-            readonly rating: Grade;
-            readonly state: State;
-            readonly scheduledDays: number;
             readonly elapsedDays: number;
             readonly lapses: number;
+            readonly state: State;
+            readonly rating: Grade;
             readonly audit: string;
+            readonly scheduleStatus: "new" | "learning" | "review";
+            readonly scheduledDays: number;
         };
     };
     readonly chrono: number;
@@ -292,25 +316,28 @@ describe('defineScheduler type display', () => {
     sm2NumericCore: `const sm2NumericCore: SchedulerCore<{
     readonly config: {
         readonly weights: readonly number[];
+        readonly chrono: Record<string, never>;
     };
     readonly card: {
         readonly input: {
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
-            readonly state: State;
-            readonly scheduledDays: number;
             readonly elapsedDays: number;
             readonly lapses: number;
+            readonly state: State;
+            readonly scheduleStatus: "new" | "learning" | "review";
+            readonly scheduledDays: number;
         };
         readonly output: {
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
-            readonly state: State;
-            readonly scheduledDays: number;
             readonly elapsedDays: number;
             readonly lapses: number;
+            readonly state: State;
+            readonly scheduleStatus: "new" | "learning" | "review";
+            readonly scheduledDays: number;
         };
     };
     readonly revlog: {
@@ -318,21 +345,23 @@ describe('defineScheduler type display', () => {
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
-            readonly rating: Grade;
-            readonly state: State;
-            readonly scheduledDays: number;
             readonly elapsedDays: number;
             readonly lapses: number;
+            readonly state: State;
+            readonly rating: Grade;
+            readonly scheduleStatus: "new" | "learning" | "review";
+            readonly scheduledDays: number;
         };
         readonly output: {
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
-            readonly rating: Grade;
-            readonly state: State;
-            readonly scheduledDays: number;
             readonly elapsedDays: number;
             readonly lapses: number;
+            readonly state: State;
+            readonly rating: Grade;
+            readonly scheduleStatus: "new" | "learning" | "review";
+            readonly scheduledDays: number;
         };
     };
     readonly chrono: number;

--- a/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
@@ -1,11 +1,11 @@
 /** biome-ignore-all lint/correctness/noUnusedVariables: type-display fixtures read by LanguageService */
 import { describe, expect, it } from 'vitest'
 import { numericChrono } from '@/chrono/presets/numeric/chrono.js'
+import type { Middleware } from '@/middleware/index.js'
+import { schedulerStatsMiddleware } from '@/middleware/stats.js'
 import { SM2_DEFAULT_WEIGHTS, SM2Model } from '@/model/sm2.test.js'
 import { defineSchema, isObject } from '@/schema/index.js'
-import { schedulerStatsMiddleware } from '../middleware/stats.js'
 import { defineScheduler } from './define-scheduler.js'
-import type { Middleware } from './middleware.js'
 
 const sm2NumericScheduler = defineScheduler({
   model: SM2Model,

--- a/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
@@ -4,7 +4,7 @@ import { numericChrono } from '@/chrono/presets/numeric/chrono.js'
 import { defineMiddleware } from '@/middleware/index.js'
 import { schedulerStatsMiddleware } from '@/middleware/stats/index.js'
 import { SM2_DEFAULT_WEIGHTS, SM2Model } from '@/model/sm2.test.js'
-import { defineSchema, isObject } from '@/schema/index.js'
+import { defineStringFieldOutputSchema } from '@/schema/string-field.test.js'
 import { defineScheduler } from './define-scheduler.js'
 
 const sm2NumericScheduler = defineScheduler({
@@ -21,23 +21,15 @@ const sm2NumericCore = sm2NumericScheduler.create({
   config: { weights: SM2_DEFAULT_WEIGHTS },
 })
 
-const sourceCardSchema = defineSchema<unknown, { readonly source: string }>(
-  (value) => {
-    if (isObject(value) && typeof value.source === 'string') {
-      return { value: { source: value.source } }
-    }
-    return { issues: [{ message: 'Expected source' }] }
-  }
-)
+const sourceCardSchema = defineStringFieldOutputSchema({
+  field: 'source',
+  message: 'Expected source',
+})
 
-const auditRevlogSchema = defineSchema<unknown, { readonly audit: string }>(
-  (value) => {
-    if (isObject(value) && typeof value.audit === 'string') {
-      return { value: { audit: value.audit } }
-    }
-    return { issues: [{ message: 'Expected audit' }] }
-  }
-)
+const auditRevlogSchema = defineStringFieldOutputSchema({
+  field: 'audit',
+  message: 'Expected audit',
+})
 
 const auditMiddlewareName = 'auditMiddleware'
 

--- a/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
@@ -70,6 +70,29 @@ const auditMiddleware: Middleware<
 
 const symbolNamedMiddleware = auditMiddleware
 
+const suspendMiddleware: Middleware<
+  {
+    readonly scheduleStatus: 'suspend'
+  },
+  'suspendMiddleware'
+> = {
+  name: 'suspendMiddleware',
+  handlers: {
+    review(_ctx, next) {
+      return next()
+    },
+  },
+}
+
+const sm2WithSuspend = defineScheduler({
+  model: SM2Model,
+  chrono: numericChrono,
+}).use(suspendMiddleware)
+
+const sm2WithSuspendCore = sm2WithSuspend.create({
+  config: { weights: SM2_DEFAULT_WEIGHTS },
+})
+
 const sm2NumericSchedulerWithMiddleware = defineScheduler({
   model: SM2Model,
   chrono: numericChrono,
@@ -351,6 +374,106 @@ describe('defineScheduler type display', () => {
 }>`,
   }
 
+  const expectedSuspend = {
+    sm2WithSuspend: `const sm2WithSuspend: ComposableScheduler<"sm2", {
+    readonly chrono: number;
+    readonly scheduleStatus: "new" | "learning" | "review" | "suspend";
+    readonly config: SRSSchema<{
+        input: {
+            readonly weights: readonly number[];
+        };
+        output: {
+            readonly weights: readonly number[];
+            readonly chrono: Record<string, never>;
+        };
+    }>;
+    readonly card: SRSSchema<{
+        input: {
+            readonly interval: number;
+            readonly easeFactor: number;
+            readonly reps: number;
+            readonly state: State;
+            readonly scheduleStatus: "new" | "learning" | "review" | "suspend";
+            readonly scheduledDays: number;
+        };
+        output: {
+            readonly interval: number;
+            readonly easeFactor: number;
+            readonly reps: number;
+            readonly state: State;
+            readonly scheduleStatus: "new" | "learning" | "review" | "suspend";
+            readonly scheduledDays: number;
+        };
+    }>;
+    readonly revlog: SRSSchema<{
+        input: {
+            readonly interval: number;
+            readonly easeFactor: number;
+            readonly reps: number;
+            readonly state: State;
+            readonly scheduleStatus: "new" | "learning" | "review" | "suspend";
+            readonly scheduledDays: number;
+            readonly rating: Grade;
+        };
+        output: {
+            readonly interval: number;
+            readonly easeFactor: number;
+            readonly reps: number;
+            readonly state: State;
+            readonly scheduleStatus: "new" | "learning" | "review" | "suspend";
+            readonly scheduledDays: number;
+            readonly rating: Grade;
+        };
+    }>;
+}>`,
+    sm2WithSuspendCore: `const sm2WithSuspendCore: SchedulerCore<{
+    readonly config: {
+        readonly weights: readonly number[];
+        readonly chrono: Record<string, never>;
+    };
+    readonly card: {
+        readonly input: {
+            readonly interval: number;
+            readonly easeFactor: number;
+            readonly reps: number;
+            readonly state: State;
+            readonly scheduleStatus: "new" | "learning" | "review" | "suspend";
+            readonly scheduledDays: number;
+        };
+        readonly output: {
+            readonly interval: number;
+            readonly easeFactor: number;
+            readonly reps: number;
+            readonly state: State;
+            readonly scheduleStatus: "new" | "learning" | "review" | "suspend";
+            readonly scheduledDays: number;
+        };
+    };
+    readonly revlog: {
+        readonly input: {
+            readonly interval: number;
+            readonly easeFactor: number;
+            readonly reps: number;
+            readonly state: State;
+            readonly scheduleStatus: "new" | "learning" | "review" | "suspend";
+            readonly scheduledDays: number;
+            readonly rating: Grade;
+        };
+        readonly output: {
+            readonly interval: number;
+            readonly easeFactor: number;
+            readonly reps: number;
+            readonly state: State;
+            readonly scheduleStatus: "new" | "learning" | "review" | "suspend";
+            readonly scheduledDays: number;
+            readonly rating: Grade;
+        };
+    };
+    readonly chrono: number;
+    readonly scheduleStatus: "new" | "learning" | "review" | "suspend";
+}>`,
+  }
+
   const expectedMiddlewares = {
     symbolNamedMiddleware: `const symbolNamedMiddleware: Middleware<{
     readonly card: typeof sourceCardSchema;
@@ -366,6 +489,12 @@ describe('defineScheduler type display', () => {
 
   it('shows SchedulerCore<T> for scheduler.create()', () => {
     for (const [marker, expected] of Object.entries(expectedCores)) {
+      expect(quickInfoAt(service, SELF, marker)).toBe(expected)
+    }
+  })
+
+  it('extends scheduleStatus with middleware-contributed status', () => {
+    for (const [marker, expected] of Object.entries(expectedSuspend)) {
       expect(quickInfoAt(service, SELF, marker)).toBe(expected)
     }
   })

--- a/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
@@ -2,7 +2,7 @@
 import { describe, expect, it } from 'vitest'
 import { numericChrono } from '@/chrono/presets/numeric/chrono.js'
 import type { Middleware } from '@/middleware/index.js'
-import { schedulerStatsMiddleware } from '@/middleware/stats.js'
+import { schedulerStatsMiddleware } from '@/middleware/stats/index.js'
 import { SM2_DEFAULT_WEIGHTS, SM2Model } from '@/model/sm2.test.js'
 import { defineSchema, isObject } from '@/schema/index.js'
 import { defineScheduler } from './define-scheduler.js'
@@ -153,7 +153,6 @@ describe('defineScheduler type display', () => {
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
-            readonly elapsedDays: number;
             readonly lapses: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
@@ -163,7 +162,6 @@ describe('defineScheduler type display', () => {
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
-            readonly elapsedDays: number;
             readonly lapses: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
@@ -175,7 +173,6 @@ describe('defineScheduler type display', () => {
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
-            readonly elapsedDays: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
             readonly scheduledDays: number;
@@ -185,7 +182,6 @@ describe('defineScheduler type display', () => {
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
-            readonly elapsedDays: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
             readonly scheduledDays: number;
@@ -211,7 +207,6 @@ describe('defineScheduler type display', () => {
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
-            readonly elapsedDays: number;
             readonly lapses: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
@@ -222,7 +217,6 @@ describe('defineScheduler type display', () => {
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
-            readonly elapsedDays: number;
             readonly lapses: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
@@ -234,7 +228,6 @@ describe('defineScheduler type display', () => {
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
-            readonly elapsedDays: number;
             readonly audit: string;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
@@ -245,7 +238,6 @@ describe('defineScheduler type display', () => {
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
-            readonly elapsedDays: number;
             readonly audit: string;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
@@ -268,7 +260,6 @@ describe('defineScheduler type display', () => {
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
-            readonly elapsedDays: number;
             readonly lapses: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
@@ -279,7 +270,6 @@ describe('defineScheduler type display', () => {
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
-            readonly elapsedDays: number;
             readonly lapses: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
@@ -291,7 +281,6 @@ describe('defineScheduler type display', () => {
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
-            readonly elapsedDays: number;
             readonly audit: string;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
@@ -302,7 +291,6 @@ describe('defineScheduler type display', () => {
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
-            readonly elapsedDays: number;
             readonly audit: string;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
@@ -323,7 +311,6 @@ describe('defineScheduler type display', () => {
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
-            readonly elapsedDays: number;
             readonly lapses: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
@@ -333,7 +320,6 @@ describe('defineScheduler type display', () => {
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
-            readonly elapsedDays: number;
             readonly lapses: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
@@ -345,7 +331,6 @@ describe('defineScheduler type display', () => {
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
-            readonly elapsedDays: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
             readonly scheduledDays: number;
@@ -355,7 +340,6 @@ describe('defineScheduler type display', () => {
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
-            readonly elapsedDays: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
             readonly scheduledDays: number;

--- a/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
@@ -120,8 +120,8 @@ describe('defineScheduler type display', () => {
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
-            readonly scheduleStatus: "new" | "learning" | "review";
             readonly state: State;
+            readonly scheduleStatus: "new" | "learning" | "review";
             readonly scheduledDays: number;
             readonly rating: Grade;
         };
@@ -129,8 +129,8 @@ describe('defineScheduler type display', () => {
             readonly interval: number;
             readonly easeFactor: number;
             readonly reps: number;
-            readonly scheduleStatus: "new" | "learning" | "review";
             readonly state: State;
+            readonly scheduleStatus: "new" | "learning" | "review";
             readonly scheduledDays: number;
             readonly rating: Grade;
         };
@@ -177,8 +177,8 @@ describe('defineScheduler type display', () => {
             readonly reps: number;
             readonly elapsedDays: number;
             readonly lapses: number;
-            readonly scheduleStatus: "new" | "learning" | "review";
             readonly state: State;
+            readonly scheduleStatus: "new" | "learning" | "review";
             readonly scheduledDays: number;
             readonly rating: Grade;
         };
@@ -188,8 +188,8 @@ describe('defineScheduler type display', () => {
             readonly reps: number;
             readonly elapsedDays: number;
             readonly lapses: number;
-            readonly scheduleStatus: "new" | "learning" | "review";
             readonly state: State;
+            readonly scheduleStatus: "new" | "learning" | "review";
             readonly scheduledDays: number;
             readonly rating: Grade;
         };
@@ -239,8 +239,8 @@ describe('defineScheduler type display', () => {
             readonly elapsedDays: number;
             readonly lapses: number;
             readonly audit: string;
-            readonly scheduleStatus: "new" | "learning" | "review";
             readonly state: State;
+            readonly scheduleStatus: "new" | "learning" | "review";
             readonly scheduledDays: number;
             readonly rating: Grade;
         };
@@ -251,8 +251,8 @@ describe('defineScheduler type display', () => {
             readonly elapsedDays: number;
             readonly lapses: number;
             readonly audit: string;
-            readonly scheduleStatus: "new" | "learning" | "review";
             readonly state: State;
+            readonly scheduleStatus: "new" | "learning" | "review";
             readonly scheduledDays: number;
             readonly rating: Grade;
         };

--- a/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
@@ -106,14 +106,14 @@ describe('defineScheduler type display', () => {
         input: {
             readonly interval: number;
             readonly easeFactor: number;
-            readonly reps: number;
+            readonly reviewStep: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
         };
         output: {
             readonly interval: number;
             readonly easeFactor: number;
-            readonly reps: number;
+            readonly reviewStep: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
         };
@@ -122,7 +122,7 @@ describe('defineScheduler type display', () => {
         input: {
             readonly interval: number;
             readonly easeFactor: number;
-            readonly reps: number;
+            readonly reviewStep: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
             readonly rating: Grade;
@@ -130,7 +130,7 @@ describe('defineScheduler type display', () => {
         output: {
             readonly interval: number;
             readonly easeFactor: number;
-            readonly reps: number;
+            readonly reviewStep: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
             readonly rating: Grade;
@@ -153,6 +153,7 @@ describe('defineScheduler type display', () => {
         input: {
             readonly interval: number;
             readonly easeFactor: number;
+            readonly reviewStep: number;
             readonly reps: number;
             readonly lapses: number;
             readonly state: State;
@@ -161,6 +162,7 @@ describe('defineScheduler type display', () => {
         output: {
             readonly interval: number;
             readonly easeFactor: number;
+            readonly reviewStep: number;
             readonly reps: number;
             readonly lapses: number;
             readonly state: State;
@@ -171,7 +173,7 @@ describe('defineScheduler type display', () => {
         input: {
             readonly interval: number;
             readonly easeFactor: number;
-            readonly reps: number;
+            readonly reviewStep: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
             readonly rating: Grade;
@@ -179,7 +181,7 @@ describe('defineScheduler type display', () => {
         output: {
             readonly interval: number;
             readonly easeFactor: number;
-            readonly reps: number;
+            readonly reviewStep: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
             readonly rating: Grade;
@@ -203,6 +205,7 @@ describe('defineScheduler type display', () => {
             readonly source: string;
             readonly interval: number;
             readonly easeFactor: number;
+            readonly reviewStep: number;
             readonly reps: number;
             readonly lapses: number;
             readonly state: State;
@@ -212,6 +215,7 @@ describe('defineScheduler type display', () => {
             readonly source: string;
             readonly interval: number;
             readonly easeFactor: number;
+            readonly reviewStep: number;
             readonly reps: number;
             readonly lapses: number;
             readonly state: State;
@@ -222,7 +226,7 @@ describe('defineScheduler type display', () => {
         input: {
             readonly interval: number;
             readonly easeFactor: number;
-            readonly reps: number;
+            readonly reviewStep: number;
             readonly audit: string;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
@@ -231,7 +235,7 @@ describe('defineScheduler type display', () => {
         output: {
             readonly interval: number;
             readonly easeFactor: number;
-            readonly reps: number;
+            readonly reviewStep: number;
             readonly audit: string;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
@@ -252,6 +256,7 @@ describe('defineScheduler type display', () => {
             readonly source: string;
             readonly interval: number;
             readonly easeFactor: number;
+            readonly reviewStep: number;
             readonly reps: number;
             readonly lapses: number;
             readonly state: State;
@@ -261,6 +266,7 @@ describe('defineScheduler type display', () => {
             readonly source: string;
             readonly interval: number;
             readonly easeFactor: number;
+            readonly reviewStep: number;
             readonly reps: number;
             readonly lapses: number;
             readonly state: State;
@@ -271,7 +277,7 @@ describe('defineScheduler type display', () => {
         readonly input: {
             readonly interval: number;
             readonly easeFactor: number;
-            readonly reps: number;
+            readonly reviewStep: number;
             readonly audit: string;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
@@ -280,7 +286,7 @@ describe('defineScheduler type display', () => {
         readonly output: {
             readonly interval: number;
             readonly easeFactor: number;
-            readonly reps: number;
+            readonly reviewStep: number;
             readonly audit: string;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
@@ -299,6 +305,7 @@ describe('defineScheduler type display', () => {
         readonly input: {
             readonly interval: number;
             readonly easeFactor: number;
+            readonly reviewStep: number;
             readonly reps: number;
             readonly lapses: number;
             readonly state: State;
@@ -307,6 +314,7 @@ describe('defineScheduler type display', () => {
         readonly output: {
             readonly interval: number;
             readonly easeFactor: number;
+            readonly reviewStep: number;
             readonly reps: number;
             readonly lapses: number;
             readonly state: State;
@@ -317,7 +325,7 @@ describe('defineScheduler type display', () => {
         readonly input: {
             readonly interval: number;
             readonly easeFactor: number;
-            readonly reps: number;
+            readonly reviewStep: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
             readonly rating: Grade;
@@ -325,7 +333,7 @@ describe('defineScheduler type display', () => {
         readonly output: {
             readonly interval: number;
             readonly easeFactor: number;
-            readonly reps: number;
+            readonly reviewStep: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
             readonly rating: Grade;
@@ -353,14 +361,14 @@ describe('defineScheduler type display', () => {
         input: {
             readonly interval: number;
             readonly easeFactor: number;
-            readonly reps: number;
+            readonly reviewStep: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review" | "suspend";
         };
         output: {
             readonly interval: number;
             readonly easeFactor: number;
-            readonly reps: number;
+            readonly reviewStep: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review" | "suspend";
         };
@@ -369,7 +377,7 @@ describe('defineScheduler type display', () => {
         input: {
             readonly interval: number;
             readonly easeFactor: number;
-            readonly reps: number;
+            readonly reviewStep: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review" | "suspend";
             readonly rating: Grade;
@@ -377,7 +385,7 @@ describe('defineScheduler type display', () => {
         output: {
             readonly interval: number;
             readonly easeFactor: number;
-            readonly reps: number;
+            readonly reviewStep: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review" | "suspend";
             readonly rating: Grade;
@@ -393,14 +401,14 @@ describe('defineScheduler type display', () => {
         readonly input: {
             readonly interval: number;
             readonly easeFactor: number;
-            readonly reps: number;
+            readonly reviewStep: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review" | "suspend";
         };
         readonly output: {
             readonly interval: number;
             readonly easeFactor: number;
-            readonly reps: number;
+            readonly reviewStep: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review" | "suspend";
         };
@@ -409,7 +417,7 @@ describe('defineScheduler type display', () => {
         readonly input: {
             readonly interval: number;
             readonly easeFactor: number;
-            readonly reps: number;
+            readonly reviewStep: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review" | "suspend";
             readonly rating: Grade;
@@ -417,7 +425,7 @@ describe('defineScheduler type display', () => {
         readonly output: {
             readonly interval: number;
             readonly easeFactor: number;
-            readonly reps: number;
+            readonly reviewStep: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review" | "suspend";
             readonly rating: Grade;

--- a/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
@@ -1,7 +1,7 @@
 /** biome-ignore-all lint/correctness/noUnusedVariables: type-display fixtures read by LanguageService */
 import { describe, expect, it } from 'vitest'
 import { numericChrono } from '@/chrono/presets/numeric/chrono.js'
-import type { Middleware } from '@/middleware/index.js'
+import { defineMiddleware } from '@/middleware/index.js'
 import { schedulerStatsMiddleware } from '@/middleware/stats/index.js'
 import { SM2_DEFAULT_WEIGHTS, SM2Model } from '@/model/sm2.test.js'
 import { defineSchema, isObject } from '@/schema/index.js'
@@ -39,15 +39,9 @@ const auditRevlogSchema = defineSchema<unknown, { readonly audit: string }>(
   }
 )
 
-const auditMiddlewareName = Symbol('auditMiddleware')
+const auditMiddlewareName = 'auditMiddleware'
 
-const auditMiddleware: Middleware<
-  {
-    readonly card: typeof sourceCardSchema
-    readonly revlog: typeof auditRevlogSchema
-  },
-  typeof auditMiddlewareName
-> = {
+const auditMiddleware = defineMiddleware({
   name: auditMiddlewareName,
   schema: {
     card: sourceCardSchema,
@@ -66,16 +60,11 @@ const auditMiddleware: Middleware<
       return next()
     },
   },
-}
+})
 
-const symbolNamedMiddleware = auditMiddleware
+const namedMiddleware = auditMiddleware
 
-const suspendMiddleware: Middleware<
-  {
-    readonly scheduleStatus: 'suspend'
-  },
-  'suspendMiddleware'
-> = {
+const suspendMiddleware = defineMiddleware({
   name: 'suspendMiddleware',
   scheduleStatus: ['suspend'],
   handlers: {
@@ -83,7 +72,7 @@ const suspendMiddleware: Middleware<
       return next()
     },
   },
-}
+})
 
 const sm2WithSuspend = defineScheduler({
   model: SM2Model,
@@ -448,10 +437,20 @@ describe('defineScheduler type display', () => {
   }
 
   const expectedMiddlewares = {
-    symbolNamedMiddleware: `const symbolNamedMiddleware: Middleware<{
-    readonly card: typeof sourceCardSchema;
-    readonly revlog: typeof auditRevlogSchema;
-}, typeof auditMiddlewareName>`,
+    namedMiddleware: `const namedMiddleware: Middleware<"auditMiddleware", {
+    readonly card: SRSSchema<{
+        input: {};
+        output: {
+            readonly source: string;
+        };
+    }>;
+    readonly revlog: SRSSchema<{
+        input: {};
+        output: {
+            readonly audit: string;
+        };
+    }>;
+}>`,
   }
 
   it('keeps scheduler hovers readable with composed env', () => {
@@ -472,7 +471,7 @@ describe('defineScheduler type display', () => {
     }
   })
 
-  it('keeps symbol middleware names readable', () => {
+  it('keeps middleware names readable', () => {
     for (const [marker, expected] of Object.entries(expectedMiddlewares)) {
       expect(quickInfoAt(service, SELF, marker)).toBe(expected)
     }

--- a/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
@@ -57,7 +57,7 @@ const auditMiddleware = defineMiddleware({
   },
   handlers: {
     review(_ctx, next) {
-      return next()
+      next()
     },
   },
 })
@@ -69,7 +69,7 @@ const suspendMiddleware = defineMiddleware({
   scheduleStatus: ['suspend'],
   handlers: {
     review(_ctx, next) {
-      return next()
+      next()
     },
   },
 })

--- a/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
@@ -77,6 +77,7 @@ const suspendMiddleware: Middleware<
   'suspendMiddleware'
 > = {
   name: 'suspendMiddleware',
+  scheduleStatus: ['suspend'],
   handlers: {
     review(_ctx, next) {
       return next()
@@ -127,7 +128,6 @@ describe('defineScheduler type display', () => {
             readonly reps: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
-            readonly scheduledDays: number;
         };
         output: {
             readonly interval: number;
@@ -135,7 +135,6 @@ describe('defineScheduler type display', () => {
             readonly reps: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
-            readonly scheduledDays: number;
         };
     }>;
     readonly revlog: SRSSchema<{
@@ -145,7 +144,6 @@ describe('defineScheduler type display', () => {
             readonly reps: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
-            readonly scheduledDays: number;
             readonly rating: Grade;
         };
         output: {
@@ -154,7 +152,6 @@ describe('defineScheduler type display', () => {
             readonly reps: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
-            readonly scheduledDays: number;
             readonly rating: Grade;
         };
     }>;
@@ -179,7 +176,6 @@ describe('defineScheduler type display', () => {
             readonly lapses: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
-            readonly scheduledDays: number;
         };
         output: {
             readonly interval: number;
@@ -188,7 +184,6 @@ describe('defineScheduler type display', () => {
             readonly lapses: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
-            readonly scheduledDays: number;
         };
     }>;
     readonly revlog: SRSSchema<{
@@ -198,7 +193,6 @@ describe('defineScheduler type display', () => {
             readonly reps: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
-            readonly scheduledDays: number;
             readonly rating: Grade;
         };
         output: {
@@ -207,7 +201,6 @@ describe('defineScheduler type display', () => {
             readonly reps: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
-            readonly scheduledDays: number;
             readonly rating: Grade;
         };
     }>;
@@ -233,7 +226,6 @@ describe('defineScheduler type display', () => {
             readonly lapses: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
-            readonly scheduledDays: number;
         };
         output: {
             readonly source: string;
@@ -243,7 +235,6 @@ describe('defineScheduler type display', () => {
             readonly lapses: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
-            readonly scheduledDays: number;
         };
     }>;
     readonly revlog: SRSSchema<{
@@ -254,7 +245,6 @@ describe('defineScheduler type display', () => {
             readonly audit: string;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
-            readonly scheduledDays: number;
             readonly rating: Grade;
         };
         output: {
@@ -264,7 +254,6 @@ describe('defineScheduler type display', () => {
             readonly audit: string;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
-            readonly scheduledDays: number;
             readonly rating: Grade;
         };
     }>;
@@ -286,7 +275,6 @@ describe('defineScheduler type display', () => {
             readonly lapses: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
-            readonly scheduledDays: number;
         };
         readonly output: {
             readonly source: string;
@@ -296,7 +284,6 @@ describe('defineScheduler type display', () => {
             readonly lapses: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
-            readonly scheduledDays: number;
         };
     };
     readonly revlog: {
@@ -307,7 +294,6 @@ describe('defineScheduler type display', () => {
             readonly audit: string;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
-            readonly scheduledDays: number;
             readonly rating: Grade;
         };
         readonly output: {
@@ -317,7 +303,6 @@ describe('defineScheduler type display', () => {
             readonly audit: string;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
-            readonly scheduledDays: number;
             readonly rating: Grade;
         };
     };
@@ -337,7 +322,6 @@ describe('defineScheduler type display', () => {
             readonly lapses: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
-            readonly scheduledDays: number;
         };
         readonly output: {
             readonly interval: number;
@@ -346,7 +330,6 @@ describe('defineScheduler type display', () => {
             readonly lapses: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
-            readonly scheduledDays: number;
         };
     };
     readonly revlog: {
@@ -356,7 +339,6 @@ describe('defineScheduler type display', () => {
             readonly reps: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
-            readonly scheduledDays: number;
             readonly rating: Grade;
         };
         readonly output: {
@@ -365,7 +347,6 @@ describe('defineScheduler type display', () => {
             readonly reps: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
-            readonly scheduledDays: number;
             readonly rating: Grade;
         };
     };
@@ -394,7 +375,6 @@ describe('defineScheduler type display', () => {
             readonly reps: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review" | "suspend";
-            readonly scheduledDays: number;
         };
         output: {
             readonly interval: number;
@@ -402,7 +382,6 @@ describe('defineScheduler type display', () => {
             readonly reps: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review" | "suspend";
-            readonly scheduledDays: number;
         };
     }>;
     readonly revlog: SRSSchema<{
@@ -412,7 +391,6 @@ describe('defineScheduler type display', () => {
             readonly reps: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review" | "suspend";
-            readonly scheduledDays: number;
             readonly rating: Grade;
         };
         output: {
@@ -421,7 +399,6 @@ describe('defineScheduler type display', () => {
             readonly reps: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review" | "suspend";
-            readonly scheduledDays: number;
             readonly rating: Grade;
         };
     }>;
@@ -438,7 +415,6 @@ describe('defineScheduler type display', () => {
             readonly reps: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review" | "suspend";
-            readonly scheduledDays: number;
         };
         readonly output: {
             readonly interval: number;
@@ -446,7 +422,6 @@ describe('defineScheduler type display', () => {
             readonly reps: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review" | "suspend";
-            readonly scheduledDays: number;
         };
     };
     readonly revlog: {
@@ -456,7 +431,6 @@ describe('defineScheduler type display', () => {
             readonly reps: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review" | "suspend";
-            readonly scheduledDays: number;
             readonly rating: Grade;
         };
         readonly output: {
@@ -465,7 +439,6 @@ describe('defineScheduler type display', () => {
             readonly reps: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review" | "suspend";
-            readonly scheduledDays: number;
             readonly rating: Grade;
         };
     };

--- a/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
@@ -176,7 +176,6 @@ describe('defineScheduler type display', () => {
             readonly easeFactor: number;
             readonly reps: number;
             readonly elapsedDays: number;
-            readonly lapses: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
             readonly scheduledDays: number;
@@ -187,7 +186,6 @@ describe('defineScheduler type display', () => {
             readonly easeFactor: number;
             readonly reps: number;
             readonly elapsedDays: number;
-            readonly lapses: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
             readonly scheduledDays: number;
@@ -237,7 +235,6 @@ describe('defineScheduler type display', () => {
             readonly easeFactor: number;
             readonly reps: number;
             readonly elapsedDays: number;
-            readonly lapses: number;
             readonly audit: string;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
@@ -249,7 +246,6 @@ describe('defineScheduler type display', () => {
             readonly easeFactor: number;
             readonly reps: number;
             readonly elapsedDays: number;
-            readonly lapses: number;
             readonly audit: string;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
@@ -296,7 +292,6 @@ describe('defineScheduler type display', () => {
             readonly easeFactor: number;
             readonly reps: number;
             readonly elapsedDays: number;
-            readonly lapses: number;
             readonly audit: string;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
@@ -308,7 +303,6 @@ describe('defineScheduler type display', () => {
             readonly easeFactor: number;
             readonly reps: number;
             readonly elapsedDays: number;
-            readonly lapses: number;
             readonly audit: string;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
@@ -352,7 +346,6 @@ describe('defineScheduler type display', () => {
             readonly easeFactor: number;
             readonly reps: number;
             readonly elapsedDays: number;
-            readonly lapses: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
             readonly scheduledDays: number;
@@ -363,7 +356,6 @@ describe('defineScheduler type display', () => {
             readonly easeFactor: number;
             readonly reps: number;
             readonly elapsedDays: number;
-            readonly lapses: number;
             readonly state: State;
             readonly scheduleStatus: "new" | "learning" | "review";
             readonly scheduledDays: number;

--- a/packages/srs-kit/tsdown.config.ts
+++ b/packages/srs-kit/tsdown.config.ts
@@ -17,6 +17,7 @@ const shared = {
     'chrono/numeric/index': 'src/chrono/presets/numeric/index.ts',
     'chrono/temporal-instant/index':
       'src/chrono/presets/temporal-instant/index.ts',
+    'scheduler/index': 'src/scheduler/index.ts',
   },
   dts: true,
   clean: true,

--- a/packages/srs-kit/tsdown.config.ts
+++ b/packages/srs-kit/tsdown.config.ts
@@ -12,6 +12,7 @@ const shared = {
     'schema/index': 'src/schema/index.ts',
     'primitives/index': 'src/primitives/index.ts',
     'model/index': 'src/model/index.ts',
+    'middleware/index': 'src/middleware/index.ts',
     'chrono/index': 'src/chrono/index.ts',
     'chrono/date/index': 'src/chrono/presets/date/index.ts',
     'chrono/numeric/index': 'src/chrono/presets/numeric/index.ts',


### PR DESCRIPTION
- https://github.com/open-spaced-repetition/ts-fsrs/issues/373

## Summary

- Add composable scheduler primitives, runtime schemas, and middleware-aware scheduler creation to srs-kit.
- Add scheduler, middleware, and compose-schema benchmark coverage.
- Update package exports and build entries for the new middleware and scheduler surfaces.

## Validation

- biome check ./src ./bench
- tsc --noEmit --pretty false
- vitest run --config=vitest.config.ts
- vitest bench --run --config=vitest.config.ts bench/scheduler.bench.ts
