### PR TITLE
feat(kit): add configurable forget support

### DIFF
--- a/.changeset/srs-kit-forget.md
+++ b/.changeset/srs-kit-forget.md
@@ -1,0 +1,5 @@
+---
+"@open-spaced-repetition/srs-kit": minor
+---
+
+feat(kit): add scheduler `forget` support with configurable stats reset.

--- a/packages/srs-kit/src/middleware/middleware.ts
+++ b/packages/srs-kit/src/middleware/middleware.ts
@@ -31,6 +31,9 @@ export type RollbackMiddlewareResult<
 
 export interface MiddlewareContextBase<Env extends MiddlewareEnv> {
   readonly config: MiddlewareContextConfig<Env>
+  readonly input?: {
+    readonly card: MiddlewareContextObjectOf<Env, 'card'>
+  }
 }
 
 export interface ReviewCandidateContext {

--- a/packages/srs-kit/src/middleware/stats/index.ts
+++ b/packages/srs-kit/src/middleware/stats/index.ts
@@ -1,2 +1,8 @@
 export { schedulerStatsMiddleware } from './middleware.js'
-export { type StatsCardFields, statsFieldsSchema } from './schema.js'
+export {
+  type StatsCardFields,
+  type StatsConfig,
+  type StatsConfigInput,
+  statsConfigSchema,
+  statsFieldsSchema,
+} from './schema.js'

--- a/packages/srs-kit/src/middleware/stats/middleware.spec.ts
+++ b/packages/srs-kit/src/middleware/stats/middleware.spec.ts
@@ -27,7 +27,7 @@ function reviewContext({
   readonly lapses?: number
 } = {}): ReviewContext {
   return {
-    config: { chrono: 0 },
+    config: { chrono: 0, clearStatsOnForget: true },
     input: {
       card: { reps, lapses, state, scheduleStatus: 'review' },
       grade,
@@ -59,7 +59,7 @@ function rollbackContext({
   readonly lapses?: number
 } = {}): RollbackContext {
   return {
-    config: { chrono: 0 },
+    config: { chrono: 0, clearStatsOnForget: true },
     input: {
       card: { reps, lapses, state, scheduleStatus: 'review' },
       revlog: { state, rating, scheduleStatus: 'review' },
@@ -73,10 +73,50 @@ function rollbackContext({
 describe('schedulerStatsMiddleware', () => {
   it('provides default stats fields', () => {
     expect(
-      schedulerStatsMiddleware.defaultValue?.card?.({ config: { chrono: 0 } })
+      schedulerStatsMiddleware.defaultValue?.card?.({
+        config: { chrono: 0, clearStatsOnForget: true },
+      })
     ).toEqual({
       reps: 0,
       lapses: 0,
+    })
+  })
+
+  it('clears old stats by default when card defaults receive input', () => {
+    expect(
+      schedulerStatsMiddleware.defaultValue?.card?.({
+        config: { chrono: 0, clearStatsOnForget: true },
+        input: {
+          card: {
+            reps: 3,
+            lapses: 1,
+            state: State.Review,
+            scheduleStatus: 'review',
+          },
+        },
+      })
+    ).toEqual({
+      reps: 0,
+      lapses: 0,
+    })
+  })
+
+  it('can preserve old stats when card defaults receive input', () => {
+    expect(
+      schedulerStatsMiddleware.defaultValue?.card?.({
+        config: { chrono: 0, clearStatsOnForget: false },
+        input: {
+          card: {
+            reps: 3,
+            lapses: 1,
+            state: State.Review,
+            scheduleStatus: 'review',
+          },
+        },
+      })
+    ).toEqual({
+      reps: 3,
+      lapses: 1,
     })
   })
 

--- a/packages/srs-kit/src/middleware/stats/middleware.ts
+++ b/packages/srs-kit/src/middleware/stats/middleware.ts
@@ -1,15 +1,24 @@
 import { Rating } from '@/primitives/rating.js'
 import { State } from '@/primitives/state.js'
 import { defineMiddleware } from '../middleware.js'
-import { statsFieldsSchema } from './schema.js'
+import { statsConfigSchema, statsFieldsSchema } from './schema.js'
 
 export const schedulerStatsMiddleware = defineMiddleware({
   name: Symbol('srs-kit.stats'),
   schema: {
+    config: statsConfigSchema,
     card: statsFieldsSchema,
   },
   defaultValue: {
-    card(_ctx) {
+    card(ctx) {
+      const card = ctx.input?.card
+      if (card && ctx.config.clearStatsOnForget === false) {
+        return {
+          reps: card.reps,
+          lapses: card.lapses,
+        }
+      }
+
       return {
         reps: 0,
         lapses: 0,

--- a/packages/srs-kit/src/middleware/stats/schema.spec.ts
+++ b/packages/srs-kit/src/middleware/stats/schema.spec.ts
@@ -1,5 +1,31 @@
 import { describe, expect, it } from 'vitest'
-import { statsFieldsSchema } from './schema.js'
+import { statsConfigSchema, statsFieldsSchema } from './schema.js'
+
+describe('statsConfigSchema', () => {
+  it('defaults clearStatsOnForget to true', () => {
+    expect(statsConfigSchema.parse({})).toEqual({
+      clearStatsOnForget: true,
+    })
+  })
+
+  it('accepts clearStatsOnForget false', () => {
+    expect(statsConfigSchema.parse({ clearStatsOnForget: false })).toEqual({
+      clearStatsOnForget: false,
+    })
+  })
+
+  it('rejects non-object values', () => {
+    expect(() => statsConfigSchema.parse(null)).toThrow(
+      'Expected stats config object'
+    )
+  })
+
+  it('rejects non-boolean clearStatsOnForget values', () => {
+    expect(() =>
+      statsConfigSchema.parse({ clearStatsOnForget: 'false' })
+    ).toThrow('Expected boolean clearStatsOnForget')
+  })
+})
 
 describe('statsFieldsSchema', () => {
   it('accepts non-negative integer stats fields', () => {

--- a/packages/srs-kit/src/middleware/stats/schema.ts
+++ b/packages/srs-kit/src/middleware/stats/schema.ts
@@ -5,6 +5,40 @@ export type StatsCardFields = {
   readonly lapses: number
 }
 
+export type StatsConfigInput = {
+  /**
+   * When forget receives an existing card, clear reps/lapses instead of
+   * carrying the previous counters forward. Defaults to true.
+   */
+  readonly clearStatsOnForget?: boolean
+}
+
+export type StatsConfig = {
+  readonly clearStatsOnForget: boolean
+}
+
+export const statsConfigSchema = defineSchema<StatsConfigInput, StatsConfig>(
+  (value) => {
+    if (!isObject(value)) {
+      return { issues: [{ message: 'Expected stats config object' }] }
+    }
+
+    const { clearStatsOnForget } = value
+    if (clearStatsOnForget === undefined) {
+      return { value: { clearStatsOnForget: true } }
+    }
+    if (typeof clearStatsOnForget !== 'boolean') {
+      return { issues: [{ message: 'Expected boolean clearStatsOnForget' }] }
+    }
+
+    return {
+      value: {
+        clearStatsOnForget,
+      },
+    }
+  }
+)
+
 export const statsFieldsSchema = defineSchema<StatsCardFields>((value) => {
   if (!isObject(value)) {
     return { issues: [{ message: 'Expected stats object' }] }

--- a/packages/srs-kit/src/scheduler/base.spec.ts
+++ b/packages/srs-kit/src/scheduler/base.spec.ts
@@ -57,7 +57,11 @@ const usedCore = usedScheduler.create({
 
 describe('SchedulerCore.create', () => {
   it('validates config and returns core', () => {
-    expect(core.config).toEqual({ ...config, chrono: {} })
+    expect(core.config).toEqual({
+      ...config,
+      chrono: {},
+      clearStatsOnForget: true,
+    })
   })
 
   it('does not expose desiredRetention on config', () => {
@@ -68,6 +72,7 @@ describe('SchedulerCore.create', () => {
     expect(c.config).toEqual({
       weights: SM2_DEFAULT_WEIGHTS,
       chrono: {},
+      clearStatsOnForget: true,
     })
     expect(c.config).not.toHaveProperty('desiredRetention')
   })
@@ -929,6 +934,148 @@ describe('SchedulerCore.preview', () => {
     expect(
       Array.from(core.preview({ card })).map((item) => item.grade)
     ).toEqual([Rating.Again, Rating.Hard, Rating.Good, Rating.Easy])
+  })
+})
+
+describe('SchedulerCore.forget', () => {
+  it('resets a reviewed card through new-card defaults without a revlog', () => {
+    const card = core.newCard({ now: 0 })
+    const first = core.review({ card, grade: Rating.Good, now: 0 })
+    const second = core.review({
+      card: first.card,
+      grade: Rating.Again,
+      now: first.card.interval,
+    })
+
+    const forgotten = core.forget({ card: second.card, now: 9 })
+
+    expect(forgotten.state).toBe(State.New)
+    expect(forgotten.scheduleStatus).toBe('new')
+    expect(forgotten.interval).toBe(0)
+    expect(forgotten.easeFactor).toBe(SM2_DEFAULT_WEIGHTS[2])
+    expect(forgotten.reviewStep).toBe(0)
+    expect(forgotten.reps).toBe(0)
+    expect(forgotten.lapses).toBe(0)
+    expect(forgotten).not.toHaveProperty('rating')
+  })
+
+  it('can preserve stats from the forgotten card', () => {
+    const preserveCore = scheduler.create({
+      config: {
+        ...config,
+        clearStatsOnForget: false,
+      },
+    })
+    const card = preserveCore.newCard({ now: 0 })
+    const first = preserveCore.review({ card, grade: Rating.Good, now: 0 })
+    const second = preserveCore.review({
+      card: first.card,
+      grade: Rating.Again,
+      now: first.card.interval,
+    })
+
+    const forgotten = preserveCore.forget({ card: second.card, now: 9 })
+
+    expect(forgotten.state).toBe(State.New)
+    expect(forgotten.interval).toBe(0)
+    expect(forgotten.reps).toBe(2)
+    expect(forgotten.lapses).toBe(1)
+  })
+
+  it('passes old card data to middleware defaults only for forget', () => {
+    const seen: string[] = []
+    const contextMiddleware = defineMiddleware({
+      name: 'forgetDefaultContext',
+      schema: {
+        card: sourceCardSchema,
+      },
+      defaultValue: {
+        card(ctx) {
+          seen.push(
+            Object.hasOwn(ctx, 'input')
+              ? (ctx.input?.card.scheduleStatus ?? 'undefined')
+              : 'none'
+          )
+          return { source: ctx.input?.card.source ?? 'fresh' }
+        },
+      },
+    })
+    const contextCore = createSM2NumericScheduler()
+      .use(contextMiddleware, schedulerStatsMiddleware)
+      .create({ config })
+    const card = contextCore.newCard({ now: 0 })
+
+    const forgotten = contextCore.forget({
+      card: { ...card, source: 'old-source' },
+      now: 1,
+    })
+
+    expect(seen).toEqual(['none', 'new'])
+    expect(forgotten.source).toBe('old-source')
+  })
+
+  it('uses chrono card defaults at the forget time', () => {
+    const dateCore = defineScheduler({
+      model: SM2Model,
+      chrono: dateChrono,
+    })
+      .use(schedulerStatsMiddleware)
+      .create({ config })
+    const first = new Date('2026-01-01T00:00:00.000Z')
+    const second = new Date('2026-01-02T00:00:00.000Z')
+    const forgottenAt = new Date('2026-02-01T00:00:00.000Z')
+    const card = dateCore.newCard({ now: first })
+    const reviewed = dateCore.review({
+      card,
+      grade: Rating.Good,
+      now: second,
+    })
+
+    const forgotten = dateCore.forget({
+      card: reviewed.card,
+      now: forgottenAt,
+    })
+
+    expect(forgotten.state).toBe(State.New)
+    expect(forgotten.dueAt).toBe(forgottenAt)
+    expect(forgotten.lastReviewAt).toBe(null)
+  })
+
+  it('uses chrono now when forget time is omitted', () => {
+    const dateCore = defineScheduler({
+      model: SM2Model,
+      chrono: dateChrono,
+    })
+      .use(schedulerStatsMiddleware)
+      .create({ config })
+    const card = dateCore.newCard({
+      now: new Date('2026-01-01T00:00:00.000Z'),
+    })
+
+    const forgotten = dateCore.forget({ card })
+
+    expect(forgotten.dueAt).toBeInstanceOf(Date)
+    expect(forgotten.lastReviewAt).toBe(null)
+  })
+
+  it('returns a mutable card', () => {
+    const card = core.newCard()
+    const result = core.review({ card, grade: Rating.Good, now: 0 })
+    const forgotten = core.forget({ card: result.card, now: 1 })
+
+    expect(Object.isFrozen(forgotten)).toBe(false)
+  })
+
+  it('validates card input', () => {
+    expect(() => core.forget({ card: {} as never, now: 0 })).toThrow()
+  })
+
+  it('validates now input', () => {
+    const card = core.newCard()
+
+    expect(() => core.forget({ card, now: 'bad' as never })).toThrow(
+      'Expected finite number'
+    )
   })
 })
 

--- a/packages/srs-kit/src/scheduler/base.ts
+++ b/packages/srs-kit/src/scheduler/base.ts
@@ -197,6 +197,23 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
     })
   }
 
+  forget = (input: {
+    readonly card: SchedulerCoreEnv<Env>['card']['input']
+    readonly now?: SchedulerCoreEnv<Env>['chrono']
+  }): SchedulerCoreEnv<Env>['card']['output'] => {
+    const card = parse(
+      this.schema.card,
+      input.card
+    ) as SchedulerCoreEnv<Env>['card']['output']
+    const now = this.parseNow(input.now ?? this.chronoCore.now())
+
+    return this.defaultValue.newCard<SchedulerCoreEnv<Env>['card']['output']>({
+      config: this.config,
+      time: now,
+      input: { card: Object.freeze(card) },
+    })
+  }
+
   review = (input: {
     readonly card: SchedulerCoreEnv<Env>['card']['input']
     readonly grade: Grade

--- a/packages/srs-kit/src/scheduler/default-value.ts
+++ b/packages/srs-kit/src/scheduler/default-value.ts
@@ -12,6 +12,9 @@ type DefaultValueConfig = Record<PropertyKey, unknown>
 
 type DefaultValueContext = {
   readonly config: DefaultValueConfig
+  readonly input?: {
+    readonly card: Readonly<Record<string, unknown>>
+  }
 }
 
 export type SchedulerDefaultValueFactory = {
@@ -25,17 +28,12 @@ export type SchedulerDefaultValueFactory = {
 function applyMiddlewareCardDefaults(
   target: Record<string, unknown>,
   middlewares: readonly AnyMiddleware[],
-  config: DefaultValueConfig
+  ctx: DefaultValueContext
 ) {
   for (const middleware of middlewares) {
     const defaultValue = middleware.defaultValue?.card
     if (isFunction(defaultValue)) {
-      Object.assign(
-        target,
-        defaultValue({
-          config,
-        })
-      )
+      Object.assign(target, defaultValue(ctx))
     }
   }
 }
@@ -52,8 +50,12 @@ function applyNewCardDefaults(ctx: {
   readonly middlewares: readonly AnyMiddleware[]
   readonly chronoDefault?: ChronoDefaultRuntimeFn
   readonly time: ChronoDefaultCtx<unknown, unknown>['time']
+  readonly input?: DefaultValueContext['input']
 }) {
   const { target, config, middlewares, chronoDefault, time } = ctx
+  const defaultCtx: DefaultValueContext = ctx.input
+    ? { config: ctx.config, input: ctx.input }
+    : { config: ctx.config }
 
   if (chronoDefault) {
     Object.assign(
@@ -65,7 +67,7 @@ function applyNewCardDefaults(ctx: {
     )
   }
 
-  applyMiddlewareCardDefaults(target, middlewares, config)
+  applyMiddlewareCardDefaults(target, middlewares, defaultCtx)
 }
 
 export function useComposeDefaultValue(ctx: {
@@ -80,6 +82,7 @@ export function useComposeDefaultValue(ctx: {
     newCard<Card extends object = Record<string, unknown>>({
       config,
       time,
+      input,
     }: DefaultValueContext & { readonly time: unknown }) {
       const card: Record<string, unknown> = model.defaultValue.memoryState({
         config,
@@ -92,6 +95,7 @@ export function useComposeDefaultValue(ctx: {
         middlewares,
         chronoDefault: chronoCardDefault,
         time,
+        input,
       })
 
       return card as Card

--- a/packages/srs-kit/src/scheduler/scheduler.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.spec.ts
@@ -235,6 +235,7 @@ describe('defineScheduler', () => {
     expectTypeOf<SchedulerConfigOf<typeof scheduler>>().toEqualTypeOf<{
       readonly weights: readonly number[]
       readonly chrono: Record<string, never>
+      readonly clearStatsOnForget: boolean
     }>()
   })
 
@@ -245,6 +246,7 @@ describe('defineScheduler', () => {
       readonly weights: readonly number[]
       readonly chrono: Record<string, never>
       readonly source: string
+      readonly clearStatsOnForget: boolean
     }>()
   })
 
@@ -253,6 +255,7 @@ describe('defineScheduler', () => {
       readonly weights: readonly number[]
       readonly chrono: Record<string, never>
       readonly source: string
+      readonly clearStatsOnForget: boolean
     }>()
   })
 
@@ -261,6 +264,7 @@ describe('defineScheduler', () => {
       readonly weights: readonly number[]
       readonly chrono: Record<string, never>
       readonly source: string
+      readonly clearStatsOnForget: boolean
     }>()
   })
 

--- a/packages/srs-kit/src/scheduler/scheduler.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.ts
@@ -60,6 +60,10 @@ export interface SchedulerCore<
   readonly newCard: (options?: {
     readonly now?: Env['chrono']
   }) => Env['card']['output']
+  readonly forget: (input: {
+    readonly card: Env['card']['input']
+    readonly now?: Env['chrono']
+  }) => Env['card']['output']
   readonly review: (input: {
     readonly card: Env['card']['input']
     readonly grade: Grade

--- a/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
@@ -143,10 +143,12 @@ describe('defineScheduler type display', () => {
     readonly config: SRSSchema<{
         input: {
             readonly weights: readonly number[];
+            readonly clearStatsOnForget?: boolean | undefined;
         };
         output: {
             readonly weights: readonly number[];
             readonly chrono: Record<string, never>;
+            readonly clearStatsOnForget: boolean;
         };
     }>;
     readonly card: SRSSchema<{
@@ -194,10 +196,12 @@ describe('defineScheduler type display', () => {
     readonly config: SRSSchema<{
         input: {
             readonly weights: readonly number[];
+            readonly clearStatsOnForget?: boolean | undefined;
         };
         output: {
             readonly weights: readonly number[];
             readonly chrono: Record<string, never>;
+            readonly clearStatsOnForget: boolean;
         };
     }>;
     readonly card: SRSSchema<{
@@ -250,6 +254,7 @@ describe('defineScheduler type display', () => {
     readonly config: {
         readonly weights: readonly number[];
         readonly chrono: Record<string, never>;
+        readonly clearStatsOnForget: boolean;
     };
     readonly card: {
         readonly input: {
@@ -300,6 +305,7 @@ describe('defineScheduler type display', () => {
     readonly config: {
         readonly weights: readonly number[];
         readonly chrono: Record<string, never>;
+        readonly clearStatsOnForget: boolean;
     };
     readonly card: {
         readonly input: {


### PR DESCRIPTION
- https://github.com/open-spaced-repetition/ts-fsrs/issues/373
## Summary

- add `SchedulerCore.forget()` by reusing the new-card default pipeline
- pass the existing card to middleware defaults during forget operations
- add `clearStatsOnForget` to control whether `reps` and `lapses` are reset
- add schema, type-display, behavior, and coverage tests

## Why

Consumers need a first-class way to return an existing card to the new state without introducing a dedicated handler or revlog. The stats middleware now resets counters by default while allowing applications to preserve them through configuration.

## Impact

- `forget({ card, now? })` is available on scheduler cores
- stats are cleared by default when forgetting a card
- set `clearStatsOnForget: false` to retain `reps` and `lapses`

## Validation

- `pnpm --filter @open-spaced-repetition/srs-kit check`
- `pnpm --filter @open-spaced-repetition/srs-kit test:coverage` (185 tests, 100% statements/branches/functions/lines)
- `pnpm --filter @open-spaced-repetition/srs-kit build`