### PR TITLE
feat(kit): add middleware card init input

### DIFF
--- a/.changeset/srs-kit-card-init-input.md
+++ b/.changeset/srs-kit-card-init-input.md
@@ -1,0 +1,5 @@
+---
+"@open-spaced-repetition/srs-kit": minor
+---
+
+feat(kit): allow middleware to define and validate new-card input fields.

--- a/packages/srs-kit/src/middleware/infer.ts
+++ b/packages/srs-kit/src/middleware/infer.ts
@@ -17,6 +17,7 @@ import type { Middleware } from './middleware.js'
 
 export type MiddlewareEnv = {
   readonly config?: AnySchema
+  readonly cardInitInput?: AnyObjectSchema
   readonly card?: AnyObjectSchema
   readonly revlog?: AnyObjectSchema
   readonly scheduleStatus?: string
@@ -32,16 +33,20 @@ type MiddlewareSchemaResolveOf<
   Env extends MiddlewareEnv,
   Key extends keyof MiddlewareEnv,
   Schema extends AnySchema,
-  Fallback,
   Mode extends 'input' | 'output' = 'output',
 > = [MiddlewareSchemaOf<Env, Key, Schema>] extends [never]
-  ? Fallback
+  ? EmptyPart
   : Mode extends 'input'
     ? SchemaInput<MiddlewareSchemaOf<Env, Key, Schema>>
     : SchemaOutput<MiddlewareSchemaOf<Env, Key, Schema>>
 
 export type MiddlewareConfigOf<Env extends MiddlewareEnv> =
-  MiddlewareSchemaResolveOf<Env, 'config', AnySchema, EmptyPart>
+  MiddlewareSchemaResolveOf<Env, 'config', AnySchema>
+
+export type MiddlewareCardInitInputOf<
+  Env extends MiddlewareEnv,
+  Mode extends 'input' | 'output' = 'output',
+> = MiddlewareSchemaResolveOf<Env, 'cardInitInput', AnyObjectSchema, Mode>
 
 export type MiddlewareRuntimeConfig = Readonly<Record<PropertyKey, unknown>>
 
@@ -71,7 +76,7 @@ export type MiddlewareContextObjectOf<
   Key extends 'card' | 'revlog',
 > = Prettify<
   Assign<
-    MiddlewareSchemaResolveOf<Env, Key, AnyObjectSchema, EmptyPart>,
+    MiddlewareSchemaResolveOf<Env, Key, AnyObjectSchema>,
     Key extends 'card' ? SchedulerCoreFields : SchedulerRevlogCoreFields
   >
 >
@@ -92,30 +97,12 @@ type MiddlewareObjectOf<
   TMiddleware extends Middleware<any, infer Env>
     ? Mode extends 'input'
       ? IntersectAssign<
-          MiddlewareSchemaResolveOf<
-            Env,
-            Key,
-            AnyObjectSchema,
-            EmptyPart,
-            'input'
-          >,
+          MiddlewareSchemaResolveOf<Env, Key, AnyObjectSchema, 'input'>,
           Partial<
-            MiddlewareSchemaResolveOf<
-              Env,
-              Key,
-              AnyObjectSchema,
-              EmptyPart,
-              'output'
-            >
+            MiddlewareSchemaResolveOf<Env, Key, AnyObjectSchema, 'output'>
           >
         >
-      : MiddlewareSchemaResolveOf<
-          Env,
-          Key,
-          AnyObjectSchema,
-          EmptyPart,
-          'output'
-        >
+      : MiddlewareSchemaResolveOf<Env, Key, AnyObjectSchema, 'output'>
     : never
 
 export type MiddlewareCardOf<
@@ -128,12 +115,20 @@ export type MiddlewareRevlogOf<
   Mode extends 'input' | 'output' = 'output',
 > = MiddlewareObjectOf<TMiddleware, 'revlog', Mode>
 
+export type MiddlewareCardInitInputResolveOf<
+  TMiddleware,
+  Mode extends 'input' | 'output' = 'output',
+> =
+  TMiddleware extends Middleware<any, infer Env>
+    ? MiddlewareCardInitInputOf<Env, Mode>
+    : never
+
 export type MiddlewareConfigResolveOf<
   TMiddleware,
   Mode extends 'input' | 'output' = 'output',
 > =
   TMiddleware extends Middleware<any, infer Env>
-    ? MiddlewareSchemaResolveOf<Env, 'config', AnySchema, EmptyPart, Mode>
+    ? MiddlewareSchemaResolveOf<Env, 'config', AnySchema, Mode>
     : never
 
 export type MiddlewareStatusOf<TMiddleware> =

--- a/packages/srs-kit/src/middleware/middleware.ts
+++ b/packages/srs-kit/src/middleware/middleware.ts
@@ -10,6 +10,7 @@ import type {
   Prettify,
 } from '@/schema/index.js'
 import type {
+  MiddlewareCardInitInputOf,
   MiddlewareContextConfig,
   MiddlewareContextObjectOf,
   MiddlewareEnv,
@@ -31,10 +32,21 @@ export type RollbackMiddlewareResult<
 
 export interface MiddlewareContextBase<Env extends MiddlewareEnv> {
   readonly config: MiddlewareContextConfig<Env>
-  readonly input?: {
-    readonly card: MiddlewareContextObjectOf<Env, 'card'>
-  }
 }
+
+export type MiddlewareDefaultValueContext<
+  Env extends MiddlewareEnv = MiddlewareEnv,
+> = MiddlewareContextBase<Env> &
+  (
+    | {
+        readonly operation: 'newCard'
+        readonly input: MiddlewareCardInitInputOf<Env>
+      }
+    | {
+        readonly operation: 'forget'
+        readonly input: MiddlewareContextObjectOf<Env, 'card'>
+      }
+  )
 
 export interface ReviewCandidateContext {
   readonly step: (grade: Grade) => Readonly<Record<string, unknown>>
@@ -96,6 +108,7 @@ export interface Middleware<
 
   readonly schema?: {
     readonly config?: Env['config']
+    readonly cardInitInput?: Env['cardInitInput']
     readonly card?: Env['card']
     readonly revlog?: Env['revlog']
   }
@@ -103,12 +116,12 @@ export interface Middleware<
   readonly defaultValue?: {
     readonly card?: FieldDefault<
       MiddlewareSchemaOf<Env, 'card', AnyObjectSchema>,
-      MiddlewareContextBase<Env>
+      MiddlewareDefaultValueContext<Env>
     >
 
     readonly revlog?: FieldDefault<
       MiddlewareSchemaOf<Env, 'revlog', AnyObjectSchema>,
-      MiddlewareContextBase<Env>
+      MiddlewareDefaultValueContext<Env>
     >
   }
 
@@ -122,7 +135,7 @@ export type AnyMiddleware = Middleware<any, any>
 
 type MiddlewareDefinitionSchema = Pick<
   MiddlewareEnv,
-  'config' | 'card' | 'revlog'
+  'config' | 'cardInitInput' | 'card' | 'revlog'
 >
 
 type MiddlewareStatusEnv<Status extends string> = [Status] extends [never]

--- a/packages/srs-kit/src/middleware/middleware.type-display.spec.ts
+++ b/packages/srs-kit/src/middleware/middleware.type-display.spec.ts
@@ -1,5 +1,6 @@
 /** biome-ignore-all lint/correctness/noUnusedVariables: type-display fixtures read by LanguageService */
 import { describe, expect, it } from 'vitest'
+import { defineSchema, isObject } from '@/schema/index.js'
 import {
   defineStringFieldOutputSchema,
   defineStringFieldSchema,
@@ -22,6 +23,35 @@ const displayRevlogSchema = defineStringFieldOutputSchema({
 })
 
 const displayMiddlewareName = Symbol('displayMiddleware')
+
+const displayCardInitInputSchema = defineSchema<
+  { readonly rawSource: string },
+  { readonly source: string }
+>((value) =>
+  isObject(value) && typeof value.rawSource === 'string'
+    ? { value: { source: value.rawSource } }
+    : { issues: [{ message: 'Expected rawSource' }] }
+)
+
+const cardInitInputMiddleware = defineMiddleware({
+  name: 'cardInitInputMiddleware',
+  schema: {
+    cardInitInput: displayCardInitInputSchema,
+    card: displayCardSchema,
+  },
+  defaultValue: {
+    card(ctx) {
+      if (ctx.operation === 'newCard') {
+        const cardInitInputHoverTarget = ctx.input
+        return { source: cardInitInputHoverTarget.source }
+      }
+      const forgetCardHoverTarget = ctx.input
+      return { source: forgetCardHoverTarget.source }
+    },
+  },
+})
+
+const cardInitInputMiddlewareHoverTarget = cardInitInputMiddleware
 
 const displayMiddleware = defineMiddleware({
   name: displayMiddlewareName,
@@ -66,6 +96,30 @@ describe('middleware type display', () => {
   const service = getTypeDisplayService()
 
   const expectedDefineMiddleware = {
+    cardInitInputMiddlewareHoverTarget: `const cardInitInputMiddlewareHoverTarget: Middleware<"cardInitInputMiddleware", {
+    readonly cardInitInput: SRSSchema<{
+        input: {
+            readonly rawSource: string;
+        };
+        output: {
+            readonly source: string;
+        };
+    }>;
+    readonly card: SRSSchema<{
+        input: {};
+        output: {
+            readonly source: string;
+        };
+    }>;
+}>`,
+    cardInitInputHoverTarget: `const cardInitInputHoverTarget: {
+    readonly source: string;
+}`,
+    forgetCardHoverTarget: `const forgetCardHoverTarget: {
+    readonly source: string;
+    readonly state: State;
+    readonly scheduleStatus: string;
+}`,
     middlewareHoverTarget: `const middlewareHoverTarget: Middleware<typeof displayMiddlewareName, {
     readonly scheduleStatus: "paused";
     readonly config: SRSSchema<{

--- a/packages/srs-kit/src/middleware/stats/middleware.spec.ts
+++ b/packages/srs-kit/src/middleware/stats/middleware.spec.ts
@@ -74,7 +74,9 @@ describe('schedulerStatsMiddleware', () => {
   it('provides default stats fields', () => {
     expect(
       schedulerStatsMiddleware.defaultValue?.card?.({
+        operation: 'newCard',
         config: { chrono: 0, clearStatsOnForget: true },
+        input: {},
       })
     ).toEqual({
       reps: 0,
@@ -85,14 +87,13 @@ describe('schedulerStatsMiddleware', () => {
   it('clears old stats by default when card defaults receive input', () => {
     expect(
       schedulerStatsMiddleware.defaultValue?.card?.({
+        operation: 'forget',
         config: { chrono: 0, clearStatsOnForget: true },
         input: {
-          card: {
-            reps: 3,
-            lapses: 1,
-            state: State.Review,
-            scheduleStatus: 'review',
-          },
+          reps: 3,
+          lapses: 1,
+          state: State.Review,
+          scheduleStatus: 'review',
         },
       })
     ).toEqual({
@@ -104,14 +105,13 @@ describe('schedulerStatsMiddleware', () => {
   it('can preserve old stats when card defaults receive input', () => {
     expect(
       schedulerStatsMiddleware.defaultValue?.card?.({
+        operation: 'forget',
         config: { chrono: 0, clearStatsOnForget: false },
         input: {
-          card: {
-            reps: 3,
-            lapses: 1,
-            state: State.Review,
-            scheduleStatus: 'review',
-          },
+          reps: 3,
+          lapses: 1,
+          state: State.Review,
+          scheduleStatus: 'review',
         },
       })
     ).toEqual({

--- a/packages/srs-kit/src/middleware/stats/middleware.ts
+++ b/packages/srs-kit/src/middleware/stats/middleware.ts
@@ -11,8 +11,11 @@ export const schedulerStatsMiddleware = defineMiddleware({
   },
   defaultValue: {
     card(ctx) {
-      const card = ctx.input?.card
-      if (card && ctx.config.clearStatsOnForget === false) {
+      if (
+        ctx.operation === 'forget' &&
+        ctx.config.clearStatsOnForget === false
+      ) {
+        const card = ctx.input
         return {
           reps: card.reps,
           lapses: card.lapses,

--- a/packages/srs-kit/src/scheduler/base.spec.ts
+++ b/packages/srs-kit/src/scheduler/base.spec.ts
@@ -205,12 +205,79 @@ describe('SchedulerCore.newCard', () => {
     expect(() => core.newCard({ now: 'bad' as never })).toThrow(
       'Expected finite number'
     )
+    expect(() => core.newCard(null as never)).toThrow(
+      'Expected card init input object'
+    )
+  })
+
+  it('parses explicit and fallback now exactly once', () => {
+    let timeParses = 0
+    const timeSchema = defineSchema<number, number>((value) => {
+      timeParses += 1
+      return typeof value === 'number'
+        ? { value: value + 1 }
+        : { issues: [{ message: 'Expected test time' }] }
+    })
+    const cardSchema = defineSchema<
+      { readonly dueAt?: number },
+      { readonly dueAt: number }
+    >((value) =>
+      isObject(value) && typeof value.dueAt === 'number'
+        ? { value: { dueAt: value.dueAt } }
+        : { issues: [{ message: 'Expected test dueAt' }] }
+    )
+    const transformingChrono = defineChrono({
+      schema: { time: timeSchema, card: cardSchema },
+      projection(value) {
+        return {
+          value: { previous: value.time, current: value.time },
+        }
+      },
+      defaultValue: {
+        card({ time }) {
+          return { dueAt: time }
+        },
+      },
+      create() {
+        return {
+          now: () => 10,
+          difference: (from, to) => to - from,
+          add: (from, days) => from + days,
+        }
+      },
+    })
+    const transformingCore = defineScheduler({
+      model: SM2Model,
+      chrono: transformingChrono,
+    }).create({ config })
+
+    expect(transformingCore.newCard({ now: 1 }).dueAt).toBe(2)
+    expect(timeParses).toBe(1)
+    expect(transformingCore.newCard().dueAt).toBe(10)
+    expect(timeParses).toBe(1)
   })
 
   it('applies middleware card defaults', () => {
     const card = middlewareCore.newCard()
 
     expect(card.source).toBe('test-source')
+  })
+
+  it('allows middleware card fields to be injected', () => {
+    const card = middlewareCore.newCard({
+      now: 0,
+      source: 'injected-source',
+    })
+
+    expect(card.source).toBe('injected-source')
+  })
+
+  it('validates injected middleware card fields', () => {
+    expect(() =>
+      middlewareCore.newCard({
+        source: 1 as never,
+      })
+    ).toThrow('Expected source card init input')
   })
 
   it('applies middleware added through use()', () => {
@@ -991,12 +1058,12 @@ describe('SchedulerCore.forget', () => {
       },
       defaultValue: {
         card(ctx) {
-          seen.push(
-            Object.hasOwn(ctx, 'input')
-              ? (ctx.input?.card.scheduleStatus ?? 'undefined')
-              : 'none'
-          )
-          return { source: ctx.input?.card.source ?? 'fresh' }
+          if (ctx.operation === 'newCard') {
+            seen.push('none')
+            return { source: 'fresh' }
+          }
+          seen.push(ctx.input.scheduleStatus)
+          return { source: ctx.input.source }
         },
       },
     })

--- a/packages/srs-kit/src/scheduler/base.ts
+++ b/packages/srs-kit/src/scheduler/base.ts
@@ -29,6 +29,8 @@ import type {
   ScheduleResult,
   SchedulerCore,
   SchedulerCoreEnv,
+  SchedulerNewCardFn,
+  SchedulerNewCardOptions,
   SchedulerSchema,
 } from './scheduler.js'
 
@@ -187,14 +189,22 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
     ) as readonly (RollbackRuntimeHandler<Env> | undefined)[]
   }
 
-  newCard = (options?: {
-    readonly now?: SchedulerCoreEnv<Env>['chrono']
-  }): SchedulerCoreEnv<Env>['card']['output'] => {
-    const now = this.parseNow(options?.now ?? this.chronoCore.now())
-    return this.defaultValue.newCard<SchedulerCoreEnv<Env>['card']['output']>({
-      config: this.config,
-      time: now,
-    })
+  newCard: SchedulerNewCardFn<SchedulerCoreEnv<Env>> = (
+    options?: SchedulerNewCardOptions<SchedulerCoreEnv<Env>>
+  ): SchedulerCoreEnv<Env>['card']['output'] => {
+    const { now, input } = parse(
+      this.schema.cardInitInput,
+      options === undefined ? {} : options
+    )
+
+    return this.defaultValue.newCard<SchedulerCoreEnv<Env>['card']['output']>(
+      {
+        operation: 'newCard',
+        config: this.config,
+        input,
+      },
+      this.parseNow(now)
+    )
   }
 
   forget = (input: {
@@ -205,13 +215,16 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
       this.schema.card,
       input.card
     ) as SchedulerCoreEnv<Env>['card']['output']
-    const now = this.parseNow(input.now ?? this.chronoCore.now())
+    const now = this.parseNow(input.now)
 
-    return this.defaultValue.newCard<SchedulerCoreEnv<Env>['card']['output']>({
-      config: this.config,
-      time: now,
-      input: { card: Object.freeze(card) },
-    })
+    return this.defaultValue.newCard<SchedulerCoreEnv<Env>['card']['output']>(
+      {
+        operation: 'forget',
+        config: this.config,
+        input: card,
+      },
+      now
+    )
   }
 
   review = (input: {
@@ -224,7 +237,7 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
   > => {
     const { card: inputCard, grade: inputGrade } = input
     const grade = parse(gradeSchema, inputGrade)
-    const now = this.parseNow(input.now ?? this.chronoCore.now())
+    const now = this.parseNow(input.now)
     const prepared = this.prepareReview(inputCard, now)
     const ctx: ReviewMiddlewareOperationContext<Env> = {
       config: this.config,
@@ -259,7 +272,7 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
     SchedulerCoreEnv<Env>['revlog']['output']
   > => {
     const inputCard = input.card
-    const now = this.parseNow(input.now ?? this.chronoCore.now())
+    const now = this.parseNow(input.now)
     const prepared = this.prepareReview(inputCard, now)
 
     return createLazyIterable(grades, (grade) => {
@@ -496,7 +509,9 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
     }
   }
 
-  private parseNow(now: unknown): SchedulerCoreEnv<Env>['chrono'] {
-    return parse(this.chrono.schema.time, now)
+  private parseNow(now?: unknown): SchedulerCoreEnv<Env>['chrono'] {
+    return now === undefined
+      ? this.chronoCore.now()
+      : parse(this.chrono.schema.time, now)
   }
 }

--- a/packages/srs-kit/src/scheduler/compose-schema.ts
+++ b/packages/srs-kit/src/scheduler/compose-schema.ts
@@ -135,14 +135,14 @@ export function composeSchema(ctx: {
       return { issues: [{ message: 'Expected card init input object' }] }
     }
 
-    const { now } = value
+    const { now, ...middlewareValue } = value
 
     let firstMiddlewareFields: Record<string, unknown> | undefined
     let combinedFields: Record<string, unknown> | undefined
     for (const middleware of middlewares) {
       const schema = middleware.schema?.cardInitInput
       if (!schema) continue
-      const middlewareResult = schema['~standard'].validate(value)
+      const middlewareResult = schema['~standard'].validate(middlewareValue)
       if (middlewareResult.issues) return middlewareResult
       const fields = middlewareResult.value as Record<string, unknown>
       if (firstMiddlewareFields === undefined) {

--- a/packages/srs-kit/src/scheduler/compose-schema.ts
+++ b/packages/srs-kit/src/scheduler/compose-schema.ts
@@ -124,6 +124,40 @@ export function composeSchema(ctx: {
     }
   })
 
+  const cardInitInput = defineSchema<
+    unknown,
+    {
+      readonly input: Record<string, unknown>
+      readonly now?: unknown
+    }
+  >((value) => {
+    if (!isObject(value)) {
+      return { issues: [{ message: 'Expected card init input object' }] }
+    }
+
+    const { now } = value
+
+    let firstMiddlewareFields: Record<string, unknown> | undefined
+    let combinedFields: Record<string, unknown> | undefined
+    for (const middleware of middlewares) {
+      const schema = middleware.schema?.cardInitInput
+      if (!schema) continue
+      const middlewareResult = schema['~standard'].validate(value)
+      if (middlewareResult.issues) return middlewareResult
+      const fields = middlewareResult.value as Record<string, unknown>
+      if (firstMiddlewareFields === undefined) {
+        firstMiddlewareFields = fields
+        continue
+      }
+      combinedFields ??= Object.assign({}, firstMiddlewareFields)
+      assignObjectFields(combinedFields, fields)
+    }
+
+    return {
+      value: { input: combinedFields ?? firstMiddlewareFields ?? {}, now },
+    }
+  })
+
   const card = defineSchema<unknown, Record<string, unknown>>((value) => {
     if (!isObject(value)) {
       return { issues: [{ message: 'Expected card object' }] }
@@ -203,6 +237,7 @@ export function composeSchema(ctx: {
 
   return {
     config,
+    cardInitInput,
     card,
     revlog,
     scheduleStatus: scheduleStatusSchema,

--- a/packages/srs-kit/src/scheduler/default-value.ts
+++ b/packages/srs-kit/src/scheduler/default-value.ts
@@ -10,18 +10,22 @@ import { isFunction } from '@/schema/index.js'
 
 type DefaultValueConfig = Record<PropertyKey, unknown>
 
-type DefaultValueContext = {
-  readonly config: DefaultValueConfig
-  readonly input?: {
-    readonly card: Readonly<Record<string, unknown>>
-  }
-}
+type DefaultValueContext =
+  | {
+      readonly operation: 'newCard'
+      readonly config: DefaultValueConfig
+      readonly input: Readonly<object>
+    }
+  | {
+      readonly operation: 'forget'
+      readonly config: DefaultValueConfig
+      readonly input: Readonly<Record<string, unknown>>
+    }
 
 export type SchedulerDefaultValueFactory = {
   readonly newCard: <Card extends object = Record<string, unknown>>(
-    ctx: DefaultValueContext & {
-      readonly time: unknown
-    }
+    ctx: DefaultValueContext,
+    time: unknown
   ) => Card
 }
 
@@ -46,28 +50,24 @@ function resolveChronoDefault(
 
 function applyNewCardDefaults(ctx: {
   readonly target: Record<string, unknown>
-  readonly config: DefaultValueConfig
+  readonly defaultValue: DefaultValueContext
   readonly middlewares: readonly AnyMiddleware[]
   readonly chronoDefault?: ChronoDefaultRuntimeFn
   readonly time: ChronoDefaultCtx<unknown, unknown>['time']
-  readonly input?: DefaultValueContext['input']
 }) {
-  const { target, config, middlewares, chronoDefault, time } = ctx
-  const defaultCtx: DefaultValueContext = ctx.input
-    ? { config: ctx.config, input: ctx.input }
-    : { config: ctx.config }
+  const { target, defaultValue, middlewares, chronoDefault, time } = ctx
 
   if (chronoDefault) {
     Object.assign(
       target,
       chronoDefault({
-        config: config.chrono as Readonly<unknown>,
+        config: defaultValue.config.chrono as Readonly<unknown>,
         time,
       })
     )
   }
 
-  applyMiddlewareCardDefaults(target, middlewares, defaultCtx)
+  applyMiddlewareCardDefaults(target, middlewares, defaultValue)
 }
 
 export function useComposeDefaultValue(ctx: {
@@ -79,11 +79,11 @@ export function useComposeDefaultValue(ctx: {
   const chronoCardDefault = resolveChronoDefault(chrono.defaultValue?.card)
 
   return {
-    newCard<Card extends object = Record<string, unknown>>({
-      config,
-      time,
-      input,
-    }: DefaultValueContext & { readonly time: unknown }) {
+    newCard<Card extends object = Record<string, unknown>>(
+      defaultValue: DefaultValueContext,
+      time: unknown
+    ) {
+      const { config } = defaultValue
       const card: Record<string, unknown> = model.defaultValue.memoryState({
         config,
       })
@@ -91,11 +91,10 @@ export function useComposeDefaultValue(ctx: {
       card.scheduleStatus = 'new'
       applyNewCardDefaults({
         target: card,
-        config,
+        defaultValue,
         middlewares,
         chronoDefault: chronoCardDefault,
         time,
-        input,
       })
 
       return card as Card

--- a/packages/srs-kit/src/scheduler/infer.ts
+++ b/packages/srs-kit/src/scheduler/infer.ts
@@ -8,6 +8,7 @@ import type {
 import type { MiddlewareConfigPart } from '@/middleware/config.js'
 import type {
   AnyMiddleware,
+  MiddlewareCardInitInputResolveOf,
   MiddlewareCardOf,
   MiddlewareRevlogOf,
   MiddlewareStatusOf,
@@ -26,6 +27,7 @@ import type {
   Mutable,
   Prettify,
   SchemaInput,
+  SchemaInputOf,
   SchemaOutput,
   SchemaOutputOf,
   SRSSchema,
@@ -37,11 +39,8 @@ import type {
 import type {
   AnyScheduler,
   BlankSchedulerEnv,
-  ComposableScheduler,
+  SchedulerCardInitSchema,
 } from './scheduler.js'
-
-type SchedulerEnvOf<T extends AnyScheduler> =
-  T extends ComposableScheduler<infer _Name, infer Env> ? Env : never
 
 export type SchedulerConfigOf<T extends AnyScheduler> = SchemaOutputOf<
   T,
@@ -77,6 +76,51 @@ type ExtendSchedulerConfigOutput<
 > = Prettify<
   Assign<SchemaOutput<Env['config']>, MiddlewareConfigPart<AddedMWs, 'output'>>
 >
+
+type MiddlewareCardInitInputFields<
+  MWs extends readonly AnyMiddleware[],
+  Mode extends 'input' | 'output',
+> = MergePart<
+  MergeAllObjects<MiddlewareCardInitInputResolveOf<MWs[number], Mode>>
+>
+
+type ExtendSchedulerCardInitInput<
+  Env extends BlankSchedulerEnv,
+  AddedMWs extends readonly AnyMiddleware[],
+> = Prettify<
+  Assign<
+    SchemaInput<Env['cardInitInput']>,
+    MiddlewareCardInitInputFields<AddedMWs, 'input'>
+  >
+>
+
+type SchedulerCardInitOutput<Env extends BlankSchedulerEnv> = SchemaOutput<
+  Env['cardInitInput']
+>['input']
+
+type ExtendSchedulerCardInitOutput<
+  Env extends BlankSchedulerEnv,
+  AddedMWs extends readonly AnyMiddleware[],
+> = Prettify<
+  Assign<
+    SchedulerCardInitOutput<Env>,
+    MiddlewareCardInitInputFields<AddedMWs, 'output'>
+  >
+>
+
+type ExtendSchedulerCardInitSchema<
+  Env extends BlankSchedulerEnv,
+  AddedMWs extends readonly AnyMiddleware[],
+> = [
+  | keyof MiddlewareCardInitInputFields<AddedMWs, 'input'>
+  | keyof MiddlewareCardInitInputFields<AddedMWs, 'output'>,
+] extends [never]
+  ? Env['cardInitInput']
+  : SchedulerCardInitSchema<
+      Env['chrono'],
+      ExtendSchedulerCardInitInput<Env, AddedMWs>,
+      ExtendSchedulerCardInitOutput<Env, AddedMWs>
+    >
 
 type SchedulerObjectKey = 'card' | 'revlog'
 
@@ -179,6 +223,7 @@ export type SchedulerEnvFor<
     input: Prettify<SchedulerConfigInput<M, C, MWs>>
     output: Prettify<SchedulerConfigOutput<M, C, MWs>>
   }>
+  readonly cardInitInput: SchedulerCardInitSchema<ChronoTimeOf<C>>
   readonly card: SRSSchema<{
     input: Prettify<Readonly<SchedulerObjectFields<M, C, MWs, 'card', 'input'>>>
     output: Prettify<SchedulerCardFields<M, C, MWs>>
@@ -203,6 +248,7 @@ export type ExtendSchedulerEnv<
     input: ExtendSchedulerConfigInput<Env, AddedMWs>
     output: ExtendSchedulerConfigOutput<Env, AddedMWs>
   }>
+  readonly cardInitInput: ExtendSchedulerCardInitSchema<Env, AddedMWs>
   readonly card: SRSSchema<{
     input: ExtendSchedulerObject<Env, AddedMWs, 'card', 'input'>
     output: ExtendSchedulerObject<Env, AddedMWs, 'card', 'output'>
@@ -213,12 +259,16 @@ export type ExtendSchedulerEnv<
   }>
 }
 
-export type SchedulerCardOf<T extends AnyScheduler> = SchemaOutput<
-  SchedulerEnvOf<T>['card']
+export type SchedulerCardOf<T extends AnyScheduler> = SchemaOutputOf<T, 'card'>
+
+export type SchedulerCardInitInputOf<T extends AnyScheduler> = SchemaInputOf<
+  T,
+  'cardInitInput'
 >
 
-export type SchedulerCardInputOf<T extends AnyScheduler> = SchemaInput<
-  SchedulerEnvOf<T>['card']
+export type SchedulerCardInputOf<T extends AnyScheduler> = SchemaInputOf<
+  T,
+  'card'
 >
 
 export type SchedulerRevlogOf<T extends AnyScheduler> = SchemaOutputOf<
@@ -226,12 +276,17 @@ export type SchedulerRevlogOf<T extends AnyScheduler> = SchemaOutputOf<
   'revlog'
 >
 
-export type SchedulerRevlogInputOf<T extends AnyScheduler> = SchemaInput<
-  SchedulerEnvOf<T>['revlog']
+export type SchedulerRevlogInputOf<T extends AnyScheduler> = SchemaInputOf<
+  T,
+  'revlog'
 >
 
 export type SchedulerTimeOf<T extends AnyScheduler> =
-  SchedulerEnvOf<T>['chrono']
+  SchedulerCardInitInputOf<T> extends { readonly now?: infer Time }
+    ? Exclude<Time, undefined>
+    : never
 
-export type SchedulerStatusOf<T extends AnyScheduler> =
-  SchedulerEnvOf<T>['scheduleStatus']
+export type SchedulerStatusOf<T extends AnyScheduler> = SchemaOutputOf<
+  T,
+  'scheduleStatus'
+>

--- a/packages/srs-kit/src/scheduler/scheduler.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.spec.ts
@@ -1,12 +1,14 @@
 import { describe, expect, expectTypeOf, it } from 'vitest'
 import { defineChrono } from '@/chrono/define-chrono.js'
 import { dateChrono } from '@/chrono/presets/date/chrono.js'
+import { defineMiddleware } from '@/middleware/index.js'
 import { schedulerStatsMiddleware } from '@/middleware/stats/index.js'
 import { SM2Model } from '@/model/sm2.test.js'
 import { type Grade, Rating, State } from '@/primitives/index.js'
-import { defineSchema, numberSchema } from '@/schema/index.js'
+import { defineSchema, isObject, numberSchema } from '@/schema/index.js'
 import { defineScheduler } from './define-scheduler.js'
 import type {
+  SchedulerCardInitInputOf,
   SchedulerCardInputOf,
   SchedulerCardOf,
   SchedulerConfigOf,
@@ -18,6 +20,8 @@ import type {
 import {
   config,
   createSM2NumericScheduler,
+  sourceCardSchema,
+  sourceConfigSchema,
   sourceMiddleware,
   statusMiddleware,
 } from './scheduler.test.js'
@@ -50,15 +54,127 @@ describe('defineScheduler', () => {
     expectTypeOf(scheduler.name).toEqualTypeOf<'sm2'>()
   })
 
+  it('types new-card input declared by middleware', () => {
+    usedCore.newCard({ source: 'injected-source' })
+    const invalidNewCard = () => {
+      usedCore.newCard({
+        // @ts-expect-error unknown fields are not declared new-card input
+        unknown: true,
+      })
+      core.newCard({
+        // @ts-expect-error schedulers without declared input do not accept it
+        input: {},
+      })
+    }
+
+    expectTypeOf(invalidNewCard).toBeFunction()
+  })
+
+  it('requires new-card input when middleware declares required fields', () => {
+    const requiredInputMiddleware = defineMiddleware({
+      name: 'requiredCardInitInput',
+      schema: {
+        cardInitInput: sourceConfigSchema,
+        card: sourceCardSchema,
+      },
+      defaultValue: {
+        card(ctx) {
+          return { source: ctx.input.source }
+        },
+      },
+    })
+    const requiredCore = createSM2NumericScheduler()
+      .use(requiredInputMiddleware)
+      .create({ config })
+
+    expect(requiredCore.newCard({ source: 'required' }).source).toBe('required')
+    const missingRequiredInput = () => {
+      // @ts-expect-error required middleware input makes options required
+      requiredCore.newCard()
+      // @ts-expect-error required middleware field cannot be omitted from options
+      requiredCore.newCard({ now: 0 })
+    }
+
+    expectTypeOf(missingRequiredInput).toBeFunction()
+  })
+
+  it('merges new-card input declared by multiple middlewares', () => {
+    const noteSchema = defineSchema<{ readonly note: string }>((value) =>
+      isObject(value) && typeof value.note === 'string'
+        ? { value: { note: value.note } }
+        : { issues: [{ message: 'Expected note' }] }
+    )
+    const noteMiddleware = defineMiddleware({
+      name: 'noteCardInitInput',
+      schema: { cardInitInput: noteSchema, card: noteSchema },
+      defaultValue: {
+        card(ctx) {
+          return { note: ctx.input.note }
+        },
+      },
+    })
+    const labelSchema = defineSchema<{ readonly label: string }>((value) =>
+      isObject(value) && typeof value.label === 'string'
+        ? { value: { label: value.label } }
+        : { issues: [{ message: 'Expected label' }] }
+    )
+    const labelMiddleware = defineMiddleware({
+      name: 'labelCardInitInput',
+      schema: { cardInitInput: labelSchema, card: labelSchema },
+      defaultValue: {
+        card(ctx) {
+          return { label: ctx.input.label }
+        },
+      },
+    })
+    const mergedScheduler = createSM2NumericScheduler().use(
+      sourceMiddleware,
+      noteMiddleware,
+      labelMiddleware
+    )
+    const mergedCore = mergedScheduler.create({
+      config: { ...config, source: 'config-source' },
+    })
+    const input = {
+      source: 'input-source',
+      note: 'input-note',
+      label: 'input-label',
+    }
+
+    expect(mergedScheduler.schema.cardInitInput.parse(input)).toStrictEqual({
+      input,
+      now: undefined,
+    })
+    expect(
+      mergedScheduler.schema.cardInitInput.parse({ ...input, now: 4 })
+    ).toEqual({ input, now: 4 })
+    expect(mergedCore.newCard(input)).toMatchObject({
+      source: 'input-source',
+      note: 'input-note',
+      label: 'input-label',
+    })
+  })
+
   it('exposes composed schemas', () => {
     expect(scheduler.schema.config).toBeDefined()
+    expect(scheduler.schema.cardInitInput).toBeDefined()
     expect(scheduler.schema.card).toBeDefined()
     expect(scheduler.schema.revlog).toBeDefined()
+    expect(() => scheduler.schema.cardInitInput.parse(null)).toThrow(
+      'Expected card init input object'
+    )
+    expect(
+      scheduler.schema.cardInitInput.parse({ now: 'raw-now' as never })
+    ).toStrictEqual({ input: {}, now: 'raw-now' })
   })
 
   it('uses middleware references from use() when schemas parse', () => {
     const dynamicScheduler = createSM2NumericScheduler()
     const schema = dynamicScheduler.schema
+    expect(schema.cardInitInput.parse({})).toStrictEqual({
+      input: {},
+      now: undefined,
+    })
 
     const dynamicSchedulerWithMiddleware = dynamicScheduler.use(
       sourceMiddleware,
@@ -84,6 +200,12 @@ describe('defineScheduler', () => {
         source: 'schema-source',
       }).source
     ).toBe('schema-source')
+    expect(
+      usedSchema.cardInitInput.parse({ source: 'schema-source' }).input.source
+    ).toBe('schema-source')
+    expect(() => usedSchema.cardInitInput.parse({ source: 1 })).toThrow(
+      'Expected source card init input'
+    )
     expect(usedSchema.card.parse(usedCore.newCard()).source).toBe('used-source')
     expect(
       usedSchema.revlog.parse({
@@ -267,6 +389,21 @@ describe('defineScheduler', () => {
       readonly chrono: Record<string, never>
       readonly source: string
       readonly clearStatsOnForget: boolean
+    }>()
+  })
+
+  it('infers the complete flat new-card input', () => {
+    expectTypeOf<
+      SchedulerCardInitInputOf<typeof usedScheduler>
+    >().toEqualTypeOf<{
+      readonly source?: string
+      readonly now?: number
+    }>()
+    expectTypeOf<
+      SchedulerCardInitInputOf<typeof chainedScheduler>
+    >().toEqualTypeOf<{
+      readonly source?: string
+      readonly now?: number
     }>()
   })
 

--- a/packages/srs-kit/src/scheduler/scheduler.test.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.test.ts
@@ -1,6 +1,7 @@
 import { numericChrono } from '@/chrono/presets/numeric/chrono.js'
 import { defineMiddleware } from '@/middleware/index.js'
 import { SM2_DEFAULT_WEIGHTS, SM2Model } from '@/model/sm2.test.js'
+import { defineSchema, isObject } from '@/schema/index.js'
 import {
   defineStringFieldOutputSchema,
   defineStringFieldSchema,
@@ -36,6 +37,18 @@ export const sourceCardSchema = defineStringFieldOutputSchema({
   message: 'Expected source card field',
 })
 
+export const sourceCardInitInputSchema = defineSchema<{
+  readonly source?: string
+}>((value) => {
+  if (!isObject(value)) {
+    return { issues: [{ message: 'Expected source card init input' }] }
+  }
+  if (value.source === undefined) return { value: {} }
+  return typeof value.source === 'string'
+    ? { value: { source: value.source } }
+    : { issues: [{ message: 'Expected source card init input' }] }
+})
+
 export const auditRevlogSchema = defineStringFieldOutputSchema({
   field: 'audit',
   message: 'Expected audit revlog field',
@@ -48,12 +61,18 @@ export const sourceMiddleware = defineMiddleware({
   name: sourceMiddlewareName,
   schema: {
     config: sourceConfigSchema,
+    cardInitInput: sourceCardInitInputSchema,
     card: sourceCardSchema,
     revlog: auditRevlogSchema,
   },
   defaultValue: {
     card(ctx) {
-      return { source: ctx.config.source }
+      return {
+        source:
+          ctx.operation === 'newCard'
+            ? (ctx.input.source ?? ctx.config.source)
+            : ctx.config.source,
+      }
     },
     revlog(ctx) {
       return { audit: ctx.config.source }

--- a/packages/srs-kit/src/scheduler/scheduler.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.ts
@@ -6,6 +6,7 @@ import type {
   AnyObjectSchema,
   AnySchema,
   Assign,
+  EmptyPart,
   Mutable,
   Prettify,
   SchemaInput,
@@ -42,6 +43,7 @@ export interface PreviewResult<Card, Revlog> {
 
 export type BlankSchedulerCoreEnv = {
   readonly config: object
+  readonly cardInitInput?: object
   readonly card: {
     readonly input: object
     readonly output: object
@@ -54,13 +56,26 @@ export type BlankSchedulerCoreEnv = {
   readonly scheduleStatus: string
 }
 
+type SchedulerCoreCardInitInput<Env extends BlankSchedulerCoreEnv> =
+  Env extends {
+    readonly cardInitInput: infer Input extends object
+  }
+    ? Input
+    : { readonly now?: Env['chrono'] }
+
+export type SchedulerNewCardOptions<Env extends BlankSchedulerCoreEnv> =
+  Prettify<SchedulerCoreCardInitInput<Env>>
+
+export type SchedulerNewCardFn<Env extends BlankSchedulerCoreEnv> =
+  EmptyPart extends SchedulerNewCardOptions<Env>
+    ? (options?: SchedulerNewCardOptions<Env>) => Env['card']['output']
+    : (options: SchedulerNewCardOptions<Env>) => Env['card']['output']
+
 export interface SchedulerCore<
   Env extends BlankSchedulerCoreEnv = BlankSchedulerCoreEnv,
 > {
   readonly config: Readonly<Env['config']>
-  readonly newCard: (options?: {
-    readonly now?: Env['chrono']
-  }) => Env['card']['output']
+  readonly newCard: SchedulerNewCardFn<Env>
   readonly forget: (input: {
     readonly card: Env['card']['input']
     readonly now?: Env['chrono']
@@ -86,9 +101,28 @@ export type AnySchedulerCore = SchedulerCore<any>
 // Scheduler
 // ==========
 
+export type SchedulerCardInitSchema<
+  Time,
+  Input extends object = EmptyPart,
+  Output extends object = EmptyPart,
+> = SRSSchema<{
+  input: Prettify<Assign<Input, { readonly now?: Time }>>
+  output: {
+    readonly input: Output
+    readonly now?: unknown
+  }
+}>
+
 export type BlankSchedulerEnv = {
   readonly chrono: unknown
   readonly config: AnySchema
+  readonly cardInitInput: SRSSchema<{
+    input: object
+    output: {
+      readonly input: object
+      readonly now?: unknown
+    }
+  }>
   readonly card: AnyObjectSchema
   readonly revlog: AnyObjectSchema
   readonly scheduleStatus: string
@@ -121,6 +155,7 @@ export interface SchedulerSchema<
   Env extends BlankSchedulerEnv = BlankSchedulerEnv,
 > {
   readonly config: Env['config']
+  readonly cardInitInput: Env['cardInitInput']
   readonly card: Env['card']
   readonly revlog: Env['revlog']
   readonly scheduleStatus: SRSSchema<{
@@ -138,6 +173,7 @@ export type SchedulerUseFn<
 
 export type SchedulerCoreEnv<Env extends BlankSchedulerEnv> = {
   readonly config: SchemaOutput<Env['config']>
+  readonly cardInitInput: SchemaInput<Env['cardInitInput']>
   readonly card: {
     readonly input: SchedulerCoreFieldSchemaPart<Env, 'card', 'input'>
     readonly output: SchedulerCoreFieldSchemaPart<Env, 'card', 'output'>

--- a/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
@@ -102,6 +102,7 @@ describe('defineScheduler type display', () => {
             readonly chrono: Record<string, never>;
         };
     }>;
+    readonly cardInitInput: SchedulerCardInitSchema<number>;
     readonly card: SRSSchema<{
         input: {
             readonly interval: number;
@@ -151,6 +152,7 @@ describe('defineScheduler type display', () => {
             readonly clearStatsOnForget: boolean;
         };
     }>;
+    readonly cardInitInput: SchedulerCardInitSchema<number>;
     readonly card: SRSSchema<{
         input: {
             readonly interval: number;
@@ -204,6 +206,7 @@ describe('defineScheduler type display', () => {
             readonly clearStatsOnForget: boolean;
         };
     }>;
+    readonly cardInitInput: SchedulerCardInitSchema<number>;
     readonly card: SRSSchema<{
         input: {
             readonly source?: string | undefined;
@@ -256,6 +259,9 @@ describe('defineScheduler type display', () => {
         readonly chrono: Record<string, never>;
         readonly clearStatsOnForget: boolean;
     };
+    readonly cardInitInput: {
+        readonly now?: number | undefined;
+    };
     readonly card: {
         readonly input: {
             readonly source?: string | undefined;
@@ -306,6 +312,9 @@ describe('defineScheduler type display', () => {
         readonly weights: readonly number[];
         readonly chrono: Record<string, never>;
         readonly clearStatsOnForget: boolean;
+    };
+    readonly cardInitInput: {
+        readonly now?: number | undefined;
     };
     readonly card: {
         readonly input: {
@@ -363,6 +372,7 @@ describe('defineScheduler type display', () => {
             readonly chrono: Record<string, never>;
         };
     }>;
+    readonly cardInitInput: SchedulerCardInitSchema<number>;
     readonly card: SRSSchema<{
         input: {
             readonly interval: number;
@@ -402,6 +412,9 @@ describe('defineScheduler type display', () => {
     readonly config: {
         readonly weights: readonly number[];
         readonly chrono: Record<string, never>;
+    };
+    readonly cardInitInput: {
+        readonly now?: number | undefined;
     };
     readonly card: {
         readonly input: {


### PR DESCRIPTION
- https://github.com/open-spaced-repetition/ts-fsrs/issues/373
## Summary
- add middleware-defined new-card input schemas
- infer and validate composed `newCard` options

## Testing
- srs-kit check, test, and build
- fsrs typecheck
