### PR TITLE
feat(kit): add model creation options

### DIFF
--- a/.changeset/model-create-bypass.md
+++ b/.changeset/model-create-bypass.md
@@ -1,0 +1,7 @@
+---
+"@open-spaced-repetition/srs-kit": minor
+"ts-fsrs": minor
+---
+
+feat(kit): add model creation options for migration, parameter checking, and scheduler-side
+config reuse.

--- a/packages/fsrs/src/fsrs.ts
+++ b/packages/fsrs/src/fsrs.ts
@@ -105,6 +105,7 @@ export class FSRS implements IFSRS {
         enableShortTerm: this.#parameters.enable_short_term,
         numRelearningSteps: this.#parameters.relearning_steps.length,
       },
+      bypass: true,
     })
   }
 

--- a/packages/fsrs/src/models/fsrs-5/index.ts
+++ b/packages/fsrs/src/models/fsrs-5/index.ts
@@ -12,6 +12,7 @@ export {
 export { FSRS5Model } from './model.js'
 export type { FSRS5Config } from './parameters.js'
 export {
+  checkFSRS5Parameters,
   clipFSRS5Parameters,
   fsrs5ConfigSchema,
   migrateFSRS5Parameters,

--- a/packages/fsrs/src/models/fsrs-5/model.spec.ts
+++ b/packages/fsrs/src/models/fsrs-5/model.spec.ts
@@ -5,6 +5,17 @@ import { FSRS5Model } from './model.js'
 import { migrateFSRS5Parameters } from './parameters.js'
 
 describe('FSRS5Model', () => {
+  it('returns the default empty memory state', () => {
+    expect(
+      FSRS5Model.defaultValue.memoryState({
+        config: {
+          weights: FSRS5_DEFAULT_WEIGHTS,
+          enableShortTerm: true,
+        },
+      })
+    ).toEqual({ stability: 0, difficulty: 0 })
+  })
+
   it('binds step, forgetting curve, interval, and forward to FSRS-5 algorithm', () => {
     const model = FSRS5Model.create({
       config: {
@@ -65,6 +76,30 @@ describe('FSRS5Model', () => {
     })
 
     expect(model.config.weights).toEqual(migrateFSRS5Parameters(weights))
+  })
+
+  it('bypasses create-time parsing when requested', () => {
+    const config = {
+      weights: Array.from(FSRS5_DEFAULT_WEIGHTS),
+      enableShortTerm: true,
+    }
+
+    const model = FSRS5Model.create({ config, bypass: true })
+
+    expect(model.config).toBe(config)
+  })
+
+  it('skips parameter bounds checks when requested', () => {
+    const weights = Array.from(FSRS5_DEFAULT_WEIGHTS)
+    weights[0] = 0
+
+    const model = FSRS5Model.create({
+      config: { weights, enableShortTerm: true },
+      migrate: false,
+      check: false,
+    })
+
+    expect(model.config.weights[0]).toBe(0)
   })
 
   it('checks parameter bounds when requested', () => {

--- a/packages/fsrs/src/models/fsrs-5/model.spec.ts
+++ b/packages/fsrs/src/models/fsrs-5/model.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { type Grade, Rating } from '../../models.js'
 import { FSRS5_DEFAULT_WEIGHTS } from './constants.js'
 import { FSRS5Model } from './model.js'
+import { migrateFSRS5Parameters } from './parameters.js'
 
 describe('FSRS5Model', () => {
   it('binds step, forgetting curve, interval, and forward to FSRS-5 algorithm', () => {
@@ -54,5 +55,28 @@ describe('FSRS5Model', () => {
         } as never,
       })
     ).toThrow()
+  })
+
+  it('migrates FSRS-4.5 weights when requested', () => {
+    const weights = FSRS5_DEFAULT_WEIGHTS.slice(0, 17)
+    const model = FSRS5Model.create({
+      config: { weights, enableShortTerm: true },
+      migrate: true,
+    })
+
+    expect(model.config.weights).toEqual(migrateFSRS5Parameters(weights))
+  })
+
+  it('checks parameter bounds when requested', () => {
+    const weights = Array.from(FSRS5_DEFAULT_WEIGHTS)
+    weights[0] = 0
+
+    expect(() =>
+      FSRS5Model.create({
+        config: { weights, enableShortTerm: true },
+        migrate: false,
+        check: true,
+      })
+    ).toThrow('Expected FSRS5 weights within model bounds.')
   })
 })

--- a/packages/fsrs/src/models/fsrs-5/model.ts
+++ b/packages/fsrs/src/models/fsrs-5/model.ts
@@ -8,7 +8,12 @@ import { FSRSMemoryStateSchema } from '../../kit/index.js'
 import type { FSRSState } from '../../models.js'
 import { FSRS5Algorithm } from './algorithm.js'
 import { FSRS5_MODEL_BOUNDS } from './constants.js'
-import { type FSRS5Config, fsrs5ConfigSchema } from './parameters.js'
+import {
+  checkFSRS5Parameters,
+  type FSRS5Config,
+  fsrs5ConfigSchema,
+  migrateFSRS5Parameters,
+} from './parameters.js'
 
 const createFSRS5Model = (
   config: FSRS5Config
@@ -18,11 +23,9 @@ const createFSRS5Model = (
 }> => {
   const bounds = FSRS5_MODEL_BOUNDS
 
-  const modelConfig: FSRS5Config = Object.freeze(config)
-
   const algo = new FSRS5Algorithm(
-    modelConfig.weights,
-    modelConfig.enableShortTerm,
+    config.weights,
+    config.enableShortTerm,
     FSRS5_MODEL_BOUNDS
   )
 
@@ -67,7 +70,7 @@ const createFSRS5Model = (
   }
 
   return {
-    config: modelConfig,
+    config,
     bounds,
     step,
     nextInterval,
@@ -87,7 +90,23 @@ export const FSRS5Model = defineModel({
       return { stability: 0, difficulty: 0 }
     },
   },
-  create({ config }) {
-    return createFSRS5Model(fsrs5ConfigSchema.parse(config))
+  create({ config, migrate = true, check = true, bypass = false }) {
+    if (bypass) {
+      return createFSRS5Model(config)
+    }
+
+    const weights = migrate
+      ? migrateFSRS5Parameters(config.weights)
+      : config.weights
+    if (check) {
+      checkFSRS5Parameters(weights)
+    }
+
+    const $config = fsrs5ConfigSchema.parse({
+      weights,
+      enableShortTerm: config.enableShortTerm,
+    })
+
+    return createFSRS5Model(Object.freeze($config))
   },
 })

--- a/packages/fsrs/src/models/fsrs-5/parameters.ts
+++ b/packages/fsrs/src/models/fsrs-5/parameters.ts
@@ -11,6 +11,21 @@ export const clipFSRS5Parameters = (parameters: number[]): number[] => {
   )
 }
 
+export const checkFSRS5Parameters = (
+  parameters: number[] | readonly number[]
+) => {
+  const clipped = clipFSRS5Parameters(Array.from(parameters))
+  const isValid =
+    parameters.length === FSRS5_DEFAULT_WEIGHTS.length &&
+    clipped.every((value, index) => value === parameters[index])
+
+  if (!isValid) {
+    throw new FSRSValidationError('Expected FSRS5 weights within model bounds.')
+  }
+
+  return parameters
+}
+
 export const migrateFSRS5Parameters = (parameters?: number[]): number[] => {
   if (!Array.isArray(parameters) || parameters.length === 0) {
     return [...FSRS5_DEFAULT_WEIGHTS]

--- a/packages/fsrs/src/models/fsrs-6/index.ts
+++ b/packages/fsrs/src/models/fsrs-6/index.ts
@@ -12,6 +12,7 @@ export {
 export { FSRS6Model } from './model.js'
 export type { FSRS6Config } from './parameters.js'
 export {
+  checkFSRS6Parameters,
   clipFSRS6Parameters,
   fsrs6ConfigSchema,
   migrateFSRS6Parameters,

--- a/packages/fsrs/src/models/fsrs-6/model.spec.ts
+++ b/packages/fsrs/src/models/fsrs-6/model.spec.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
+import { FSRS5_DEFAULT_WEIGHTS } from '../fsrs-5/constants.js'
 import { FSRS6_DEFAULT_WEIGHTS } from './constants.js'
 import { FSRS6Model } from './model.js'
+import { migrateFSRS6Parameters } from './parameters.js'
 
 describe('FSRS6Model', () => {
   it('validates config with schema before creating model runtime', () => {
@@ -13,5 +15,39 @@ describe('FSRS6Model', () => {
         } as never,
       })
     ).toThrow()
+  })
+
+  it('migrates FSRS-5 weights when requested', () => {
+    const weights = Array.from(FSRS5_DEFAULT_WEIGHTS)
+    const model = FSRS6Model.create({
+      config: {
+        weights,
+        enableShortTerm: true,
+        numRelearningSteps: 0,
+      },
+      migrate: true,
+      check: false,
+    })
+
+    expect(model.config.weights).toEqual(
+      migrateFSRS6Parameters(weights, 0, true)
+    )
+  })
+
+  it('checks parameter bounds when requested', () => {
+    const weights = Array.from(FSRS6_DEFAULT_WEIGHTS)
+    weights[0] = 0
+
+    expect(() =>
+      FSRS6Model.create({
+        config: {
+          weights,
+          enableShortTerm: true,
+          numRelearningSteps: 0,
+        },
+        migrate: false,
+        check: true,
+      })
+    ).toThrow('Expected FSRS6 weights within model bounds.')
   })
 })

--- a/packages/fsrs/src/models/fsrs-6/model.ts
+++ b/packages/fsrs/src/models/fsrs-6/model.ts
@@ -8,7 +8,12 @@ import { FSRSMemoryStateSchema } from '../../kit/index.js'
 import type { FSRSState } from '../../models.js'
 import { FSRS6Algorithm } from './algorithm.js'
 import { FSRS6_MODEL_BOUNDS } from './constants.js'
-import { type FSRS6Config, fsrs6ConfigSchema } from './parameters.js'
+import {
+  checkFSRS6Parameters,
+  type FSRS6Config,
+  fsrs6ConfigSchema,
+  migrateFSRS6Parameters,
+} from './parameters.js'
 
 const createFSRS6Model = (
   config: FSRS6Config
@@ -18,11 +23,9 @@ const createFSRS6Model = (
 }> => {
   const bounds = FSRS6_MODEL_BOUNDS
 
-  const modelConfig: FSRS6Config = Object.freeze(config)
-
   const algo = new FSRS6Algorithm(
-    modelConfig.weights,
-    modelConfig.enableShortTerm,
+    config.weights,
+    config.enableShortTerm,
     FSRS6_MODEL_BOUNDS
   )
 
@@ -67,7 +70,7 @@ const createFSRS6Model = (
   }
 
   return {
-    config: modelConfig,
+    config,
     bounds,
     step,
     nextInterval,
@@ -87,7 +90,32 @@ export const FSRS6Model = defineModel({
       return { stability: 0, difficulty: 0 }
     },
   },
-  create({ config }) {
-    return createFSRS6Model(fsrs6ConfigSchema.parse(config))
+  create({ config, migrate = true, check = true, bypass = false }) {
+    if (bypass) {
+      return createFSRS6Model(config)
+    }
+
+    const weights = migrate
+      ? migrateFSRS6Parameters(
+          config.weights,
+          config.numRelearningSteps,
+          config.enableShortTerm
+        )
+      : config.weights
+    if (check) {
+      checkFSRS6Parameters(
+        weights,
+        config.numRelearningSteps,
+        config.enableShortTerm
+      )
+    }
+
+    const $config = fsrs6ConfigSchema.parse({
+      weights,
+      enableShortTerm: config.enableShortTerm,
+      numRelearningSteps: config.numRelearningSteps,
+    })
+
+    return createFSRS6Model(Object.freeze($config))
   },
 })

--- a/packages/fsrs/src/models/fsrs-6/parameters.spec.ts
+++ b/packages/fsrs/src/models/fsrs-6/parameters.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { FSRS6_DEFAULT_WEIGHTS } from './constants.js'
+import {
+  checkFSRS6Parameters,
+  clipFSRS6Parameters,
+} from './parameters.js'
+
+describe('FSRS-6 parameters', () => {
+  it('checks default weights with default options', () => {
+    const weights = Array.from(FSRS6_DEFAULT_WEIGHTS)
+
+    expect(checkFSRS6Parameters(weights)).toBe(weights)
+    expect(clipFSRS6Parameters(weights)).toEqual(weights)
+  })
+
+  it('rejects incorrect parameter length', () => {
+    expect(() =>
+      checkFSRS6Parameters(FSRS6_DEFAULT_WEIGHTS.slice(0, 20))
+    ).toThrow('Expected FSRS6 weights within model bounds.')
+  })
+})

--- a/packages/fsrs/src/models/fsrs-6/parameters.spec.ts
+++ b/packages/fsrs/src/models/fsrs-6/parameters.spec.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { FSRS6_DEFAULT_WEIGHTS } from './constants.js'
-import {
-  checkFSRS6Parameters,
-  clipFSRS6Parameters,
-} from './parameters.js'
+import { checkFSRS6Parameters, clipFSRS6Parameters } from './parameters.js'
 
 describe('FSRS-6 parameters', () => {
   it('checks default weights with default options', () => {

--- a/packages/fsrs/src/models/fsrs-6/parameters.ts
+++ b/packages/fsrs/src/models/fsrs-6/parameters.ts
@@ -50,6 +50,27 @@ export const clipFSRS6Parameters = (
   )
 }
 
+export const checkFSRS6Parameters = (
+  parameters: number[] | readonly number[],
+  numRelearningSteps = 0,
+  enableShortTerm = true
+) => {
+  const clipped = clipFSRS6Parameters(
+    Array.from(parameters),
+    numRelearningSteps,
+    enableShortTerm
+  )
+  const isValid =
+    parameters.length === FSRS6_DEFAULT_WEIGHTS.length &&
+    clipped.every((value, index) => value === parameters[index])
+
+  if (!isValid) {
+    throw new FSRSValidationError('Expected FSRS6 weights within model bounds.')
+  }
+
+  return parameters
+}
+
 export const migrateFSRS6Parameters = (
   parameters?: number[],
   numRelearningSteps = 0,

--- a/packages/fsrs/src/models/fsrs-6/parameters.ts
+++ b/packages/fsrs/src/models/fsrs-6/parameters.ts
@@ -41,8 +41,8 @@ export const clipFSRS6Parameters = (
       0.01,
       FSRS6_W17_W18_CEILING
     )
-    if (clip[17]) clip[17] = [clip[17][0], w17W18Ceiling]
-    if (clip[18]) clip[18] = [clip[18][0], w17W18Ceiling]
+    clip[17] = [clip[17][0], w17W18Ceiling]
+    clip[18] = [clip[18][0], w17W18Ceiling]
   }
 
   return clip.map(([min, max], index) =>

--- a/packages/srs-kit/bench/compose-schema.bench.ts
+++ b/packages/srs-kit/bench/compose-schema.bench.ts
@@ -5,9 +5,10 @@ import { schedulerStatsMiddleware } from '@/middleware/stats/index.js'
 import { SM2_DEFAULT_WEIGHTS, SM2Model } from '@/model/sm2.test.js'
 import {
   composeSchema,
-  getParsedCardMemoryState,
+  parsedCardMemoryStateSymbol,
 } from '@/scheduler/compose-schema.js'
 import { defineScheduler } from '@/scheduler/index.js'
+import { getAttachedValue } from '@/schema/attached-value.js'
 
 let composeSchemaSink = 0
 
@@ -25,7 +26,10 @@ function consumeParsedCard(value: {
 function consumeCardWithRememberedMemoryState(
   card: Readonly<Record<string, unknown>> & object
 ): void {
-  const memoryState = getParsedCardMemoryState(card)
+  const memoryState = getAttachedValue<
+    typeof parsedCardMemoryStateSymbol,
+    Record<string, unknown>
+  >(card, parsedCardMemoryStateSymbol)
   if (!memoryState) {
     throw new Error('Parsed card is missing remembered memory state')
   }

--- a/packages/srs-kit/src/model/model.ts
+++ b/packages/srs-kit/src/model/model.ts
@@ -90,7 +90,17 @@ export interface ModelSchema<
 }
 
 export type ModelCreate<Schema extends BlankModelSchema> = (ctx: {
-  readonly config: SchemaInput<Schema['config']>
+  readonly config:
+    | SchemaInput<Schema['config']>
+    | SchemaOutput<Schema['config']>
+  readonly migrate?: boolean
+  readonly check?: boolean
+  /**
+   * The config has already been parsed by the composed scheduler schema.
+   * Model implementations should use it directly and skip create-time
+   * validation, migration, range checks, and freezing.
+   */
+  readonly bypass?: boolean
 }) => ModelCore<{
   readonly config: SchemaOutput<Schema['config']>
   readonly memoryState: SchemaOutput<Schema['memoryState']>

--- a/packages/srs-kit/src/model/sm2.test.ts
+++ b/packages/srs-kit/src/model/sm2.test.ts
@@ -187,7 +187,7 @@ export const SM2Model = defineModel({
       return { interval: 0, easeFactor: config.weights[2], reviewStep: 0 }
     },
   },
-  create({ config }) {
-    return createSM2Core(sm2ConfigSchema.parse(config))
+  create({ config, bypass }) {
+    return createSM2Core(bypass ? config : sm2ConfigSchema.parse(config))
   },
 })

--- a/packages/srs-kit/src/scheduler/base.spec.ts
+++ b/packages/srs-kit/src/scheduler/base.spec.ts
@@ -5,7 +5,11 @@ import { numericChrono } from '@/chrono/presets/numeric/index.js'
 import { defineMiddleware } from '@/middleware/index.js'
 import { schedulerStatsMiddleware } from '@/middleware/stats/index.js'
 import { defineModel } from '@/model/model.js'
-import { SM2_DEFAULT_WEIGHTS, SM2Model } from '@/model/sm2.test.js'
+import {
+  SM2_DEFAULT_WEIGHTS,
+  type SM2Config,
+  SM2Model,
+} from '@/model/sm2.test.js'
 import { Rating, State } from '@/primitives/index.js'
 import { defineSchema, isObject, numberSchema } from '@/schema/index.js'
 import { BaseScheduler } from './base.js'
@@ -72,6 +76,32 @@ describe('SchedulerCore.create', () => {
     expect(() =>
       scheduler.create({ config: { weights: [1] } as never })
     ).toThrow()
+  })
+
+  it('reuses model config parsed by composed scheduler config', () => {
+    let configParses = 0
+    let createdConfigFrozen = true
+    const spiedConfigSchema = defineSchema<SM2Config>((value) => {
+      configParses += 1
+      return SM2Model.schema.config['~standard'].validate(value)
+    })
+    const spiedModel = defineModel({
+      name: 'sm2-config-spied',
+      schema: { ...SM2Model.schema, config: spiedConfigSchema },
+      defaultValue: SM2Model.defaultValue,
+      create({ config, bypass }) {
+        const modelConfig = bypass ? config : Object.freeze(config)
+        createdConfigFrozen = Object.isFrozen(modelConfig)
+        return SM2Model.create({ config })
+      },
+    })
+
+    defineScheduler({ model: spiedModel, chrono: numericChrono }).create({
+      config: { weights: SM2_DEFAULT_WEIGHTS },
+    })
+
+    expect(configParses).toBe(1)
+    expect(createdConfigFrozen).toBe(false)
   })
 
   it('does not copy inherited middleware config fields', () => {

--- a/packages/srs-kit/src/scheduler/base.ts
+++ b/packages/srs-kit/src/scheduler/base.ts
@@ -10,6 +10,11 @@ import type {
 import type { AnyModel, AnyModelCore } from '@/model/model.js'
 import { type Grade, gradeSchema, grades } from '@/primitives/rating.js'
 import { State } from '@/primitives/state.js'
+import {
+  parsedCardMemoryStateSymbol,
+  parsedModelConfigSymbol,
+} from '@/scheduler/compose-schema.js'
+import { getAttachedValue } from '@/schema/attached-value.js'
 import type { Mutable, SchemaInput } from '@/schema/index.js'
 import {
   composeMiddleware,
@@ -17,7 +22,6 @@ import {
   parse,
   withCache,
 } from '@/schema/index.js'
-import { getParsedCardMemoryState } from './compose-schema.js'
 import type { SchedulerDefaultValueFactory } from './default-value.js'
 import type {
   BlankSchedulerEnv,
@@ -165,7 +169,13 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
     const config = parse(schema.config, ctx.config)
 
     this.config = config
-    this.modelCore = model.create({ config })
+    this.modelCore = model.create({
+      config: getAttachedValue<typeof parsedModelConfigSymbol, typeof config>(
+        config,
+        parsedModelConfigSymbol
+      ),
+      bypass: true,
+    })
     this.chronoCore = Reflect.apply(chrono.create, chrono, [
       { config: config.chrono },
     ])
@@ -303,7 +313,10 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
       this.schema.card,
       inputCard
     ) as SchedulerCoreEnv<Env>['card']['output']
-    const memoryState = getParsedCardMemoryState(parsedCard)
+    const memoryState = getAttachedValue<
+      typeof parsedCardMemoryStateSymbol,
+      PreparedReview<Env>['memoryState']
+    >(parsedCard, parsedCardMemoryStateSymbol)
     if (!memoryState) {
       throw new Error('Parsed scheduler card is missing model memory state')
     }

--- a/packages/srs-kit/src/scheduler/compose-schema.spec.ts
+++ b/packages/srs-kit/src/scheduler/compose-schema.spec.ts
@@ -1,13 +1,17 @@
 import { describe, expect, expectTypeOf, it } from 'vitest'
 import type { SM2State } from '@/model/sm2.test.js'
 import {
-  getParsedCardMemoryState,
-  rememberParsedCardMemoryState,
-} from './compose-schema.js'
+  getAttachedValue,
+  rememberAttachedValue,
+} from '@/schema/attached-value.js'
+import { parsedCardMemoryStateSymbol } from './compose-schema.js'
 
 describe('parsed card memory state', () => {
   it('falls back to unknown record for unmarked cards', () => {
-    const memoryState = getParsedCardMemoryState({})
+    const memoryState = getAttachedValue<
+      typeof parsedCardMemoryStateSymbol,
+      Record<string, unknown>
+    >({}, parsedCardMemoryStateSymbol)
 
     expectTypeOf(memoryState).toEqualTypeOf<
       Record<string, unknown> | undefined
@@ -21,11 +25,15 @@ describe('parsed card memory state', () => {
       easeFactor: 2.5,
       reviewStep: 3,
     }
-    const remembered = rememberParsedCardMemoryState(
+    const remembered = rememberAttachedValue(
       { source: 'fixture' },
+      parsedCardMemoryStateSymbol,
       inputMemoryState
     )
-    const memoryState = getParsedCardMemoryState(remembered)
+    const memoryState = getAttachedValue<
+      typeof parsedCardMemoryStateSymbol,
+      SM2State
+    >(remembered, parsedCardMemoryStateSymbol)
 
     expectTypeOf(memoryState).toEqualTypeOf<SM2State | undefined>()
     expect(memoryState).toEqual({

--- a/packages/srs-kit/src/scheduler/compose-schema.ts
+++ b/packages/srs-kit/src/scheduler/compose-schema.ts
@@ -6,6 +6,7 @@ import type { AnyModel } from '@/model/model.js'
 import { gradeSchema } from '@/primitives/rating.js'
 import { stateSchema } from '@/primitives/state.js'
 import { scheduleStatuses } from '@/primitives/status.js'
+import { rememberAttachedValue } from '@/schema/attached-value.js'
 import {
   assignObjectFields,
   defineSchema,
@@ -18,37 +19,8 @@ import type {
 } from './fields.js'
 import type { SchedulerSchema } from './scheduler.js'
 
-const parsedCardMemoryState = Symbol('parsedCardMemoryState')
-
-type ParsedCardMemoryState<MemoryState extends object> = {
-  readonly [parsedCardMemoryState]: MemoryState
-}
-
-export function getParsedCardMemoryState<MemoryState extends object>(
-  card: ParsedCardMemoryState<MemoryState>
-): MemoryState | undefined
-export function getParsedCardMemoryState(
-  card: object
-): Record<string, unknown> | undefined
-export function getParsedCardMemoryState(card: object): object | undefined {
-  return (card as Partial<ParsedCardMemoryState<Record<string, unknown>>>)[
-    parsedCardMemoryState
-  ]
-}
-
-export function rememberParsedCardMemoryState<
-  Card extends object,
-  MemoryState extends object,
->(
-  card: Card,
-  memoryState: MemoryState
-): Card & ParsedCardMemoryState<MemoryState> {
-  const parsedCard = card as Card & {
-    [parsedCardMemoryState]: MemoryState
-  }
-  parsedCard[parsedCardMemoryState] = memoryState
-  return parsedCard
-}
+export const parsedModelConfigSymbol = Symbol('parsedModelConfig')
+export const parsedCardMemoryStateSymbol = Symbol('parsedCardMemoryState')
 
 export function composeSchema(ctx: {
   readonly model: AnyModel
@@ -143,7 +115,13 @@ export function composeSchema(ctx: {
       assignObjectFields(result, middlewareResult.value)
     }
 
-    return { value: result }
+    return {
+      value: rememberAttachedValue(
+        result,
+        parsedModelConfigSymbol,
+        modelResult.value
+      ),
+    }
   })
 
   const card = defineSchema<unknown, Record<string, unknown>>((value) => {
@@ -177,7 +155,13 @@ export function composeSchema(ctx: {
       Object.assign(card, middlewareCard.value)
     }
 
-    return { value: rememberParsedCardMemoryState(card, memoryState) }
+    return {
+      value: rememberAttachedValue(
+        card,
+        parsedCardMemoryStateSymbol,
+        memoryState
+      ),
+    }
   })
 
   const revlog = defineSchema<unknown, Record<string, unknown>>((value) => {

--- a/packages/srs-kit/src/schema/attached-value.ts
+++ b/packages/srs-kit/src/schema/attached-value.ts
@@ -1,0 +1,24 @@
+export type AttachedValue<Key extends symbol, Value> = {
+  readonly [Property in Key]: Value
+}
+
+export function getAttachedValue<Key extends symbol, Value>(
+  target: object,
+  key: Key
+): Value | undefined {
+  return (target as Partial<AttachedValue<Key, Value>>)[key]
+}
+
+export function rememberAttachedValue<
+  Target extends object,
+  Key extends symbol,
+  Value,
+>(target: Target, key: Key, value: Value): Target & AttachedValue<Key, Value> {
+  Object.defineProperty(target, key, {
+    value,
+    writable: false,
+    enumerable: false,
+    configurable: false,
+  })
+  return target as Target & AttachedValue<Key, Value>
+}


### PR DESCRIPTION
- https://github.com/open-spaced-repetition/ts-fsrs/issues/373
## Summary
- Reuse parsed model config when scheduler creates model runtimes.
- Add FSRS-5/6 model create options and parameter bound helpers.

## Checks
- git diff --cached --check
- packages/srs-kit: vitest, tsc
- packages/fsrs: vitest, tsc