### PR TITLE
feat(fsrs): add FSRS-4 model

### DIFF
--- a/.changeset/add-fsrs4-model.md
+++ b/.changeset/add-fsrs4-model.md
@@ -1,0 +1,6 @@
+---
+"ts-fsrs": minor
+---
+
+feat(model): add FSRS-4 model support through the new `ts-fsrs/models/fsrs-4` entry.
+

--- a/packages/fsrs/package.json
+++ b/packages/fsrs/package.json
@@ -51,6 +51,17 @@
         "default": "./dist/models/fsrs-4dot5.mjs"
       },
       "default": "./dist/models/fsrs-4dot5.mjs"
+    },
+    "./models/fsrs-4": {
+      "require": {
+        "types": "./dist/models/fsrs-4.d.cts",
+        "default": "./dist/models/fsrs-4.cjs"
+      },
+      "import": {
+        "types": "./dist/models/fsrs-4.d.mts",
+        "default": "./dist/models/fsrs-4.mjs"
+      },
+      "default": "./dist/models/fsrs-4.mjs"
     }
   },
   "type": "module",

--- a/packages/fsrs/src/models/fsrs-4/algorithm.spec.ts
+++ b/packages/fsrs/src/models/fsrs-4/algorithm.spec.ts
@@ -1,12 +1,13 @@
-import { grades } from '@open-spaced-repetition/srs-kit'
+import { type Grade, grades, Rating } from '@open-spaced-repetition/srs-kit'
 import { describe, expect, it } from 'vitest'
-import { type FSRSState, type Grade, Rating } from '../../models.js'
 import {
   FSRS4_DEFAULT_WEIGHTS,
   FSRS4_MODEL_BOUNDS,
   FSRS4Algorithm,
   forgettingCurve,
 } from './index.js'
+
+type FSRSState = ReturnType<FSRS4Algorithm['next_state']>
 
 describe('FSRS4Algorithm', () => {
   const weights = FSRS4_DEFAULT_WEIGHTS
@@ -27,12 +28,16 @@ describe('FSRS4Algorithm', () => {
   }
 
   it('uses the FSRS-4 forgetting curve', () => {
+    // Expected values source: srs-benchmark/models/fsrs_v4.py Python reference at 70cc4387f573ff20b13ac9c106333a335c8a4cb8.
+    // https://github.com/open-spaced-repetition/srs-benchmark/blob/70cc4387f573ff20b13ac9c106333a335c8a4cb8/models/fsrs_v4.py
     expect([0, 1, 2, 3].map((t) => forgettingCurve(t, 1))).toEqual([
       1, 0.9, 0.81818182, 0.75,
     ])
   })
 
   it('calculates intervals through the FSRS-4 interval modifier', () => {
+    // Expected values source: fsrs-rs PR #58 test_next_interval result.
+    // https://github.com/open-spaced-repetition/fsrs-rs/pull/58/changes
     const requestRetentions = Array.from({ length: 10 }, (_, index) =>
       Number(((index + 1) / 10).toFixed(1))
     )
@@ -69,6 +74,8 @@ describe('FSRS4Algorithm', () => {
   })
 
   it('matches the Python reference difficulty update results to 4 decimals', () => {
+    // Expected values source: srs-benchmark/models/fsrs_v4.py Python reference at 70cc4387f573ff20b13ac9c106333a335c8a4cb8.
+    // https://github.com/open-spaced-repetition/srs-benchmark/blob/70cc4387f573ff20b13ac9c106333a335c8a4cb8/models/fsrs_v4.py
     expectCloseArray(
       grades.map((rating) => 5 - weights[6] * (rating - 3)),
       [5 + 2 * weights[6], 5 + weights[6], 5, 5 - weights[6]]
@@ -81,6 +88,8 @@ describe('FSRS4Algorithm', () => {
   })
 
   it('matches the Python reference stability update results to 4 decimals', () => {
+    // Expected values source: srs-benchmark/models/fsrs_v4.py Python reference at 70cc4387f573ff20b13ac9c106333a335c8a4cb8.
+    // https://github.com/open-spaced-repetition/srs-benchmark/blob/70cc4387f573ff20b13ac9c106333a335c8a4cb8/models/fsrs_v4.py
     const stability = [5, 5, 5, 5]
     const difficulty = [1, 2, 3, 4]
     const retention = [0.9, 0.8, 0.7, 0.6]
@@ -118,13 +127,15 @@ describe('FSRS4Algorithm', () => {
     )
   })
 
-  it('matches the fsrs-rs scheduler memory-state fixture', () => {
+  it('matches the fsrs-rs PR #58 scheduler memory-state results', () => {
+    // Expected values source: fsrs-rs PR #58 test_memo_state result.
+    // https://github.com/open-spaced-repetition/fsrs-rs/pull/58/changes
     const rsWeights = [
       0.81497127, 1.5411042, 4.007436, 9.045982, 4.9264183, 1.039322,
       0.93803364, 0, 1.5530516, 0.10299722, 0.9981442, 2.210701, 0.018248068,
       0.3422524, 1.3384504, 0.22278537, 2.6646678,
     ]
-    const rsAlgorithm = new FSRS4Algorithm(rsWeights, FSRS4_MODEL_BOUNDS)
+    const algo = new FSRS4Algorithm(rsWeights, FSRS4_MODEL_BOUNDS)
     const reviews: { rating: Grade; deltaT: number }[] = [
       { rating: Rating.Again, deltaT: 0 },
       { rating: Rating.Good, deltaT: 1 },
@@ -135,7 +146,7 @@ describe('FSRS4Algorithm', () => {
     let state: FSRSState | null = null
 
     for (const review of reviews) {
-      state = rsAlgorithm.next_state(state, review.deltaT, review.rating)
+      state = algo.next_state(state, review.deltaT, review.rating)
     }
 
     expectCloseArray(
@@ -143,7 +154,7 @@ describe('FSRS4Algorithm', () => {
       [51.344814, 7.005062],
       4
     )
-    const nextState = rsAlgorithm.next_state(
+    const nextState = algo.next_state(
       { stability: 20.925528, difficulty: 7.005062 },
       21,
       Rating.Good
@@ -157,6 +168,8 @@ describe('FSRS4Algorithm', () => {
   })
 
   it('matches the Python reference default memory-state progression', () => {
+    // Expected values source: srs-benchmark/models/fsrs_v4.py Python reference at 70cc4387f573ff20b13ac9c106333a335c8a4cb8.
+    // https://github.com/open-spaced-repetition/srs-benchmark/blob/70cc4387f573ff20b13ac9c106333a335c8a4cb8/models/fsrs_v4.py
     const ratings: Grade[] = [
       Rating.Again,
       Rating.Good,

--- a/packages/fsrs/src/models/fsrs-4/algorithm.spec.ts
+++ b/packages/fsrs/src/models/fsrs-4/algorithm.spec.ts
@@ -62,6 +62,12 @@ describe('FSRS4Algorithm', () => {
       weights[2],
       weights[3],
     ])
+    const clamped = new FSRS4Algorithm(
+      [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY, ...weights.slice(2)],
+      FSRS4_MODEL_BOUNDS
+    )
+    expect(clamped.init_stability(Rating.Again)).toBe(FSRS4_MODEL_BOUNDS.sMin)
+    expect(clamped.init_stability(Rating.Hard)).toBe(FSRS4_MODEL_BOUNDS.sMax)
     expectCloseArray(
       grades.map((rating) => algorithm.init_difficulty(rating)),
       [

--- a/packages/fsrs/src/models/fsrs-4/algorithm.spec.ts
+++ b/packages/fsrs/src/models/fsrs-4/algorithm.spec.ts
@@ -1,0 +1,199 @@
+import { grades } from '@open-spaced-repetition/srs-kit'
+import { describe, expect, it } from 'vitest'
+import { type FSRSState, type Grade, Rating } from '../../models.js'
+import {
+  FSRS4_DEFAULT_WEIGHTS,
+  FSRS4_MODEL_BOUNDS,
+  FSRS4Algorithm,
+  forgettingCurve,
+} from './index.js'
+
+describe('FSRS4Algorithm', () => {
+  const weights = FSRS4_DEFAULT_WEIGHTS
+  const algorithm = new FSRS4Algorithm(weights, FSRS4_MODEL_BOUNDS)
+  const roundState = (state: FSRSState): FSRSState => ({
+    stability: Number(state.stability.toFixed(4)),
+    difficulty: Number(state.difficulty.toFixed(4)),
+  })
+  const expectCloseArray = (
+    actual: number[],
+    expected: number[],
+    precision = 6
+  ) => {
+    expect(actual).toHaveLength(expected.length)
+    actual.forEach((value, index) => {
+      expect(value).toBeCloseTo(expected[index], precision)
+    })
+  }
+
+  it('uses the FSRS-4 forgetting curve', () => {
+    expect([0, 1, 2, 3].map((t) => forgettingCurve(t, 1))).toEqual([
+      1, 0.9, 0.81818182, 0.75,
+    ])
+  })
+
+  it('calculates intervals through the FSRS-4 interval modifier', () => {
+    const requestRetentions = Array.from({ length: 10 }, (_, index) =>
+      Number(((index + 1) / 10).toFixed(1))
+    )
+    const intervals = requestRetentions.map((retention) =>
+      algorithm.next_interval(1, retention)
+    )
+
+    expect(intervals).toEqual([81, 36, 21, 14, 9, 6, 4, 2, 1, 1])
+    expect(algorithm.next_interval(13.8206, 0.9)).toBe(14)
+    expect(() => algorithm.next_interval(13.8206, 0)).toThrow(
+      'Requested retention rate should be in the range (0,1]'
+    )
+  })
+
+  it('initializes the first review state from FSRS-4 weights', () => {
+    expect(
+      () => new FSRS4Algorithm(weights.slice(0, 16), FSRS4_MODEL_BOUNDS)
+    ).toThrow('FSRS4Algorithm requires exactly 17 weights')
+    expect(grades.map((rating) => algorithm.init_stability(rating))).toEqual([
+      weights[0],
+      weights[1],
+      weights[2],
+      weights[3],
+    ])
+    expectCloseArray(
+      grades.map((rating) => algorithm.init_difficulty(rating)),
+      [
+        weights[4] + 2 * weights[5],
+        weights[4] + weights[5],
+        weights[4],
+        weights[4] - weights[5],
+      ]
+    )
+  })
+
+  it('matches the Python reference difficulty update results to 4 decimals', () => {
+    expectCloseArray(
+      grades.map((rating) => 5 - weights[6] * (rating - 3)),
+      [5 + 2 * weights[6], 5 + weights[6], 5, 5 - weights[6]]
+    )
+    expectCloseArray(
+      grades.map((rating) => algorithm.next_difficulty(5, rating)),
+      [6.7021008, 5.8507004, 4.9993, 4.1479001],
+      4
+    )
+  })
+
+  it('matches the Python reference stability update results to 4 decimals', () => {
+    const stability = [5, 5, 5, 5]
+    const difficulty = [1, 2, 3, 4]
+    const retention = [0.9, 0.8, 0.7, 0.6]
+    const recall = grades.map((rating, index) =>
+      algorithm.next_recall_stability(
+        difficulty[index],
+        stability[index],
+        retention[index],
+        rating
+      )
+    )
+    const forget = grades.map((_, index) =>
+      algorithm.next_forget_stability(
+        difficulty[index],
+        stability[index],
+        retention[index]
+      )
+    )
+    const nextStability = grades.map(
+      (rating, index) =>
+        algorithm.next_state(
+          { difficulty: difficulty[index], stability: stability[index] },
+          0,
+          rating,
+          retention[index]
+        ).stability
+    )
+
+    expectCloseArray(recall, [22.454704, 14.560361, 51.155739, 152.6869], 4)
+    expectCloseArray(forget, [2.074517, 2.272933, 2.526406, 2.824732], 4)
+    expectCloseArray(
+      nextStability,
+      [2.074517, 14.560361, 51.155739, 152.6869],
+      4
+    )
+  })
+
+  it('matches the fsrs-rs scheduler memory-state fixture', () => {
+    const rsWeights = [
+      0.81497127, 1.5411042, 4.007436, 9.045982, 4.9264183, 1.039322,
+      0.93803364, 0, 1.5530516, 0.10299722, 0.9981442, 2.210701, 0.018248068,
+      0.3422524, 1.3384504, 0.22278537, 2.6646678,
+    ]
+    const rsAlgorithm = new FSRS4Algorithm(rsWeights, FSRS4_MODEL_BOUNDS)
+    const reviews: { rating: Grade; deltaT: number }[] = [
+      { rating: Rating.Again, deltaT: 0 },
+      { rating: Rating.Good, deltaT: 1 },
+      { rating: Rating.Good, deltaT: 3 },
+      { rating: Rating.Good, deltaT: 8 },
+      { rating: Rating.Good, deltaT: 21 },
+    ]
+    let state: FSRSState | null = null
+
+    for (const review of reviews) {
+      state = rsAlgorithm.next_state(state, review.deltaT, review.rating)
+    }
+
+    expectCloseArray(
+      [state!.stability, state!.difficulty],
+      [51.344814, 7.005062],
+      4
+    )
+    const nextState = rsAlgorithm.next_state(
+      { stability: 20.925528, difficulty: 7.005062 },
+      21,
+      Rating.Good
+    )
+
+    expectCloseArray(
+      [nextState.stability, nextState.difficulty],
+      [51.344814, 7.005062],
+      4
+    )
+  })
+
+  it('matches the Python reference default memory-state progression', () => {
+    const ratings: Grade[] = [
+      Rating.Again,
+      Rating.Good,
+      Rating.Good,
+      Rating.Good,
+      Rating.Good,
+      Rating.Good,
+    ]
+    const intervals = [0, 0, 1, 3, 8, 21]
+    const states: FSRSState[] = []
+    let state: FSRSState | null = null
+
+    for (const [index, rating] of ratings.entries()) {
+      state = algorithm.next_state(state, intervals[index], rating)
+      states.push(state)
+    }
+
+    expect(states.map(roundState)).toEqual([
+      { difficulty: 6.81, stability: 0.4 },
+      { difficulty: 6.7912, stability: 0.4 },
+      { difficulty: 6.7726, stability: 2.3254 },
+      { difficulty: 6.7542, stability: 7.1731 },
+      { difficulty: 6.7359, stability: 18.3727 },
+      { difficulty: 6.7179, stability: 44.2147 },
+    ])
+  })
+
+  it('validates next-state inputs', () => {
+    expect(
+      algorithm.next_state({ difficulty: 5, stability: 5 }, 1, Rating.Manual)
+    ).toEqual({ difficulty: 5, stability: 5 })
+    expect(() => algorithm.next_state(null, -1, Rating.Good)).toThrow(
+      'Invalid delta_t "-1"'
+    )
+    expect(() => algorithm.next_state(null, 0, 5)).toThrow('Invalid grade "5"')
+    expect(() =>
+      algorithm.next_state({ difficulty: 0.5, stability: 0.1 }, 1, Rating.Good)
+    ).toThrow('Invalid memory state { difficulty: 0.5, stability: 0.1 }')
+  })
+})

--- a/packages/fsrs/src/models/fsrs-4/algorithm.ts
+++ b/packages/fsrs/src/models/fsrs-4/algorithm.ts
@@ -1,0 +1,145 @@
+import type { ModelBounds } from '@open-spaced-repetition/srs-kit/model'
+import { FSRSValidationError } from '../../error.js'
+import { clamp, roundTo } from '../../help.js'
+import { type FSRSState, type Grade, Rating } from '../../models.js'
+
+export function forgetting_curve(
+  elapsed_days: number,
+  stability: number
+): number {
+  return roundTo(Math.pow(1 + elapsed_days / (9 * stability), -1), 8)
+}
+
+/**
+ * @see https://github.com/open-spaced-repetition/awesome-fsrs/wiki/The-Algorithm#fsrs-v4
+ */
+export class FSRS4Algorithm {
+  constructor(
+    private weights: number[],
+    private bounds: ModelBounds<FSRSState>
+  ) {
+    if (!Array.isArray(weights) || weights.length !== 17) {
+      throw new FSRSValidationError(
+        `FSRS4Algorithm requires exactly 17 weights, but received ${weights?.length}`
+      )
+    }
+  }
+
+  init_stability(g: Grade): number {
+    return Math.max(this.weights[g - 1], 0.1)
+  }
+
+  init_difficulty(g: Grade): number {
+    const w = this.weights
+    const d = w[4] - (g - 3) * w[5]
+    return clamp(roundTo(d, 8), this.bounds.dMin, this.bounds.dMax)
+  }
+
+  next_interval(s: number, desired_retention: number): number {
+    if (
+      !Number.isFinite(desired_retention) ||
+      desired_retention <= 0 ||
+      desired_retention > 1
+    ) {
+      throw new FSRSValidationError(
+        'Requested retention rate should be in the range (0,1]'
+      )
+    }
+    const intervalModifier = roundTo(9 * (1 / desired_retention - 1), 8)
+    return Math.max(Math.round(s * intervalModifier), 1)
+  }
+
+  next_difficulty(d: number, g: Grade): number {
+    const next_d = d - this.weights[6] * (g - 3)
+    return clamp(
+      this.mean_reversion(this.weights[4], next_d),
+      this.bounds.dMin,
+      this.bounds.dMax
+    )
+  }
+
+  mean_reversion(init: number, current: number): number {
+    const w = this.weights
+    return roundTo(w[7] * init + (1 - w[7]) * current, 8)
+  }
+
+  next_recall_stability(d: number, s: number, r: number, g: Grade): number {
+    const w = this.weights
+    const hard_penalty = Rating.Hard === g ? w[15] : 1
+    const easy_bound = Rating.Easy === g ? w[16] : 1
+    return roundTo(
+      clamp(
+        s *
+          (1 +
+            Math.exp(w[8]) *
+              (11 - d) *
+              Math.pow(s, -w[9]) *
+              (Math.exp((1 - r) * w[10]) - 1) *
+              hard_penalty *
+              easy_bound),
+        this.bounds.sMin,
+        this.bounds.sMax
+      ),
+      8
+    )
+  }
+
+  next_forget_stability(d: number, s: number, r: number): number {
+    const w = this.weights
+    return roundTo(
+      clamp(
+        w[11] *
+          Math.pow(d, -w[12]) *
+          (Math.pow(s + 1, w[13]) - 1) *
+          Math.exp((1 - r) * w[14]),
+        this.bounds.sMin,
+        this.bounds.sMax
+      ),
+      8
+    )
+  }
+
+  forgetting_curve = forgetting_curve
+
+  next_state(
+    memory_state: FSRSState | null,
+    t: number,
+    g: number,
+    r?: number
+  ): FSRSState {
+    const { difficulty: d, stability: s } = memory_state ?? {
+      difficulty: 0,
+      stability: 0,
+    }
+    if (t < 0) {
+      throw new FSRSValidationError(`Invalid delta_t "${t}"`)
+    }
+    if (g < 0 || g > 4) {
+      throw new FSRSValidationError(`Invalid grade "${g}"`)
+    }
+    if (d === 0 && s === 0) {
+      return {
+        difficulty: this.init_difficulty(g),
+        stability: this.init_stability(g),
+      }
+    }
+    if (g === 0) {
+      return {
+        difficulty: d,
+        stability: s,
+      }
+    }
+    if (d < this.bounds.dMin || s < this.bounds.sMin) {
+      throw new FSRSValidationError(
+        `Invalid memory state { difficulty: ${d}, stability: ${s} }`
+      )
+    }
+    r = typeof r === 'number' ? r : this.forgetting_curve(t, s)
+    const new_s =
+      g === Rating.Again
+        ? this.next_forget_stability(d, s, r)
+        : this.next_recall_stability(d, s, r, g)
+    const new_d = this.next_difficulty(d, g)
+    return { difficulty: new_d, stability: new_s }
+  }
+}

--- a/packages/fsrs/src/models/fsrs-4/algorithm.ts
+++ b/packages/fsrs/src/models/fsrs-4/algorithm.ts
@@ -1,7 +1,8 @@
+import { type Grade, Rating } from '@open-spaced-repetition/srs-kit'
 import type { ModelBounds } from '@open-spaced-repetition/srs-kit/model'
 import { FSRSValidationError } from '../../error.js'
 import { clamp, roundTo } from '../../help.js'
-import { type FSRSState, type Grade, Rating } from '../../models.js'
+import type { FSRSState } from '../../models.js'
 
 export function forgetting_curve(
   elapsed_days: number,
@@ -117,16 +118,17 @@ export class FSRS4Algorithm {
     if (g < 0 || g > 4) {
       throw new FSRSValidationError(`Invalid grade "${g}"`)
     }
-    if (d === 0 && s === 0) {
-      return {
-        difficulty: this.init_difficulty(g),
-        stability: this.init_stability(g),
-      }
-    }
-    if (g === 0) {
+    if (g === Rating.Manual) {
       return {
         difficulty: d,
         stability: s,
+      }
+    }
+    const grade = g as Grade
+    if (d === 0 && s === 0) {
+      return {
+        difficulty: this.init_difficulty(grade),
+        stability: this.init_stability(grade),
       }
     }
     if (d < this.bounds.dMin || s < this.bounds.sMin) {
@@ -136,10 +138,10 @@ export class FSRS4Algorithm {
     }
     r = typeof r === 'number' ? r : this.forgetting_curve(t, s)
     const new_s =
-      g === Rating.Again
+      grade === Rating.Again
         ? this.next_forget_stability(d, s, r)
-        : this.next_recall_stability(d, s, r, g)
-    const new_d = this.next_difficulty(d, g)
+        : this.next_recall_stability(d, s, r, grade)
+    const new_d = this.next_difficulty(d, grade)
     return { difficulty: new_d, stability: new_s }
   }
 }

--- a/packages/fsrs/src/models/fsrs-4/algorithm.ts
+++ b/packages/fsrs/src/models/fsrs-4/algorithm.ts
@@ -27,7 +27,7 @@ export class FSRS4Algorithm {
   }
 
   init_stability(g: Grade): number {
-    return Math.max(this.weights[g - 1], 0.1)
+    return clamp(this.weights[g - 1], this.bounds.sMin, this.bounds.sMax)
   }
 
   init_difficulty(g: Grade): number {

--- a/packages/fsrs/src/models/fsrs-4/constants.ts
+++ b/packages/fsrs/src/models/fsrs-4/constants.ts
@@ -1,10 +1,8 @@
 import type { ModelBounds } from '@open-spaced-repetition/srs-kit/model'
 import type { FSRSState } from '../../models.js'
 
-export const INIT_S_MAX = 100.0
-
 export const FSRS4_MODEL_BOUNDS: ModelBounds<FSRSState> = Object.freeze({
-  sMin: 0.01,
+  sMin: 0.1,
   sMax: 36500.0,
   dMin: 1.0,
   dMax: 10.0,
@@ -16,10 +14,10 @@ export const FSRS4_DEFAULT_WEIGHTS = Object.freeze([
 ]) as number[]
 
 export const FSRS4ParameterBounds = (): [number, number][] => [
-  [FSRS4_MODEL_BOUNDS.sMin, INIT_S_MAX],
-  [FSRS4_MODEL_BOUNDS.sMin, INIT_S_MAX],
-  [FSRS4_MODEL_BOUNDS.sMin, INIT_S_MAX],
-  [FSRS4_MODEL_BOUNDS.sMin, INIT_S_MAX],
+  [FSRS4_MODEL_BOUNDS.sMin, FSRS4_MODEL_BOUNDS.sMax],
+  [FSRS4_MODEL_BOUNDS.sMin, FSRS4_MODEL_BOUNDS.sMax],
+  [FSRS4_MODEL_BOUNDS.sMin, FSRS4_MODEL_BOUNDS.sMax],
+  [FSRS4_MODEL_BOUNDS.sMin, FSRS4_MODEL_BOUNDS.sMax],
   [1.0, 10.0],
   [0.1, 5.0],
   [0.1, 5.0],

--- a/packages/fsrs/src/models/fsrs-4/constants.ts
+++ b/packages/fsrs/src/models/fsrs-4/constants.ts
@@ -2,7 +2,7 @@ import type { ModelBounds } from '@open-spaced-repetition/srs-kit/model'
 import type { FSRSState } from '../../models.js'
 
 export const FSRS4_MODEL_BOUNDS: ModelBounds<FSRSState> = Object.freeze({
-  sMin: 0.1,
+  sMin: 0.01,
   sMax: 36500.0,
   dMin: 1.0,
   dMax: 10.0,

--- a/packages/fsrs/src/models/fsrs-4/constants.ts
+++ b/packages/fsrs/src/models/fsrs-4/constants.ts
@@ -1,0 +1,36 @@
+import type { ModelBounds } from '@open-spaced-repetition/srs-kit/model'
+import type { FSRSState } from '../../models.js'
+
+export const INIT_S_MAX = 100.0
+
+export const FSRS4_MODEL_BOUNDS: ModelBounds<FSRSState> = Object.freeze({
+  sMin: 0.01,
+  sMax: 36500.0,
+  dMin: 1.0,
+  dMax: 10.0,
+})
+
+export const FSRS4_DEFAULT_WEIGHTS = Object.freeze([
+  0.4, 0.9, 2.3, 10.9, 4.93, 0.94, 0.86, 0.01, 1.49, 0.14, 0.94, 2.18, 0.05,
+  0.34, 1.26, 0.29, 2.61,
+]) as number[]
+
+export const FSRS4ParameterBounds = (): [number, number][] => [
+  [FSRS4_MODEL_BOUNDS.sMin, INIT_S_MAX],
+  [FSRS4_MODEL_BOUNDS.sMin, INIT_S_MAX],
+  [FSRS4_MODEL_BOUNDS.sMin, INIT_S_MAX],
+  [FSRS4_MODEL_BOUNDS.sMin, INIT_S_MAX],
+  [1.0, 10.0],
+  [0.1, 5.0],
+  [0.1, 5.0],
+  [0.0, 0.5],
+  [0.0, 3.0],
+  [0.1, 0.8],
+  [0.01, 2.5],
+  [0.5, 5.0],
+  [0.01, 0.2],
+  [0.01, 0.9],
+  [0.01, 2.0],
+  [0.0, 1.0],
+  [1.0, 4.0],
+]

--- a/packages/fsrs/src/models/fsrs-4/index.ts
+++ b/packages/fsrs/src/models/fsrs-4/index.ts
@@ -1,0 +1,16 @@
+export {
+  FSRS4Algorithm,
+  forgetting_curve as forgettingCurve,
+} from './algorithm.js'
+export {
+  FSRS4_DEFAULT_WEIGHTS,
+  FSRS4_MODEL_BOUNDS,
+} from './constants.js'
+export { FSRS4Model } from './model.js'
+export type { FSRS4Config } from './parameters.js'
+export {
+  checkFSRS4Parameters,
+  clipFSRS4Parameters,
+  fsrs4ConfigSchema,
+  migrateFSRS4Parameters,
+} from './parameters.js'

--- a/packages/fsrs/src/models/fsrs-4/model.spec.ts
+++ b/packages/fsrs/src/models/fsrs-4/model.spec.ts
@@ -1,7 +1,12 @@
-import type { ModelForwardInput } from '@open-spaced-repetition/srs-kit/model'
+import { Rating } from '@open-spaced-repetition/srs-kit'
+import type {
+  ModelForwardInput,
+  ModelMemoryOf,
+} from '@open-spaced-repetition/srs-kit/model'
 import { describe, expect, it } from 'vitest'
-import { type FSRSState, Rating } from '../../models.js'
 import { FSRS4_DEFAULT_WEIGHTS, FSRS4Model, forgettingCurve } from './index.js'
+
+type FSRSState = ModelMemoryOf<typeof FSRS4Model>
 
 describe('FSRS-4 model', () => {
   const weights = FSRS4_DEFAULT_WEIGHTS
@@ -86,7 +91,7 @@ describe('FSRS-4 model', () => {
   })
 
   it('calculates the FSRS-4 forgetting curve and interval modifier', () => {
-    const model = FSRS4Model.create({ config: { weights: [...weights] } })
+    const model = FSRS4Model.create({ config: { weights } })
     const state: FSRSState = { stability: 10, difficulty: 5 }
 
     expect(forgettingCurve(10, 10)).toBe(0.9)

--- a/packages/fsrs/src/models/fsrs-4/model.spec.ts
+++ b/packages/fsrs/src/models/fsrs-4/model.spec.ts
@@ -1,0 +1,166 @@
+import type { ModelForwardInput } from '@open-spaced-repetition/srs-kit/model'
+import { describe, expect, it } from 'vitest'
+import { type FSRSState, Rating } from '../../models.js'
+import { FSRS4_DEFAULT_WEIGHTS, FSRS4Model, forgettingCurve } from './index.js'
+
+describe('FSRS-4 model', () => {
+  const weights = FSRS4_DEFAULT_WEIGHTS
+
+  it('creates model runtime with schema validation and create options', () => {
+    const model = FSRS4Model.create({
+      config: {
+        weights,
+      },
+    })
+    const bypassConfig = {
+      weights: Array.from(weights),
+    }
+
+    expect(
+      FSRS4Model.defaultValue.memoryState({ config: model.config })
+    ).toEqual({
+      stability: 0,
+      difficulty: 0,
+    })
+    expect(
+      FSRS4Model.create({ config: bypassConfig, bypass: true }).config
+    ).toBe(bypassConfig)
+    expect(() =>
+      FSRS4Model.create({
+        config: {
+          weights: 'invalid',
+        } as never,
+        migrate: false,
+        check: false,
+      })
+    ).toThrow()
+    expect(() =>
+      FSRS4Model.create({
+        config: {
+          weights: [0, ...weights.slice(1)],
+        },
+        migrate: false,
+        check: true,
+      })
+    ).toThrow('Expected FSRS4 weights within model bounds.')
+    expect(
+      FSRS4Model.create({
+        config: {
+          weights,
+          enableShortTerm: true,
+        } as never,
+      }).config
+    ).toEqual(model.config)
+  })
+
+  it('exposes the FSRS-4 model runtime methods', () => {
+    const model = FSRS4Model.create({
+      config: {
+        weights,
+      },
+    })
+    const initialState = model.step({
+      memoryState: null,
+      rating: Rating.Easy,
+      elapsedDays: 0,
+    })
+    const states = model.forward({
+      history: [
+        { rating: Rating.Again, deltaT: 0 },
+        { rating: Rating.Good, deltaT: 1 },
+      ],
+    })
+
+    expect(Number.isFinite(initialState.stability)).toBe(true)
+    expect(Number.isFinite(initialState.difficulty)).toBe(true)
+    expect(Number.isFinite(model.nextInterval(initialState, 0.9))).toBe(true)
+    expect(Number.isFinite(model.forgettingCurve(initialState, 14))).toBe(true)
+    expect(states).toHaveLength(2)
+  })
+
+  it('uses FSRS-4 default weights', () => {
+    expect(FSRS4_DEFAULT_WEIGHTS).toEqual([
+      0.4, 0.9, 2.3, 10.9, 4.93, 0.94, 0.86, 0.01, 1.49, 0.14, 0.94, 2.18, 0.05,
+      0.34, 1.26, 0.29, 2.61,
+    ])
+  })
+
+  it('calculates the FSRS-4 forgetting curve and interval modifier', () => {
+    const model = FSRS4Model.create({ config: { weights: [...weights] } })
+    const state: FSRSState = { stability: 10, difficulty: 5 }
+
+    expect(forgettingCurve(10, 10)).toBe(0.9)
+    expect(model.forgettingCurve(state, 10)).toBe(0.9)
+    expect(model.nextInterval(state, 0.9)).toBe(10)
+    expect(model.nextInterval(state, 0.8)).toBe(23)
+  })
+
+  it('calculates initial memory states with FSRS-4 formulas', () => {
+    const model = FSRS4Model.create({ config: { weights } })
+
+    expect(
+      model.step({ memoryState: null, rating: Rating.Again, elapsedDays: 0 })
+    ).toEqual({
+      difficulty: 6.81,
+      stability: 0.4,
+    })
+    expect(
+      model.step({ memoryState: null, rating: Rating.Hard, elapsedDays: 0 })
+    ).toEqual({
+      difficulty: 5.87,
+      stability: 0.9,
+    })
+    expect(
+      model.step({ memoryState: null, rating: Rating.Good, elapsedDays: 0 })
+    ).toEqual({
+      difficulty: 4.93,
+      stability: 2.3,
+    })
+    expect(
+      model.step({ memoryState: null, rating: Rating.Easy, elapsedDays: 0 })
+    ).toEqual({
+      difficulty: 3.99,
+      stability: 10.9,
+    })
+  })
+
+  it('calculates review memory states with FSRS-4 formulas', () => {
+    const model = FSRS4Model.create({ config: { weights } })
+    const initial = model.step({
+      memoryState: null,
+      rating: Rating.Good,
+      elapsedDays: 0,
+    })
+    const reviewed = model.step({
+      memoryState: initial,
+      rating: Rating.Good,
+      elapsedDays: 2,
+    })
+    const lapsed = model.step({
+      memoryState: reviewed,
+      rating: Rating.Again,
+      elapsedDays: 6,
+    })
+
+    expect(reviewed.stability).toBeCloseTo(7.06007207, 8)
+    expect(reviewed.difficulty).toBeCloseTo(4.93, 8)
+    expect(lapsed.stability).toBeCloseTo(2.31826584, 8)
+    expect(lapsed.difficulty).toBeCloseTo(6.6328, 8)
+  })
+
+  it('forwards review history', () => {
+    const model = FSRS4Model.create({ config: { weights } })
+    const input = {
+      history: [
+        { rating: Rating.Good, deltaT: 0 },
+        { rating: Rating.Good, deltaT: 2 },
+        { rating: Rating.Again, deltaT: 6 },
+      ],
+    } satisfies ModelForwardInput<FSRSState>
+
+    expect(model.forward(input).at(-1)).toEqual({
+      difficulty: 6.6328,
+      stability: 2.31826584,
+    })
+  })
+})

--- a/packages/fsrs/src/models/fsrs-4/model.ts
+++ b/packages/fsrs/src/models/fsrs-4/model.ts
@@ -1,0 +1,105 @@
+import type {
+  ModelCore,
+  ModelForwardInput,
+  ModelStepInput,
+} from '@open-spaced-repetition/srs-kit/model'
+import { defineModel } from '@open-spaced-repetition/srs-kit/model'
+import { FSRSMemoryStateSchema } from '../../kit/index.js'
+import type { FSRSState } from '../../models.js'
+import { FSRS4Algorithm } from './algorithm.js'
+import { FSRS4_MODEL_BOUNDS } from './constants.js'
+import {
+  checkFSRS4Parameters,
+  type FSRS4Config,
+  fsrs4ConfigSchema,
+  migrateFSRS4Parameters,
+} from './parameters.js'
+
+const createFSRS4Model = (
+  config: FSRS4Config
+): ModelCore<{
+  readonly config: FSRS4Config
+  readonly memoryState: FSRSState
+}> => {
+  const bounds = FSRS4_MODEL_BOUNDS
+
+  const algo = new FSRS4Algorithm(config.weights, FSRS4_MODEL_BOUNDS)
+
+  const step = ({
+    memoryState,
+    rating,
+    elapsedDays,
+    retrievability,
+  }: ModelStepInput<FSRSState>): FSRSState => {
+    return algo.next_state(memoryState, elapsedDays, rating, retrievability)
+  }
+
+  const nextInterval = (
+    memoryState: FSRSState,
+    desiredRetention: number
+  ): number => {
+    return algo.next_interval(memoryState.stability, desiredRetention)
+  }
+
+  const forgettingCurve = (
+    memoryState: FSRSState,
+    elapsedDays: number
+  ): number => {
+    return algo.forgetting_curve(elapsedDays, memoryState.stability)
+  }
+
+  const forward = ({
+    history,
+    initialState,
+  }: ModelForwardInput<FSRSState>): FSRSState[] => {
+    const states: FSRSState[] = []
+    let memoryState = initialState || null
+    for (const review of history) {
+      memoryState = step({
+        memoryState,
+        rating: review.rating,
+        elapsedDays: review.deltaT,
+      })
+      states.push(memoryState)
+    }
+    return states
+  }
+
+  return {
+    config,
+    bounds,
+    step,
+    nextInterval,
+    forgettingCurve,
+    forward,
+  }
+}
+
+export const FSRS4Model = defineModel({
+  name: 'fsrs-4',
+  schema: {
+    config: fsrs4ConfigSchema,
+    memoryState: FSRSMemoryStateSchema,
+  },
+  defaultValue: {
+    memoryState() {
+      return { stability: 0, difficulty: 0 }
+    },
+  },
+  create({ config, migrate = true, check = true, bypass = false }) {
+    if (bypass) {
+      return createFSRS4Model(config)
+    }
+
+    const weights = migrate
+      ? migrateFSRS4Parameters(config.weights)
+      : config.weights
+    if (check) {
+      checkFSRS4Parameters(weights)
+    }
+
+    const $config = fsrs4ConfigSchema.parse({ weights })
+
+    return createFSRS4Model(Object.freeze($config))
+  },
+})

--- a/packages/fsrs/src/models/fsrs-4/parameters.spec.ts
+++ b/packages/fsrs/src/models/fsrs-4/parameters.spec.ts
@@ -19,7 +19,7 @@ describe('FSRS-4 parameters', () => {
     expect(
       clipFSRS4Parameters(Array(17).fill(Number.NEGATIVE_INFINITY))
     ).toEqual([
-      0.1, 0.1, 0.1, 0.1, 1, 0.1, 0.1, 0, 0, 0.1, 0.01, 0.5, 0.01, 0.01, 0.01,
+      0.01, 0.01, 0.01, 0.01, 1, 0.1, 0.1, 0, 0, 0.1, 0.01, 0.5, 0.01, 0.01, 0.01,
       0, 1,
     ])
   })

--- a/packages/fsrs/src/models/fsrs-4/parameters.spec.ts
+++ b/packages/fsrs/src/models/fsrs-4/parameters.spec.ts
@@ -13,7 +13,14 @@ describe('FSRS-4 parameters', () => {
     expect(
       clipFSRS4Parameters(Array(17).fill(Number.POSITIVE_INFINITY))
     ).toEqual([
-      100, 100, 100, 100, 10, 5, 5, 0.5, 3, 0.8, 2.5, 5, 0.2, 0.9, 2, 1, 4,
+      36500, 36500, 36500, 36500, 10, 5, 5, 0.5, 3, 0.8, 2.5, 5, 0.2, 0.9, 2, 1,
+      4,
+    ])
+    expect(
+      clipFSRS4Parameters(Array(17).fill(Number.NEGATIVE_INFINITY))
+    ).toEqual([
+      0.1, 0.1, 0.1, 0.1, 1, 0.1, 0.1, 0, 0, 0.1, 0.01, 0.5, 0.01, 0.01, 0.01,
+      0, 1,
     ])
   })
 

--- a/packages/fsrs/src/models/fsrs-4/parameters.spec.ts
+++ b/packages/fsrs/src/models/fsrs-4/parameters.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import {
+  checkFSRS4Parameters,
+  clipFSRS4Parameters,
+  FSRS4_DEFAULT_WEIGHTS,
+  migrateFSRS4Parameters,
+} from './index.js'
+
+describe('FSRS-4 parameters', () => {
+  const weights = FSRS4_DEFAULT_WEIGHTS
+
+  it('uses the FSRS-4 parameter bounds from the reference implementation', () => {
+    expect(
+      clipFSRS4Parameters(Array(17).fill(Number.POSITIVE_INFINITY))
+    ).toEqual([
+      100, 100, 100, 100, 10, 5, 5, 0.5, 3, 0.8, 2.5, 5, 0.2, 0.9, 2, 1, 4,
+    ])
+  })
+
+  it('migrates FSRS-4 weights while filling missing parameters', () => {
+    expect(migrateFSRS4Parameters()).toEqual(weights)
+    expect(migrateFSRS4Parameters(Array.from(weights))).toEqual(weights)
+    expect(migrateFSRS4Parameters([1, 2, 3])).toEqual([
+      1,
+      2,
+      3,
+      ...weights.slice(3),
+    ])
+    expect(migrateFSRS4Parameters([...weights, 1, 1])).toEqual(weights)
+  })
+
+  it('checks parameter bounds after migration', () => {
+    expect(() => checkFSRS4Parameters([0, ...weights.slice(1)])).toThrow(
+      'Expected FSRS4 weights within model bounds.'
+    )
+  })
+})

--- a/packages/fsrs/src/models/fsrs-4/parameters.spec.ts
+++ b/packages/fsrs/src/models/fsrs-4/parameters.spec.ts
@@ -19,8 +19,8 @@ describe('FSRS-4 parameters', () => {
     expect(
       clipFSRS4Parameters(Array(17).fill(Number.NEGATIVE_INFINITY))
     ).toEqual([
-      0.01, 0.01, 0.01, 0.01, 1, 0.1, 0.1, 0, 0, 0.1, 0.01, 0.5, 0.01, 0.01, 0.01,
-      0, 1,
+      0.01, 0.01, 0.01, 0.01, 1, 0.1, 0.1, 0, 0, 0.1, 0.01, 0.5, 0.01, 0.01,
+      0.01, 0, 1,
     ])
   })
 

--- a/packages/fsrs/src/models/fsrs-4/parameters.ts
+++ b/packages/fsrs/src/models/fsrs-4/parameters.ts
@@ -1,0 +1,50 @@
+import { defineSchema, isObject } from '@open-spaced-repetition/srs-kit'
+import { FSRSValidationError } from '../../error.js'
+import { clamp } from '../../help.js'
+import { isNumberArray } from '../../kit/schema-utils.js'
+import { FSRS4_DEFAULT_WEIGHTS, FSRS4ParameterBounds } from './constants.js'
+
+export const clipFSRS4Parameters = (parameters: number[]): number[] => {
+  const clip = FSRS4ParameterBounds()
+  return clip.map(([min, max], index) =>
+    clamp(parameters[index] ?? FSRS4_DEFAULT_WEIGHTS[index], min, max)
+  )
+}
+
+export const checkFSRS4Parameters = (
+  parameters: number[] | readonly number[]
+) => {
+  const clipped = clipFSRS4Parameters(Array.from(parameters))
+  const isValid =
+    parameters.length === FSRS4_DEFAULT_WEIGHTS.length &&
+    clipped.every((value, index) => value === parameters[index])
+
+  if (!isValid) {
+    throw new FSRSValidationError('Expected FSRS4 weights within model bounds.')
+  }
+
+  return parameters
+}
+
+export const migrateFSRS4Parameters = (parameters?: number[]): number[] => {
+  if (!Array.isArray(parameters) || parameters.length === 0) {
+    return [...FSRS4_DEFAULT_WEIGHTS]
+  }
+  return clipFSRS4Parameters(parameters)
+}
+
+export type FSRS4Config = {
+  readonly weights: number[]
+}
+
+export const fsrs4ConfigSchema = defineSchema<FSRS4Config>((value) => {
+  if (isObject(value) && isNumberArray(value.weights)) {
+    return {
+      value: {
+        weights: value.weights,
+      },
+    }
+  }
+
+  return { issues: [{ message: 'Expected FSRS4 config' }] }
+})

--- a/packages/fsrs/tsdown.config.ts
+++ b/packages/fsrs/tsdown.config.ts
@@ -5,6 +5,7 @@ export default defineConfig([
     entry: {
       index: 'src/index.ts',
       error: 'src/error.ts',
+      'models/fsrs-4': 'src/models/fsrs-4/index.ts',
       'models/fsrs-4dot5': 'src/models/fsrs-4dot5/index.ts',
       'models/fsrs-5': 'src/models/fsrs-5/index.ts',
       'models/fsrs-6': 'src/models/fsrs-6/index.ts',


### PR DESCRIPTION
- https://github.com/open-spaced-repetition/ts-fsrs/issues/373
## Summary
- Add FSRS-4 model implementation and entrypoint.
- Add algorithm, model, and parameter tests with reference sources.

## Tests
- `vitest run --config=vitest.config.ts src/models/fsrs-4/algorithm.spec.ts src/models/fsrs-4/model.spec.ts src/models/fsrs-4dot5/algorithm.spec.ts`
- `tsc --noEmit --pretty false`