### PR TITLE
typo(kit): simplify type definitions

### DIFF
--- a/packages/srs-kit/src/chrono/define-chrono.ts
+++ b/packages/srs-kit/src/chrono/define-chrono.ts
@@ -8,6 +8,7 @@ import {
   type SchemaOutput,
 } from '../schema/index.js'
 import type {
+  AnyChronoSchema,
   Chrono,
   ChronoCreate,
   ChronoDefaultValue,
@@ -82,12 +83,7 @@ function resolveChronoProjection(projection: unknown) {
   return projection
 }
 
-type ChronoDefinitionSchema = {
-  readonly time: AnySchema
-  readonly config?: AnySchema
-  readonly card?: AnyObjectSchema
-  readonly revlog?: AnyObjectSchema
-}
+type ChronoDefinitionSchema = AnyChronoSchema
 
 type ChronoDefinitionConfig<Schema extends ChronoDefinitionSchema> =
   Schema extends { readonly config: infer Config extends AnySchema }
@@ -138,21 +134,7 @@ type ChronoDefinition<Schema extends ChronoDefinitionSchema> = {
 
 export function defineChrono<const Schema extends ChronoDefinitionSchema>(
   definition: ChronoDefinition<Schema>
-): Chrono<{
-  readonly [Key in keyof ({
-    readonly time: Schema['time']
-  } & ChronoDefinitionConfig<Schema> & {
-      readonly fields: {
-        readonly [Field in keyof ChronoDefinitionFields<Schema>]: ChronoDefinitionFields<Schema>[Field]
-      }
-    })]: ({
-    readonly time: Schema['time']
-  } & ChronoDefinitionConfig<Schema> & {
-      readonly fields: {
-        readonly [Field in keyof ChronoDefinitionFields<Schema>]: ChronoDefinitionFields<Schema>[Field]
-      }
-    })[Key]
-}> {
+): Chrono<ChronoDefinitionEnv<Schema>> {
   return {
     schema: {
       time: definition.schema.time,

--- a/packages/srs-kit/src/middleware/infer.ts
+++ b/packages/srs-kit/src/middleware/infer.ts
@@ -103,9 +103,7 @@ export type MiddlewareConfigResolveOf<
   Mode extends 'input' | 'output' = 'output',
 > =
   TMiddleware extends Middleware<any, infer Env>
-    ? Mode extends 'input'
-      ? MiddlewareSchemaResolveOf<Env, 'config', AnySchema, EmptyPart, 'input'>
-      : MiddlewareConfigOf<Env>
+    ? MiddlewareSchemaResolveOf<Env, 'config', AnySchema, EmptyPart, Mode>
     : never
 
 export type MiddlewareStatusOf<TMiddleware> =

--- a/packages/srs-kit/src/scheduler/infer.ts
+++ b/packages/srs-kit/src/scheduler/infer.ts
@@ -97,10 +97,8 @@ type SchedulerCoreFieldsFor<
   ? SchedulerCoreFields<Status>
   : SchedulerRevlogCoreFields<Status>
 
-type MiddlewareScheduleStatus<MWs extends readonly AnyMiddleware[]> = Extract<
-  MiddlewareStatusOf<MWs[number]>,
-  string
->
+type MiddlewareScheduleStatus<MWs extends readonly AnyMiddleware[]> =
+  MiddlewareStatusOf<MWs[number]>
 
 type ExtendSchedulerObject<
   Env extends BlankSchedulerEnv,
@@ -111,8 +109,7 @@ type ExtendSchedulerObject<
     Assign<SchemaOutput<Env[Key]>, MiddlewareObjectFields<AddedMWs, Key>>,
     SchedulerCoreFieldsFor<
       Key,
-      | Extract<Env['scheduleStatus'], string>
-      | MiddlewareScheduleStatus<AddedMWs>
+      Env['scheduleStatus'] | MiddlewareScheduleStatus<AddedMWs>
     >
   >
 >
@@ -159,9 +156,7 @@ export type SchedulerEnvFor<
   MWs extends readonly AnyMiddleware[],
 > = {
   readonly chrono: ChronoTimeOf<C>
-  readonly scheduleStatus:
-    | ScheduleStatus
-    | Extract<MiddlewareStatusOf<MWs[number]>, string>
+  readonly scheduleStatus: ScheduleStatus | MiddlewareScheduleStatus<MWs>
   readonly config: SRSSchema<{
     input: Prettify<SchedulerConfigInput<M, C, MWs>>
     output: Prettify<SchedulerConfigOutput<M, C, MWs>>
@@ -182,7 +177,7 @@ export type ExtendSchedulerEnv<
 > = {
   readonly chrono: Env['chrono']
   readonly scheduleStatus:
-    | Extract<Env['scheduleStatus'], string>
+    | Env['scheduleStatus']
     | MiddlewareScheduleStatus<AddedMWs>
   readonly config: SRSSchema<{
     input: ExtendSchedulerConfigInput<Env, AddedMWs>

--- a/packages/srs-kit/src/schema/utils.ts
+++ b/packages/srs-kit/src/schema/utils.ts
@@ -122,17 +122,7 @@ export type UnionToIntersection<T> = (
   ? U
   : never
 
-type ExtractObjects<TUnion> = TUnion extends
-  | ReadonlyArray<any>
-  | number
-  | string
-  | bigint
-  | boolean
-  | symbol
-  | undefined
-  | null
-  ? never
-  : TUnion
+type ExtractObjects<TUnion> = Exclude<TUnion, ReadonlyArray<any> | Primitive>
 
 export type MergeAllObjects<
   TUnion,


### PR DESCRIPTION
- https://github.com/open-spaced-repetition/ts-fsrs/issues/373
## Summary

- reuse existing chrono schema and environment types to remove duplicate type definitions
- simplify middleware and scheduler inference by removing redundant conditional extraction
- reuse standard utility types when filtering object unions

## Impact

This is a type-only cleanup. It does not change runtime behavior, public type names, or scheduler semantics.

## Validation

- `pnpm --filter @open-spaced-repetition/srs-kit check`
- `pnpm --filter @open-spaced-repetition/srs-kit test` (25 files, 171 tests)
- `pnpm --filter @open-spaced-repetition/srs-kit build`
- `git diff --check`