### PR TITLE
feat(fsrs): add FSRS-3 model

### DIFF
--- a/.changeset/add-fsrs3-model.md
+++ b/.changeset/add-fsrs3-model.md
@@ -1,0 +1,5 @@
+---
+"ts-fsrs": minor
+---
+
+feat(model): add `ts-fsrs/models/fsrs-3` as a dedicated FSRS-3 model entry.

--- a/packages/fsrs/package.json
+++ b/packages/fsrs/package.json
@@ -19,6 +19,17 @@
       },
       "default": "./dist/index.mjs"
     },
+    "./models/fsrs-3": {
+      "require": {
+        "types": "./dist/models/fsrs-3.d.cts",
+        "default": "./dist/models/fsrs-3.cjs"
+      },
+      "import": {
+        "types": "./dist/models/fsrs-3.d.mts",
+        "default": "./dist/models/fsrs-3.mjs"
+      },
+      "default": "./dist/models/fsrs-3.mjs"
+    },
     "./models/fsrs-5": {
       "require": {
         "types": "./dist/models/fsrs-5.d.cts",

--- a/packages/fsrs/src/models/fsrs-3/algorithm.spec.ts
+++ b/packages/fsrs/src/models/fsrs-3/algorithm.spec.ts
@@ -1,94 +1,153 @@
+import { type Grade, grades, Rating } from '@open-spaced-repetition/srs-kit'
 import { describe, expect, it } from 'vitest'
-import { type Grade, Rating } from '../../models.js'
-import { FSRS3Algorithm, forgetting_curve } from './algorithm.js'
-import { FSRS3_DEFAULT_WEIGHTS, FSRS3_MODEL_BOUNDS } from './constants.js'
+import {
+  FSRS3_DEFAULT_WEIGHTS,
+  FSRS3_MODEL_BOUNDS,
+  FSRS3Algorithm,
+  forgettingCurve,
+} from './index.js'
+
+type FSRSState = ReturnType<FSRS3Algorithm['next_state']>
 
 describe('FSRS3Algorithm', () => {
-  const algorithm = new FSRS3Algorithm(
-    FSRS3_DEFAULT_WEIGHTS,
-    FSRS3_MODEL_BOUNDS
-  )
-  const expectCloseStates = (
-    actual: Array<{ stability: number; difficulty: number }>,
-    expected: Array<{ stability: number; difficulty: number }>
+  const weights = FSRS3_DEFAULT_WEIGHTS
+  const algorithm = new FSRS3Algorithm(weights, FSRS3_MODEL_BOUNDS)
+  const formatState = (state: FSRSState) => ({
+    stability: state.stability.toFixed(8),
+    difficulty: state.difficulty.toFixed(8),
+  })
+  const expectCloseArray = (
+    actual: number[],
+    expected: number[],
+    precision = 6
   ) => {
     expect(actual).toHaveLength(expected.length)
-    actual.forEach((state, index) => {
-      expect(state.stability).toBeCloseTo(expected[index].stability, 4)
-      expect(state.difficulty).toBeCloseTo(expected[index].difficulty, 4)
+    actual.forEach((value, index) => {
+      expect(value).toBeCloseTo(expected[index], precision)
     })
   }
 
-  it('uses the FSRS-3 forgetting curve and interval formula', () => {
-    expect(forgetting_curve(10, 10)).toBe(0.9)
-    expect(algorithm.forgetting_curve(5, 10)).toBeCloseTo(Math.pow(0.9, 0.5), 8)
-    expect(algorithm.next_interval(10, 0.9)).toBe(10)
-    expect(algorithm.next_interval(10, 1)).toBe(1)
-    expect(() => algorithm.next_interval(1, 0)).toThrow(
+  it('uses the FSRS-3 forgetting curve', () => {
+    // Expected values source: srs-benchmark/models/fsrs_v3.py Python reference at 70cc4387f573ff20b13ac9c106333a335c8a4cb8.
+    // https://github.com/open-spaced-repetition/srs-benchmark/blob/70cc4387f573ff20b13ac9c106333a335c8a4cb8/models/fsrs_v3.py
+    expect([0, 1, 2, 3].map((t) => forgettingCurve(t, 1))).toEqual([
+      1, 0.9, 0.81, 0.729,
+    ])
+  })
+
+  it('calculates intervals through the FSRS-3 interval modifier', () => {
+    const requestRetentions = Array.from({ length: 10 }, (_, index) =>
+      Number(((index + 1) / 10).toFixed(1))
+    )
+    const intervals = requestRetentions.map((retention) =>
+      algorithm.next_interval(1, retention)
+    )
+
+    expect(intervals).toEqual([22, 15, 11, 9, 7, 5, 3, 2, 1, 1])
+    expect(algorithm.next_interval(6.1307, 0.9)).toBe(6)
+    expect(() => algorithm.next_interval(6.1307, 0)).toThrow(
       'Desired retention rate should be in the range (0,1]'
     )
   })
 
   it('initializes the first review state from FSRS-3 weights', () => {
-    const states = [Rating.Again, Rating.Hard, Rating.Good, Rating.Easy].map(
-      (rating) => algorithm.next_state(null, 0, rating)
+    expect(
+      () => new FSRS3Algorithm(weights.slice(0, 12), FSRS3_MODEL_BOUNDS)
+    ).toThrow('FSRS3Algorithm requires exactly 13 weights')
+    expectCloseArray(
+      grades.map((rating) => algorithm.init_stability(rating)),
+      [
+        weights[0],
+        weights[0] + weights[1],
+        weights[0] + 2 * weights[1],
+        weights[0] + 3 * weights[1],
+      ]
+    )
+    const lowerClamped = new FSRS3Algorithm(
+      [Number.NEGATIVE_INFINITY, ...weights.slice(1)],
+      FSRS3_MODEL_BOUNDS
+    )
+    const upperClamped = new FSRS3Algorithm(
+      [Number.POSITIVE_INFINITY, ...weights.slice(1)],
+      FSRS3_MODEL_BOUNDS
+    )
+    expect(lowerClamped.init_stability(Rating.Again)).toBe(
+      FSRS3_MODEL_BOUNDS.sMin
+    )
+    expect(upperClamped.init_stability(Rating.Again)).toBe(
+      FSRS3_MODEL_BOUNDS.sMax
+    )
+    expectCloseArray(
+      grades.map((rating) => algorithm.init_difficulty(rating)),
+      [
+        weights[2] - 2 * weights[3],
+        weights[2] - weights[3],
+        weights[2],
+        weights[2] + weights[3],
+      ]
+    )
+  })
+
+  it('matches the Python reference difficulty update results to 4 decimals', () => {
+    // Expected values source: srs-benchmark/models/fsrs_v3.py Python reference at 70cc4387f573ff20b13ac9c106333a335c8a4cb8.
+    // https://github.com/open-spaced-repetition/srs-benchmark/blob/70cc4387f573ff20b13ac9c106333a335c8a4cb8/models/fsrs_v3.py
+    expectCloseArray(
+      grades.map((rating) => 5 + weights[4] * (rating - 3)),
+      [5 - 2 * weights[4], 5 - weights[4], 5, 5 + weights[4]]
+    )
+    expectCloseArray(
+      grades.map((rating) => algorithm.next_difficulty(5, rating)),
+      [7.43428395, 6.21292183, 4.99155971, 3.77019759],
+      4
+    )
+  })
+
+  it('matches the Python reference stability update results to 4 decimals', () => {
+    // Expected values source: srs-benchmark/models/fsrs_v3.py Python reference at 70cc4387f573ff20b13ac9c106333a335c8a4cb8.
+    // https://github.com/open-spaced-repetition/srs-benchmark/blob/70cc4387f573ff20b13ac9c106333a335c8a4cb8/models/fsrs_v3.py
+    const stability = [5, 5, 5, 5]
+    const difficulty = [1, 2, 3, 4]
+    const retention = [0.9, 0.8, 0.7, 0.6]
+    const recall = grades.map((_, index) =>
+      algorithm.next_recall_stability(
+        difficulty[index],
+        stability[index],
+        retention[index]
+      )
+    )
+    const forget = grades.map((_, index) =>
+      algorithm.next_forget_stability(
+        difficulty[index],
+        stability[index],
+        retention[index]
+      )
+    )
+    const nextStability = grades.map(
+      (rating, index) =>
+        algorithm.next_state(
+          { difficulty: difficulty[index], stability: stability[index] },
+          0,
+          rating,
+          retention[index]
+        ).stability
     )
 
-    expect(states.map((state) => state.stability)).toEqual([
-      0.9605, 2.6839, 4.4073, 6.1307,
-    ])
-    expect(states.map((state) => state.difficulty)).toEqual([
-      7.2361, 6.0444, 4.8527, 3.661,
-    ])
+    expectCloseArray(
+      recall,
+      [29.33890984, 51.27167832, 70.2236555, 85.52142222],
+      4
+    )
+    expectCloseArray(forget, [5.41089414, 4.61822464, 4.4010631, 4.38774907], 4)
+    expectCloseArray(
+      nextStability,
+      [3.2899155, 44.15189718, 69.35813996, 99.00878817],
+      4
+    )
   })
 
-  it('matches the FSRS-3 recall and forget formulas', () => {
-    const memoryState = { stability: 5, difficulty: 5 }
-
-    expect(algorithm.next_state(memoryState, 5, Rating.Good)).toEqual({
-      difficulty: 4.99155971,
-      stability: 19.62388865,
-    })
-    expect(algorithm.next_state(memoryState, 10, Rating.Again)).toEqual({
-      difficulty: 7.43428395,
-      stability: 2.76257983,
-    })
-  })
-
-  it('validates algorithm inputs and handles manual reviews as no-ops', () => {
-    expect(
-      () =>
-        new FSRS3Algorithm(
-          FSRS3_DEFAULT_WEIGHTS.slice(0, 12),
-          FSRS3_MODEL_BOUNDS
-        )
-    ).toThrow('FSRS3Algorithm requires exactly 13 weights')
-    expect(() =>
-      algorithm.next_state({ stability: 5, difficulty: 5 }, -1, Rating.Good)
-    ).toThrow('Invalid delta_t "-1"')
-    expect(() =>
-      algorithm.next_state({ stability: 5, difficulty: 5 }, 1, 5)
-    ).toThrow('Invalid grade "5"')
-    expect(
-      algorithm.next_state({ stability: 5, difficulty: 5 }, 1, Rating.Manual)
-    ).toEqual({ stability: 5, difficulty: 5 })
-    expect(() =>
-      algorithm.next_state(
-        { stability: 0.001, difficulty: 0.5 },
-        1,
-        Rating.Good
-      )
-    ).toThrow('Invalid memory state { difficulty: 0.5, stability: 0.001 }')
-  })
-
-  it('uses provided retrievability when stepping a reviewed memory state', () => {
-    expect(
-      algorithm.next_state({ stability: 5, difficulty: 5 }, 1, Rating.Good, 1)
-    ).toEqual({ difficulty: 4.99155971, stability: 5 })
-  })
-
-  it('progresses review history through the FSRS-3 state machine', () => {
-    // Expected values source: local srs-benchmark/models/fsrs_v3.py Python reference.
+  it('matches the Python reference default memory-state progression to 8 decimals', () => {
+    // Expected values source: srs-benchmark/models/fsrs_v3.py Python reference at 70cc4387f573ff20b13ac9c106333a335c8a4cb8.
+    // https://github.com/open-spaced-repetition/srs-benchmark/blob/70cc4387f573ff20b13ac9c106333a335c8a4cb8/models/fsrs_v3.py
     const ratings: Grade[] = [
       Rating.Again,
       Rating.Good,
@@ -98,21 +157,34 @@ describe('FSRS3Algorithm', () => {
       Rating.Good,
     ]
     const intervals = [0, 0, 1, 3, 8, 21]
-    const states = []
-    let state = null
+    const states: FSRSState[] = []
+    let state: FSRSState | null = null
 
     for (const [index, rating] of ratings.entries()) {
       state = algorithm.next_state(state, intervals[index], rating)
       states.push(state)
     }
 
-    expectCloseStates(states, [
-      { stability: 0.9605000019073486, difficulty: 7.236100196838379 },
-      { stability: 0.9605000019073486, difficulty: 7.099531173706055 },
-      { stability: 3.545196771621704, difficulty: 6.97078800201416 },
-      { stability: 9.965413093566895, difficulty: 6.849421501159668 },
-      { stability: 24.764307022094727, difficulty: 6.73500919342041 },
-      { stability: 58.96782684326172, difficulty: 6.627153396606445 },
+    expect(states.map(formatState)).toEqual([
+      { stability: '0.96050000', difficulty: '7.23610000' },
+      { stability: '0.96050000', difficulty: '7.09953118' },
+      { stability: '3.54519473', difficulty: '6.97078775' },
+      { stability: '9.96540903', difficulty: '6.84942132' },
+      { stability: '24.76429562', difficulty: '6.73500919' },
+      { stability: '58.96783581', difficulty: '6.62715287' },
     ])
+  })
+
+  it('validates next-state inputs', () => {
+    expect(
+      algorithm.next_state({ difficulty: 5, stability: 5 }, 1, Rating.Manual)
+    ).toEqual({ difficulty: 5, stability: 5 })
+    expect(() => algorithm.next_state(null, -1, Rating.Good)).toThrow(
+      'Invalid delta_t "-1"'
+    )
+    expect(() => algorithm.next_state(null, 0, 5)).toThrow('Invalid grade "5"')
+    expect(() =>
+      algorithm.next_state({ difficulty: 0.5, stability: 0.1 }, 1, Rating.Good)
+    ).toThrow('Invalid memory state { difficulty: 0.5, stability: 0.1 }')
   })
 })

--- a/packages/fsrs/src/models/fsrs-3/algorithm.spec.ts
+++ b/packages/fsrs/src/models/fsrs-3/algorithm.spec.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest'
+import { type Grade, Rating } from '../../models.js'
+import { FSRS3Algorithm, forgetting_curve } from './algorithm.js'
+import { FSRS3_DEFAULT_WEIGHTS, FSRS3_MODEL_BOUNDS } from './constants.js'
+
+describe('FSRS3Algorithm', () => {
+  const algorithm = new FSRS3Algorithm(
+    FSRS3_DEFAULT_WEIGHTS,
+    FSRS3_MODEL_BOUNDS
+  )
+  const expectCloseStates = (
+    actual: Array<{ stability: number; difficulty: number }>,
+    expected: Array<{ stability: number; difficulty: number }>
+  ) => {
+    expect(actual).toHaveLength(expected.length)
+    actual.forEach((state, index) => {
+      expect(state.stability).toBeCloseTo(expected[index].stability, 4)
+      expect(state.difficulty).toBeCloseTo(expected[index].difficulty, 4)
+    })
+  }
+
+  it('uses the FSRS-3 forgetting curve and interval formula', () => {
+    expect(forgetting_curve(10, 10)).toBe(0.9)
+    expect(algorithm.forgetting_curve(5, 10)).toBeCloseTo(Math.pow(0.9, 0.5), 8)
+    expect(algorithm.next_interval(10, 0.9)).toBe(10)
+    expect(algorithm.next_interval(10, 1)).toBe(1)
+    expect(() => algorithm.next_interval(1, 0)).toThrow(
+      'Desired retention rate should be in the range (0,1]'
+    )
+  })
+
+  it('initializes the first review state from FSRS-3 weights', () => {
+    const states = [Rating.Again, Rating.Hard, Rating.Good, Rating.Easy].map(
+      (rating) => algorithm.next_state(null, 0, rating)
+    )
+
+    expect(states.map((state) => state.stability)).toEqual([
+      0.9605, 2.6839, 4.4073, 6.1307,
+    ])
+    expect(states.map((state) => state.difficulty)).toEqual([
+      7.2361, 6.0444, 4.8527, 3.661,
+    ])
+  })
+
+  it('matches the FSRS-3 recall and forget formulas', () => {
+    const memoryState = { stability: 5, difficulty: 5 }
+
+    expect(algorithm.next_state(memoryState, 5, Rating.Good)).toEqual({
+      difficulty: 4.99155971,
+      stability: 19.62388865,
+    })
+    expect(algorithm.next_state(memoryState, 10, Rating.Again)).toEqual({
+      difficulty: 7.43428395,
+      stability: 2.76257983,
+    })
+  })
+
+  it('validates algorithm inputs and handles manual reviews as no-ops', () => {
+    expect(
+      () =>
+        new FSRS3Algorithm(
+          FSRS3_DEFAULT_WEIGHTS.slice(0, 12),
+          FSRS3_MODEL_BOUNDS
+        )
+    ).toThrow('FSRS3Algorithm requires exactly 13 weights')
+    expect(() =>
+      algorithm.next_state({ stability: 5, difficulty: 5 }, -1, Rating.Good)
+    ).toThrow('Invalid delta_t "-1"')
+    expect(() =>
+      algorithm.next_state({ stability: 5, difficulty: 5 }, 1, 5)
+    ).toThrow('Invalid grade "5"')
+    expect(
+      algorithm.next_state({ stability: 5, difficulty: 5 }, 1, Rating.Manual)
+    ).toEqual({ stability: 5, difficulty: 5 })
+    expect(() =>
+      algorithm.next_state(
+        { stability: 0.001, difficulty: 0.5 },
+        1,
+        Rating.Good
+      )
+    ).toThrow('Invalid memory state { difficulty: 0.5, stability: 0.001 }')
+  })
+
+  it('uses provided retrievability when stepping a reviewed memory state', () => {
+    expect(
+      algorithm.next_state({ stability: 5, difficulty: 5 }, 1, Rating.Good, 1)
+    ).toEqual({ difficulty: 4.99155971, stability: 5 })
+  })
+
+  it('progresses review history through the FSRS-3 state machine', () => {
+    // Expected values source: local srs-benchmark/models/fsrs_v3.py Python reference.
+    const ratings: Grade[] = [
+      Rating.Again,
+      Rating.Good,
+      Rating.Good,
+      Rating.Good,
+      Rating.Good,
+      Rating.Good,
+    ]
+    const intervals = [0, 0, 1, 3, 8, 21]
+    const states = []
+    let state = null
+
+    for (const [index, rating] of ratings.entries()) {
+      state = algorithm.next_state(state, intervals[index], rating)
+      states.push(state)
+    }
+
+    expectCloseStates(states, [
+      { stability: 0.9605000019073486, difficulty: 7.236100196838379 },
+      { stability: 0.9605000019073486, difficulty: 7.099531173706055 },
+      { stability: 3.545196771621704, difficulty: 6.97078800201416 },
+      { stability: 9.965413093566895, difficulty: 6.849421501159668 },
+      { stability: 24.764307022094727, difficulty: 6.73500919342041 },
+      { stability: 58.96782684326172, difficulty: 6.627153396606445 },
+    ])
+  })
+})

--- a/packages/fsrs/src/models/fsrs-3/algorithm.ts
+++ b/packages/fsrs/src/models/fsrs-3/algorithm.ts
@@ -13,6 +13,7 @@ export function forgetting_curve(
 
 /**
  * @see https://github.com/open-spaced-repetition/awesome-fsrs/wiki/The-Algorithm#fsrs-3
+ * @see https://github.com/open-spaced-repetition/fsrs4anki/blob/6dba490ed156c28172f37f5969fe70e8301bca0f/fsrs4anki_scheduler.js
  */
 export class FSRS3Algorithm {
   constructor(
@@ -28,18 +29,12 @@ export class FSRS3Algorithm {
 
   init_stability(g: Grade): number {
     const w = this.weights
-    return roundTo(
-      clamp(w[0] + (g - 1) * w[1], this.bounds.sMin, this.bounds.sMax),
-      8
-    )
+    return clamp(w[0] + (g - 1) * w[1], this.bounds.sMin, this.bounds.sMax)
   }
 
   init_difficulty(g: Grade): number {
     const w = this.weights
-    return roundTo(
-      clamp(w[2] + (g - 3) * w[3], this.bounds.dMin, this.bounds.dMax),
-      8
-    )
+    return clamp(w[2] + (g - 3) * w[3], this.bounds.dMin, this.bounds.dMax)
   }
 
   next_interval(s: number, desired_retention: number): number {
@@ -52,10 +47,8 @@ export class FSRS3Algorithm {
         'Desired retention rate should be in the range (0,1]'
       )
     }
-    return Math.max(
-      Math.round((s * Math.log(desired_retention)) / Math.log(0.9)),
-      1
-    )
+    const intervalModifier = Math.log(desired_retention) / Math.log(0.9)
+    return roundTo(Math.max(Math.round(s * intervalModifier), 1), 8)
   }
 
   next_difficulty(d: number, g: Grade): number {

--- a/packages/fsrs/src/models/fsrs-3/algorithm.ts
+++ b/packages/fsrs/src/models/fsrs-3/algorithm.ts
@@ -1,0 +1,155 @@
+import { type Grade, Rating } from '@open-spaced-repetition/srs-kit'
+import type { ModelBounds } from '@open-spaced-repetition/srs-kit/model'
+import { FSRSValidationError } from '../../error.js'
+import { clamp, roundTo } from '../../help.js'
+import type { FSRSState } from '../../models.js'
+
+export function forgetting_curve(
+  elapsed_days: number,
+  stability: number
+): number {
+  return roundTo(Math.pow(0.9, elapsed_days / stability), 8)
+}
+
+/**
+ * @see https://github.com/open-spaced-repetition/awesome-fsrs/wiki/The-Algorithm#fsrs-3
+ */
+export class FSRS3Algorithm {
+  constructor(
+    private weights: number[],
+    private bounds: ModelBounds<FSRSState>
+  ) {
+    if (!Array.isArray(weights) || weights.length !== 13) {
+      throw new FSRSValidationError(
+        `FSRS3Algorithm requires exactly 13 weights, but received ${weights?.length}`
+      )
+    }
+  }
+
+  init_stability(g: Grade): number {
+    const w = this.weights
+    return roundTo(
+      clamp(w[0] + (g - 1) * w[1], this.bounds.sMin, this.bounds.sMax),
+      8
+    )
+  }
+
+  init_difficulty(g: Grade): number {
+    const w = this.weights
+    return roundTo(
+      clamp(w[2] + (g - 3) * w[3], this.bounds.dMin, this.bounds.dMax),
+      8
+    )
+  }
+
+  next_interval(s: number, desired_retention: number): number {
+    if (
+      !Number.isFinite(desired_retention) ||
+      desired_retention <= 0 ||
+      desired_retention > 1
+    ) {
+      throw new FSRSValidationError(
+        'Desired retention rate should be in the range (0,1]'
+      )
+    }
+    return Math.max(
+      Math.round((s * Math.log(desired_retention)) / Math.log(0.9)),
+      1
+    )
+  }
+
+  next_difficulty(d: number, g: Grade): number {
+    const w = this.weights
+    const next_d = d + w[4] * (g - 3)
+    return roundTo(
+      clamp(
+        this.mean_reversion(w[2], next_d),
+        this.bounds.dMin,
+        this.bounds.dMax
+      ),
+      8
+    )
+  }
+
+  mean_reversion(init: number, current: number): number {
+    const w = this.weights
+    return roundTo(w[5] * init + (1 - w[5]) * current, 8)
+  }
+
+  next_recall_stability(d: number, s: number, r: number): number {
+    const w = this.weights
+    return roundTo(
+      clamp(
+        s *
+          (1 +
+            Math.exp(w[6]) *
+              (11 - d) *
+              Math.pow(s, w[7]) *
+              (Math.exp((1 - r) * w[8]) - 1)),
+        this.bounds.sMin,
+        this.bounds.sMax
+      ),
+      8
+    )
+  }
+
+  next_forget_stability(d: number, s: number, r: number): number {
+    const w = this.weights
+    return roundTo(
+      clamp(
+        w[9] *
+          Math.pow(d, w[10]) *
+          Math.pow(s, w[11]) *
+          Math.exp((1 - r) * w[12]),
+        this.bounds.sMin,
+        this.bounds.sMax
+      ),
+      8
+    )
+  }
+
+  forgetting_curve = forgetting_curve
+
+  next_state(
+    memory_state: FSRSState | null,
+    t: number,
+    g: number,
+    r?: number
+  ): FSRSState {
+    const { difficulty: d, stability: s } = memory_state ?? {
+      difficulty: 0,
+      stability: 0,
+    }
+    if (t < 0) {
+      throw new FSRSValidationError(`Invalid delta_t "${t}"`)
+    }
+    if (g < 0 || g > 4) {
+      throw new FSRSValidationError(`Invalid grade "${g}"`)
+    }
+    if (g === Rating.Manual) {
+      return {
+        difficulty: d,
+        stability: s,
+      }
+    }
+    const grade = g as Grade
+    if (d === 0 && s === 0) {
+      return {
+        difficulty: this.init_difficulty(grade),
+        stability: this.init_stability(grade),
+      }
+    }
+    if (d < this.bounds.dMin || s < this.bounds.sMin) {
+      throw new FSRSValidationError(
+        `Invalid memory state { difficulty: ${d}, stability: ${s} }`
+      )
+    }
+    r = typeof r === 'number' ? r : this.forgetting_curve(t, s)
+    const new_d = this.next_difficulty(d, grade)
+    const new_s =
+      grade === Rating.Again
+        ? this.next_forget_stability(new_d, s, r)
+        : this.next_recall_stability(new_d, s, r)
+    return { difficulty: new_d, stability: new_s }
+  }
+}

--- a/packages/fsrs/src/models/fsrs-3/constants.ts
+++ b/packages/fsrs/src/models/fsrs-3/constants.ts
@@ -1,0 +1,31 @@
+import type { ModelBounds } from '@open-spaced-repetition/srs-kit/model'
+import type { FSRSState } from '../../models.js'
+
+export const FSRS3_MODEL_BOUNDS: ModelBounds<FSRSState> = Object.freeze({
+  sMin: 0.01,
+  sMax: 36500.0,
+  dMin: 1.0,
+  dMax: 10.0,
+})
+
+export const FSRS3_DEFAULT_WEIGHTS = Object.freeze([
+  0.9605, 1.7234, 4.8527, -1.1917, -1.2956, 0.0573, 1.7352, -0.1673, 1.065,
+  1.8907, -0.3832, 0.5867, 1.0721,
+]) as number[]
+
+// https://github.com/open-spaced-repetition/srs-benchmark/blob/main/models/fsrs_v3.py
+export const FSRS3ParameterBounds = (): [number, number][] => [
+  [0.1, 10.0],
+  [0.1, 5.0],
+  [FSRS3_MODEL_BOUNDS.dMin, FSRS3_MODEL_BOUNDS.dMax],
+  [-5.0, -0.1],
+  [-5.0, -0.1],
+  [0.05, 0.5],
+  [0.0, 2.0],
+  [-0.8, -0.15],
+  [0.01, 1.5],
+  [0.5, 5.0],
+  [-2.0, -0.01],
+  [0.01, 0.9],
+  [0.01, 2.0],
+]

--- a/packages/fsrs/src/models/fsrs-3/index.ts
+++ b/packages/fsrs/src/models/fsrs-3/index.ts
@@ -1,0 +1,17 @@
+export {
+  FSRS3Algorithm,
+  forgetting_curve as forgettingCurve,
+} from './algorithm.js'
+export {
+  FSRS3_DEFAULT_WEIGHTS,
+  FSRS3_MODEL_BOUNDS,
+  FSRS3ParameterBounds,
+} from './constants.js'
+export { FSRS3Model } from './model.js'
+export type { FSRS3Config } from './parameters.js'
+export {
+  checkFSRS3Parameters,
+  clipFSRS3Parameters,
+  fsrs3ConfigSchema,
+  migrateFSRS3Parameters,
+} from './parameters.js'

--- a/packages/fsrs/src/models/fsrs-3/model.spec.ts
+++ b/packages/fsrs/src/models/fsrs-3/model.spec.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest'
+import { type Grade, Rating } from '../../models.js'
+import { FSRS3_DEFAULT_WEIGHTS } from './constants.js'
+import { FSRS3Model } from './model.js'
+import { migrateFSRS3Parameters } from './parameters.js'
+
+describe('FSRS3Model', () => {
+  it('returns the default empty memory state', () => {
+    expect(
+      FSRS3Model.defaultValue.memoryState({
+        config: {
+          weights: FSRS3_DEFAULT_WEIGHTS,
+        },
+      })
+    ).toEqual({ stability: 0, difficulty: 0 })
+  })
+
+  it('binds step, forgetting curve, interval, and forward to FSRS-3 algorithm', () => {
+    const model = FSRS3Model.create({
+      config: {
+        weights: FSRS3_DEFAULT_WEIGHTS,
+      },
+    })
+
+    const initial = model.step({
+      memoryState: null,
+      rating: Rating.Good,
+      elapsedDays: 0,
+    })
+
+    expect(initial).toEqual({ stability: 4.4073, difficulty: 4.8527 })
+    expect(model.nextInterval(initial, 0.9)).toBe(4)
+    expect(model.forgettingCurve(initial, 1)).toBe(0.97637757)
+
+    const history: { rating: Grade; deltaT: number }[] = [
+      { rating: Rating.Good, deltaT: 0 },
+      { rating: Rating.Good, deltaT: 1 },
+    ]
+
+    expect(model.forward({ history })).toEqual([
+      { difficulty: 4.8527, stability: 4.4073 },
+      { difficulty: 4.8527, stability: 7.4609786 },
+    ])
+  })
+
+  it('validates config with schema before creating model runtime', () => {
+    expect(() =>
+      FSRS3Model.create({
+        config: {
+          weights: 'invalid',
+        } as never,
+        migrate: false,
+        check: false,
+      })
+    ).toThrow()
+  })
+
+  it('migrates FSRS-3 weights when requested', () => {
+    const weights = Array.from(FSRS3_DEFAULT_WEIGHTS)
+    weights[0] = 0
+
+    const model = FSRS3Model.create({
+      config: { weights },
+      migrate: true,
+    })
+
+    expect(model.config.weights).toEqual(migrateFSRS3Parameters(weights))
+  })
+
+  it('bypasses create-time parsing when requested', () => {
+    const config = {
+      weights: Array.from(FSRS3_DEFAULT_WEIGHTS),
+    }
+
+    const model = FSRS3Model.create({ config, bypass: true })
+
+    expect(model.config).toBe(config)
+  })
+
+  it('skips parameter bounds checks when requested', () => {
+    const weights = Array.from(FSRS3_DEFAULT_WEIGHTS)
+    weights[0] = 0
+
+    const model = FSRS3Model.create({
+      config: { weights },
+      migrate: false,
+      check: false,
+    })
+
+    expect(model.config.weights[0]).toBe(0)
+  })
+
+  it('checks parameter bounds when requested', () => {
+    const weights = Array.from(FSRS3_DEFAULT_WEIGHTS)
+    weights[0] = 0
+
+    expect(() =>
+      FSRS3Model.create({
+        config: { weights },
+        migrate: false,
+        check: true,
+      })
+    ).toThrow('Expected FSRS3 weights within model bounds.')
+  })
+})

--- a/packages/fsrs/src/models/fsrs-3/model.ts
+++ b/packages/fsrs/src/models/fsrs-3/model.ts
@@ -1,0 +1,104 @@
+import type {
+  ModelCore,
+  ModelForwardInput,
+  ModelStepInput,
+} from '@open-spaced-repetition/srs-kit/model'
+import { defineModel } from '@open-spaced-repetition/srs-kit/model'
+import { FSRSMemoryStateSchema } from '../../kit/index.js'
+import type { FSRSState } from '../../models.js'
+import { FSRS3Algorithm } from './algorithm.js'
+import { FSRS3_MODEL_BOUNDS } from './constants.js'
+import {
+  checkFSRS3Parameters,
+  type FSRS3Config,
+  fsrs3ConfigSchema,
+  migrateFSRS3Parameters,
+} from './parameters.js'
+
+const createFSRS3Model = (
+  config: FSRS3Config
+): ModelCore<{
+  readonly config: FSRS3Config
+  readonly memoryState: FSRSState
+}> => {
+  const bounds = FSRS3_MODEL_BOUNDS
+  const algo = new FSRS3Algorithm(config.weights, bounds)
+
+  const step = ({
+    memoryState,
+    rating,
+    elapsedDays,
+    retrievability,
+  }: ModelStepInput<FSRSState>): FSRSState => {
+    return algo.next_state(memoryState, elapsedDays, rating, retrievability)
+  }
+
+  const nextInterval = (
+    memoryState: FSRSState,
+    desiredRetention: number
+  ): number => {
+    return algo.next_interval(memoryState.stability, desiredRetention)
+  }
+
+  const forgettingCurve = (
+    memoryState: FSRSState,
+    elapsedDays: number
+  ): number => {
+    return algo.forgetting_curve(elapsedDays, memoryState.stability)
+  }
+
+  const forward = ({
+    history,
+    initialState,
+  }: ModelForwardInput<FSRSState>): FSRSState[] => {
+    const states: FSRSState[] = []
+    let memoryState = initialState || null
+    for (const review of history) {
+      memoryState = step({
+        memoryState,
+        rating: review.rating,
+        elapsedDays: review.deltaT,
+      })
+      states.push(memoryState)
+    }
+    return states
+  }
+
+  return {
+    config,
+    bounds,
+    step,
+    nextInterval,
+    forgettingCurve,
+    forward,
+  }
+}
+
+export const FSRS3Model = defineModel({
+  name: 'fsrs-3',
+  schema: {
+    config: fsrs3ConfigSchema,
+    memoryState: FSRSMemoryStateSchema,
+  },
+  defaultValue: {
+    memoryState() {
+      return { stability: 0, difficulty: 0 }
+    },
+  },
+  create({ config, migrate = true, check = true, bypass = false }) {
+    if (bypass) {
+      return createFSRS3Model(config)
+    }
+
+    const weights = migrate
+      ? migrateFSRS3Parameters(config.weights)
+      : config.weights
+    if (check) {
+      checkFSRS3Parameters(weights)
+    }
+
+    const $config = fsrs3ConfigSchema.parse({ weights })
+
+    return createFSRS3Model(Object.freeze($config))
+  },
+})

--- a/packages/fsrs/src/models/fsrs-3/parameters.spec.ts
+++ b/packages/fsrs/src/models/fsrs-3/parameters.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { FSRS3_DEFAULT_WEIGHTS } from './constants.js'
+import { clipFSRS3Parameters, migrateFSRS3Parameters } from './parameters.js'
+
+describe('FSRS-3 parameters', () => {
+  it('returns FSRS-3 default weights when input is missing', () => {
+    expect(migrateFSRS3Parameters()).toEqual(FSRS3_DEFAULT_WEIGHTS)
+  })
+
+  it('clips 13 FSRS-3 weights to model bounds', () => {
+    const weights = Array(13).fill(Number.POSITIVE_INFINITY)
+
+    expect(clipFSRS3Parameters(weights)).toEqual([
+      10, 5, 10, -0.1, -0.1, 0.5, 2, -0.15, 1.5, 5, -0.01, 0.9, 2,
+    ])
+  })
+
+  it('clips lower FSRS-3 weight bounds', () => {
+    const weights = Array(13).fill(Number.NEGATIVE_INFINITY)
+
+    expect(clipFSRS3Parameters(weights)).toEqual([
+      0.1, 0.1, 1, -5, -5, 0.05, 0, -0.8, 0.01, 0.5, -2, 0.01, 0.01,
+    ])
+  })
+
+  it('fills omitted FSRS-3 weights from defaults when clipping', () => {
+    expect(migrateFSRS3Parameters([1, 2, 3])).toEqual([
+      1,
+      2,
+      3,
+      ...FSRS3_DEFAULT_WEIGHTS.slice(3),
+    ])
+  })
+})

--- a/packages/fsrs/src/models/fsrs-3/parameters.ts
+++ b/packages/fsrs/src/models/fsrs-3/parameters.ts
@@ -1,0 +1,50 @@
+import { defineSchema, isObject } from '@open-spaced-repetition/srs-kit'
+import { FSRSValidationError } from '../../error.js'
+import { clamp } from '../../help.js'
+import { isNumberArray } from '../../kit/schema-utils.js'
+import { FSRS3_DEFAULT_WEIGHTS, FSRS3ParameterBounds } from './constants.js'
+
+export const clipFSRS3Parameters = (parameters: number[]): number[] => {
+  const clip = FSRS3ParameterBounds()
+  return clip.map(([min, max], index) =>
+    clamp(parameters[index] ?? FSRS3_DEFAULT_WEIGHTS[index], min, max)
+  )
+}
+
+export const checkFSRS3Parameters = (
+  parameters: number[] | readonly number[]
+) => {
+  const clipped = clipFSRS3Parameters(Array.from(parameters))
+  const isValid =
+    parameters.length === FSRS3_DEFAULT_WEIGHTS.length &&
+    clipped.every((value, index) => value === parameters[index])
+
+  if (!isValid) {
+    throw new FSRSValidationError('Expected FSRS3 weights within model bounds.')
+  }
+
+  return parameters
+}
+
+export const migrateFSRS3Parameters = (parameters?: number[]): number[] => {
+  if (!Array.isArray(parameters) || parameters.length === 0) {
+    return [...FSRS3_DEFAULT_WEIGHTS]
+  }
+  return clipFSRS3Parameters(parameters)
+}
+
+export type FSRS3Config = {
+  readonly weights: number[]
+}
+
+export const fsrs3ConfigSchema = defineSchema<FSRS3Config>((value) => {
+  if (isObject(value) && isNumberArray(value.weights)) {
+    return {
+      value: {
+        weights: value.weights,
+      },
+    }
+  }
+
+  return { issues: [{ message: 'Expected FSRS3 config' }] }
+})

--- a/packages/fsrs/tsdown.config.ts
+++ b/packages/fsrs/tsdown.config.ts
@@ -5,6 +5,7 @@ export default defineConfig([
     entry: {
       index: 'src/index.ts',
       error: 'src/error.ts',
+      'models/fsrs-3': 'src/models/fsrs-3/index.ts',
       'models/fsrs-4': 'src/models/fsrs-4/index.ts',
       'models/fsrs-4dot5': 'src/models/fsrs-4dot5/index.ts',
       'models/fsrs-5': 'src/models/fsrs-5/index.ts',


### PR DESCRIPTION
- https://github.com/open-spaced-repetition/ts-fsrs/issues/373
## Summary
- Add FSRS-3 model support for the new srs-kit model architecture.
- Align FSRS-3 scheduling behavior with [fsrs4anki_scheduler.js](https://github.com/open-spaced-repetition/fsrs4anki/blob/6dba490ed156c28172f37f5969fe70e8301bca0f/fsrs4anki_scheduler.js) and srs-benchmark fsrs_v3.py.
- Add focused FSRS-3 algorithm, model, and parameter tests.

## Tests
- ../../node_modules/.bin/vitest run --config=vitest.config.ts src/models/fsrs-3/algorithm.spec.ts src/models/fsrs-3/model.spec.ts src/models/fsrs-3/parameters.spec.ts