### PR TITLE
feat(middleware): add monotonic interval scheduling

### DIFF
--- a/.changeset/monotonic-interval-middleware.md
+++ b/.changeset/monotonic-interval-middleware.md
@@ -1,0 +1,5 @@
+---
+"ts-fsrs": patch
+---
+
+feat(fsrs): share monotonic interval scheduling and compose fuzzing and learning steps through scheduler middleware.

--- a/packages/fsrs/bench/monotonic-interval.bench.ts
+++ b/packages/fsrs/bench/monotonic-interval.bench.ts
@@ -1,0 +1,256 @@
+import { defineScheduler, Rating } from '@open-spaced-repetition/srs-kit'
+import { dateChrono } from '@open-spaced-repetition/srs-kit/chrono/date'
+import { createEmptyCard } from 'ts-fsrs/default'
+import { fsrs } from 'ts-fsrs/fsrs'
+import {
+  calculateScheduleDay,
+  calculateScheduleDays,
+} from 'ts-fsrs/middlewares/monotonic-interval/core'
+import { schedulerMonotonicIntervalMiddleware } from 'ts-fsrs/middlewares/monotonic-interval/middleware'
+import { FSRS6_DEFAULT_WEIGHTS } from 'ts-fsrs/models/fsrs-6/constants'
+import { FSRS6Model } from 'ts-fsrs/models/fsrs-6/model'
+import { bench, describe } from 'vitest'
+
+let sink = 0
+
+function consume(value: number): void {
+  sink = (sink + value) % Number.MAX_SAFE_INTEGER
+}
+
+const maximumInterval = 36_500
+
+describe('monotonic interval core', () => {
+  bench('calculate one-rating chain', () => {
+    consume(calculateScheduleDays([4], maximumInterval)[0])
+  })
+
+  bench('calculate two-rating chain', () => {
+    consume(calculateScheduleDays([4, 2], maximumInterval)[1])
+  })
+
+  bench('calculate three-rating chain', () => {
+    consume(calculateScheduleDays([4, 2, 7], maximumInterval)[2])
+  })
+
+  bench('calculate four-rating chain', () => {
+    consume(calculateScheduleDays([4, 2, 7, 6], maximumInterval)[3])
+  })
+
+  bench('calculate current four-rating interval', () => {
+    consume(calculateScheduleDay([4, 2, 7, 6], maximumInterval))
+  })
+})
+
+const now = new Date('2026-01-01T00:00:00.000Z')
+const later = new Date('2026-01-10T00:00:00.000Z')
+
+const legacyLongTerm = fsrs({
+  enable_fuzz: false,
+  enable_short_term: false,
+  maximum_interval: maximumInterval,
+})
+const legacyLongTermNewCard = createEmptyCard(now)
+const legacyLongTermReviewCard = legacyLongTerm.next(
+  legacyLongTermNewCard,
+  now,
+  Rating.Good
+).card
+
+const legacyShortTerm = fsrs({
+  enable_fuzz: false,
+  enable_short_term: true,
+  maximum_interval: maximumInterval,
+})
+const legacyShortTermReviewCard = legacyShortTerm.next(
+  createEmptyCard(now),
+  now,
+  Rating.Easy
+).card
+
+describe('legacy FSRS', () => {
+  bench('long-term next new card', () => {
+    consume(
+      legacyLongTerm.next(legacyLongTermNewCard, now, Rating.Good).card
+        .scheduled_days
+    )
+  })
+
+  bench('long-term next review card', () => {
+    consume(
+      legacyLongTerm.next(legacyLongTermReviewCard, later, Rating.Easy).card
+        .scheduled_days
+    )
+  })
+
+  bench('long-term repeat review card', () => {
+    for (const item of Array.from(
+      legacyLongTerm.repeat(legacyLongTermReviewCard, later)
+    )) {
+      consume(item.card.scheduled_days)
+    }
+  })
+
+  bench('short-term next review card', () => {
+    consume(
+      legacyShortTerm.next(legacyShortTermReviewCard, later, Rating.Easy).card
+        .scheduled_days
+    )
+  })
+
+  bench('short-term repeat review card', () => {
+    for (const item of Array.from(
+      legacyShortTerm.repeat(legacyShortTermReviewCard, later)
+    )) {
+      consume(item.card.scheduled_days)
+    }
+  })
+})
+
+const longTermModelConfig = {
+  weights: [...FSRS6_DEFAULT_WEIGHTS],
+  enableShortTerm: false,
+  numRelearningSteps: 0,
+}
+const shortTermModelConfig = {
+  weights: [...FSRS6_DEFAULT_WEIGHTS],
+  enableShortTerm: true,
+  numRelearningSteps: 1,
+}
+
+const longTermBaseCore = defineScheduler({
+  model: FSRS6Model,
+  chrono: dateChrono,
+}).create({ config: longTermModelConfig })
+const longTermBaseCard = longTermBaseCore.review({
+  card: longTermBaseCore.newCard({ now }),
+  grade: Rating.Good,
+  now,
+}).card
+
+const longTermMonotonicCore = defineScheduler({
+  model: FSRS6Model,
+  chrono: dateChrono,
+})
+  .use(schedulerMonotonicIntervalMiddleware)
+  .create({
+    config: { ...longTermModelConfig, maximumInterval },
+  })
+const longTermMonotonicCard = longTermMonotonicCore.review({
+  card: longTermMonotonicCore.newCard({ now }),
+  grade: Rating.Good,
+  now,
+}).card
+
+const shortTermBaseCore = defineScheduler({
+  model: FSRS6Model,
+  chrono: dateChrono,
+}).create({ config: shortTermModelConfig })
+const shortTermBaseCard = shortTermBaseCore.review({
+  card: shortTermBaseCore.newCard({ now }),
+  grade: Rating.Easy,
+  now,
+}).card
+
+const shortTermMonotonicCore = defineScheduler({
+  model: FSRS6Model,
+  chrono: dateChrono,
+})
+  .use(schedulerMonotonicIntervalMiddleware)
+  .create({
+    config: { ...shortTermModelConfig, maximumInterval },
+  })
+const shortTermMonotonicCard = shortTermMonotonicCore.review({
+  card: shortTermMonotonicCore.newCard({ now }),
+  grade: Rating.Easy,
+  now,
+}).card
+
+describe('srs-kit long-term review card', () => {
+  bench('base review', () => {
+    consume(
+      longTermBaseCore
+        .review({
+          card: longTermBaseCard,
+          grade: Rating.Easy,
+          now: later,
+        })
+        .card.dueAt.getTime()
+    )
+  })
+
+  bench('monotonic middleware review', () => {
+    consume(
+      longTermMonotonicCore
+        .review({
+          card: longTermMonotonicCard,
+          grade: Rating.Easy,
+          now: later,
+        })
+        .card.dueAt.getTime()
+    )
+  })
+
+  bench('base preview', () => {
+    for (const item of Array.from(
+      longTermBaseCore.preview({ card: longTermBaseCard, now: later })
+    )) {
+      consume(item.card.dueAt.getTime())
+    }
+  })
+
+  bench('monotonic middleware preview', () => {
+    for (const item of Array.from(
+      longTermMonotonicCore.preview({
+        card: longTermMonotonicCard,
+        now: later,
+      })
+    )) {
+      consume(item.card.dueAt.getTime())
+    }
+  })
+})
+
+describe('srs-kit short-term review card', () => {
+  bench('base review', () => {
+    consume(
+      shortTermBaseCore
+        .review({
+          card: shortTermBaseCard,
+          grade: Rating.Easy,
+          now: later,
+        })
+        .card.dueAt.getTime()
+    )
+  })
+
+  bench('monotonic middleware review', () => {
+    consume(
+      shortTermMonotonicCore
+        .review({
+          card: shortTermMonotonicCard,
+          grade: Rating.Easy,
+          now: later,
+        })
+        .card.dueAt.getTime()
+    )
+  })
+
+  bench('base preview', () => {
+    for (const item of Array.from(
+      shortTermBaseCore.preview({ card: shortTermBaseCard, now: later })
+    )) {
+      consume(item.card.dueAt.getTime())
+    }
+  })
+
+  bench('monotonic middleware preview', () => {
+    for (const item of Array.from(
+      shortTermMonotonicCore.preview({
+        card: shortTermMonotonicCard,
+        now: later,
+      })
+    )) {
+      consume(item.card.dueAt.getTime())
+    }
+  })
+})

--- a/packages/fsrs/src/impl/basic_scheduler.ts
+++ b/packages/fsrs/src/impl/basic_scheduler.ts
@@ -9,6 +9,7 @@ import type {
   LearningStepsResolver,
   LearningStepsResult,
 } from '../middlewares/learning-steps/types.js'
+import { calculateScheduleDays } from '../middlewares/monotonic-interval/core.js'
 import {
   type Card,
   type CardInput,
@@ -221,29 +222,22 @@ export default class BasicScheduler extends AbstractScheduler {
     interval: number
   ): void {
     const { maximum_interval } = this.parameters
-    let hard_interval: int, good_interval: int
-    hard_interval = this.scheduler_next_interval(next_hard, interval)
-    good_interval = this.scheduler_next_interval(next_good, interval)
-    hard_interval = Math.min(hard_interval, good_interval) as int
-    good_interval = Math.min(
-      Math.max(good_interval, hard_interval + 1),
-      maximum_interval
-    ) as int
-    const easy_interval = Math.min(
-      Math.max(
+    const [hard_interval, good_interval, easy_interval] = calculateScheduleDays(
+      [
+        this.scheduler_next_interval(next_hard, interval),
+        this.scheduler_next_interval(next_good, interval),
         this.scheduler_next_interval(next_easy, interval),
-        good_interval + 1
-      ),
+      ],
       maximum_interval
-    ) as int
+    )
 
     next_hard.scheduled_days = hard_interval
-    next_hard.due = date_scheduler(this.review_time, hard_interval, true)
+    next_hard.due = date_scheduler(this.review_time, hard_interval as int, true)
     next_good.scheduled_days = good_interval
-    next_good.due = date_scheduler(this.review_time, good_interval, true)
+    next_good.due = date_scheduler(this.review_time, good_interval as int, true)
 
     next_easy.scheduled_days = easy_interval
-    next_easy.due = date_scheduler(this.review_time, easy_interval, true)
+    next_easy.due = date_scheduler(this.review_time, easy_interval as int, true)
   }
 
   private scheduler_next_interval(card: Card, elapsed_days: number): int {

--- a/packages/fsrs/src/impl/long_term_scheduler.ts
+++ b/packages/fsrs/src/impl/long_term_scheduler.ts
@@ -2,6 +2,7 @@ import { AbstractScheduler } from '../abstract_scheduler'
 import { TypeConvert } from '../convert'
 import { date_scheduler } from '../help'
 import { withFuzzing } from '../middlewares/fuzzing/core.js'
+import { calculateScheduleDays } from '../middlewares/monotonic-interval/core.js'
 import {
   type Card,
   type Grade,
@@ -92,40 +93,32 @@ export default class LongTermScheduler extends AbstractScheduler {
     interval: number
   ): void {
     const { maximum_interval } = this.parameters
-    let again_interval: int,
-      hard_interval: int,
-      good_interval: int,
-      easy_interval: int
-    again_interval = this.scheduler_next_interval(next_again, interval)
-    hard_interval = this.scheduler_next_interval(next_hard, interval)
-    good_interval = this.scheduler_next_interval(next_good, interval)
-    easy_interval = this.scheduler_next_interval(next_easy, interval)
-
-    again_interval = Math.min(again_interval, hard_interval) as int
-    hard_interval = Math.min(
-      Math.max(hard_interval, again_interval + 1),
-      maximum_interval
-    ) as int
-    good_interval = Math.min(
-      Math.max(good_interval, hard_interval + 1),
-      maximum_interval
-    ) as int
-    easy_interval = Math.min(
-      Math.max(easy_interval, good_interval + 1),
-      maximum_interval
-    ) as int
+    const [again_interval, hard_interval, good_interval, easy_interval] =
+      calculateScheduleDays(
+        [
+          this.scheduler_next_interval(next_again, interval),
+          this.scheduler_next_interval(next_hard, interval),
+          this.scheduler_next_interval(next_good, interval),
+          this.scheduler_next_interval(next_easy, interval),
+        ],
+        maximum_interval
+      )
 
     next_again.scheduled_days = again_interval
-    next_again.due = date_scheduler(this.review_time, again_interval, true)
+    next_again.due = date_scheduler(
+      this.review_time,
+      again_interval as int,
+      true
+    )
 
     next_hard.scheduled_days = hard_interval
-    next_hard.due = date_scheduler(this.review_time, hard_interval, true)
+    next_hard.due = date_scheduler(this.review_time, hard_interval as int, true)
 
     next_good.scheduled_days = good_interval
-    next_good.due = date_scheduler(this.review_time, good_interval, true)
+    next_good.due = date_scheduler(this.review_time, good_interval as int, true)
 
     next_easy.scheduled_days = easy_interval
-    next_easy.due = date_scheduler(this.review_time, easy_interval, true)
+    next_easy.due = date_scheduler(this.review_time, easy_interval as int, true)
   }
 
   private scheduler_next_interval(card: Card, elapsed_days: number): int {

--- a/packages/fsrs/src/middlewares/fuzzing/middleware.spec.ts
+++ b/packages/fsrs/src/middlewares/fuzzing/middleware.spec.ts
@@ -203,18 +203,35 @@ describe('schedulerFuzzingMiddleware review', () => {
     expect(result.card.dueAt).toEqual(expected.card.dueAt)
   })
 
-  it('reuses one fuzz factor for every grade in a preview', () => {
+  it('derives stable intervals without caching the fuzz factor', () => {
+    const rng = vi.fn((_seed: string) => () => 0.5)
+    const core = defineScheduler({ model: FSRS6Model, chrono: dateChrono })
+      .use(createSchedulerFuzzingMiddleware({ rng }))
+      .create({ config })
+    const plainCard = plainCore.newCard({ now })
+    const rawIntervals = Array.from(
+      plainCore.preview({ card: plainCard, now }),
+      (item) => scheduledDays(item.card.dueAt, now)
+    )
     const card = fuzzFirstCore.newCard({
       now,
       cardId: 'preview-card',
     })
 
-    const first = Array.from(fuzzFirstCore.preview({ card, now }))
-    const second = Array.from(fuzzFirstCore.preview({ card, now }))
+    const first = Array.from(core.preview({ card, now }))
+    const firstCallCount = rng.mock.calls.length
+    const second = Array.from(core.preview({ card, now }))
 
     expect(first).toHaveLength(4)
     expect(second.map((item) => item.card.dueAt)).toEqual(
       first.map((item) => item.card.dueAt)
+    )
+    expect(firstCallCount).toBe(
+      rawIntervals.filter((interval) => interval >= 2.5).length
+    )
+    expect(rng).toHaveBeenCalledTimes(firstCallCount * 2)
+    expect(rng.mock.calls.every(([seed]) => seed === 'preview-card1')).toBe(
+      true
     )
   })
 

--- a/packages/fsrs/src/middlewares/fuzzing/middleware.ts
+++ b/packages/fsrs/src/middlewares/fuzzing/middleware.ts
@@ -2,6 +2,7 @@ import {
   defineMiddleware,
   type ReviewCandidateContext,
 } from '@open-spaced-repetition/srs-kit'
+import type { Mutable } from '@open-spaced-repetition/srs-kit/schema'
 import { createCardId } from './card-id.js'
 import {
   FUZZ_RANGES,
@@ -17,10 +18,10 @@ import {
   fuzzingRevlogFieldsSchema,
 } from './schema.js'
 
-const fuzzFactorSymbol = Symbol('ts-fsrs.fuzzing.factor')
+const fuzzingDecoratorSymbol = Symbol('ts-fsrs.fuzzing.decorator')
 
 type FuzzingCandidate = ReviewCandidateContext & {
-  [fuzzFactorSymbol]?: number
+  [fuzzingDecoratorSymbol]?: true
 }
 
 export type SchedulerFuzzingMiddlewareOptions = {
@@ -67,29 +68,29 @@ export function createSchedulerFuzzingMiddleware(
         }
 
         const reps = ctx.result.card.reps ?? card.reps + 1
-        const nextMemoryState = ctx.candidate.step(ctx.input.grade)
-        const interval = ctx.candidate.nextInterval(
-          nextMemoryState,
-          ctx.desiredRetention
-        )
-        if (interval < 2.5) {
-          ctx.scheduledDays = Math.round(interval)
-        } else {
-          const { minInterval, maxInterval } = getFuzzRange(
-            interval,
-            ctx.elapsedDays,
-            ctx.config.maximumInterval,
-            fuzzingRange
-          )
-          const fuzzFactor = getFuzzFactor({
-            candidate: ctx.candidate,
-            seed: `${card.cardId}${reps}`,
-            rng,
-          })
-          ctx.scheduledDays = Math.floor(
-            fuzzFactor * (maxInterval - minInterval + 1) + minInterval
-          )
+        const candidate = ctx.candidate as Mutable<FuzzingCandidate>
+        if (!candidate[fuzzingDecoratorSymbol]) {
+          const nextInterval = candidate.nextInterval
+          const seed = `${card.cardId}${reps}`
+          candidate.nextInterval = (memoryState, desiredRetention) => {
+            const interval = nextInterval(memoryState, desiredRetention)
+            if (interval < 2.5) return Math.round(interval)
+
+            const { minInterval, maxInterval } = getFuzzRange(
+              interval,
+              ctx.elapsedDays,
+              ctx.config.maximumInterval,
+              fuzzingRange
+            )
+            const fuzzFactor = rng(seed)()
+            return Math.floor(
+              fuzzFactor * (maxInterval - minInterval + 1) + minInterval
+            )
+          }
+          candidate[fuzzingDecoratorSymbol] = true
         }
+
+        ctx.scheduledDays = undefined
         next()
         ctx.result.card.cardId = card.cardId
         ctx.result.card.reps ??= reps
@@ -106,21 +107,3 @@ export function createSchedulerFuzzingMiddleware(
 }
 
 export const schedulerFuzzingMiddleware = createSchedulerFuzzingMiddleware()
-
-function getFuzzFactor({
-  candidate,
-  seed,
-  rng,
-}: {
-  readonly candidate: ReviewCandidateContext
-  readonly seed: string
-  readonly rng: FuzzingRng
-}): number {
-  const cache = candidate as FuzzingCandidate
-  let fuzzFactor = cache[fuzzFactorSymbol]
-  if (fuzzFactor === undefined) {
-    fuzzFactor = rng(seed)()
-    cache[fuzzFactorSymbol] = fuzzFactor
-  }
-  return fuzzFactor
-}

--- a/packages/fsrs/src/middlewares/fuzzing/middleware.ts
+++ b/packages/fsrs/src/middlewares/fuzzing/middleware.ts
@@ -90,6 +90,8 @@ export function createSchedulerFuzzingMiddleware(
           candidate[fuzzingDecoratorSymbol] = true
         }
 
+        // Leave this unset so finalizeReview resolves the decorated interval
+        // after downstream middleware has had a chance to override it.
         ctx.scheduledDays = undefined
         next()
         ctx.result.card.cardId = card.cardId

--- a/packages/fsrs/src/middlewares/index.ts
+++ b/packages/fsrs/src/middlewares/index.ts
@@ -1,2 +1,3 @@
 export * from './fuzzing/index.js'
 export * from './learning-steps/index.js'
+export * from './monotonic-interval/index.js'

--- a/packages/fsrs/src/middlewares/monotonic-interval/core.spec.ts
+++ b/packages/fsrs/src/middlewares/monotonic-interval/core.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { calculateScheduleDay, calculateScheduleDays } from './core.js'
+
+describe('calculateScheduleDays', () => {
+  it('keeps the first interval and advances each later rating', () => {
+    expect(calculateScheduleDays([4], 100)).toEqual([4])
+    expect(calculateScheduleDays([4, 2], 100)).toEqual([4, 5])
+    expect(calculateScheduleDays([4, 2, 8], 100)).toEqual([4, 5, 8])
+    expect(calculateScheduleDays([4, 2, 8, 7], 100)).toEqual([4, 5, 8, 9])
+  })
+
+  it('preserves already monotonic intervals', () => {
+    expect(calculateScheduleDays([2, 4, 8, 16], 100)).toEqual([2, 4, 8, 16])
+  })
+
+  it('allows equal intervals once the maximum is reached', () => {
+    expect(calculateScheduleDays([98, 99, 100, 101], 100)).toEqual([
+      98, 99, 100, 100,
+    ])
+    expect(calculateScheduleDays([100, 100, 100], 100)).toEqual([100, 100, 100])
+  })
+
+  it('caps the first interval without comparing it with the next rating', () => {
+    expect(calculateScheduleDays([102], 100)).toEqual([100])
+    expect(calculateScheduleDays([102, 101, 100], 100)).toEqual([100, 100, 100])
+  })
+
+  it('does not mutate the candidate tuple', () => {
+    const candidates = [8, 5, 4, 3] as const
+
+    const result = calculateScheduleDays(candidates, 100)
+    result[0] = 1
+
+    expect(candidates).toEqual([8, 5, 4, 3])
+  })
+
+  it('returns the current rating interval', () => {
+    expect(calculateScheduleDay([4], 100)).toBe(4)
+    expect(calculateScheduleDay([4, 2], 100)).toBe(5)
+    expect(calculateScheduleDay([4, 2, 8], 100)).toBe(8)
+    expect(calculateScheduleDay([4, 2, 8, 7], 100)).toBe(9)
+  })
+})

--- a/packages/fsrs/src/middlewares/monotonic-interval/core.ts
+++ b/packages/fsrs/src/middlewares/monotonic-interval/core.ts
@@ -1,0 +1,49 @@
+import type { Mutable } from '@open-spaced-repetition/srs-kit/schema'
+
+export type IntervalCandidates =
+  | readonly [number]
+  | readonly [number, number]
+  | readonly [number, number, number]
+  | readonly [number, number, number, number]
+
+type ScheduledDays<T extends readonly number[]> = Mutable<{
+  [K in keyof T]: number
+}>
+
+/**
+ * Keeps rating intervals monotonic after rounding and fuzzing.
+ *
+ * The first interval is capped at the maximum. Each later interval is kept at
+ * least one day after the previous result until the maximum is reached. The
+ * input tuple is never mutated.
+ */
+export function calculateScheduleDays<const T extends IntervalCandidates>(
+  candidates: T,
+  maximumInterval: number
+): ScheduledDays<T> {
+  const first = Math.min(candidates[0], maximumInterval)
+  if (candidates.length === 1) {
+    return [first] as ScheduledDays<T>
+  }
+
+  const second = Math.min(Math.max(candidates[1], first + 1), maximumInterval)
+  if (candidates.length === 2) {
+    return [first, second] as ScheduledDays<T>
+  }
+
+  const third = Math.min(Math.max(candidates[2], second + 1), maximumInterval)
+  if (candidates.length === 3) {
+    return [first, second, third] as ScheduledDays<T>
+  }
+
+  const fourth = Math.min(Math.max(candidates[3], third + 1), maximumInterval)
+  return [first, second, third, fourth] as ScheduledDays<T>
+}
+
+export function calculateScheduleDay(
+  candidates: IntervalCandidates,
+  maximumInterval: number
+): number {
+  const scheduledDays = calculateScheduleDays(candidates, maximumInterval)
+  return scheduledDays[scheduledDays.length - 1]
+}

--- a/packages/fsrs/src/middlewares/monotonic-interval/index.ts
+++ b/packages/fsrs/src/middlewares/monotonic-interval/index.ts
@@ -1,0 +1,8 @@
+export * from './core.js'
+export { schedulerMonotonicIntervalMiddleware } from './middleware.js'
+export {
+  DEFAULT_MAXIMUM_INTERVAL,
+  type MonotonicIntervalConfig,
+  type MonotonicIntervalConfigInput,
+  monotonicIntervalConfigSchema,
+} from './schema.js'

--- a/packages/fsrs/src/middlewares/monotonic-interval/legacy.spec.ts
+++ b/packages/fsrs/src/middlewares/monotonic-interval/legacy.spec.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest'
+import { createEmptyCard } from '../../default.js'
+import { fsrs } from '../../fsrs.js'
+import { dateDiffInDays } from '../../help.js'
+import { type Card, type Grade, Rating, State } from '../../models.js'
+import { calculateScheduleDays } from './core.js'
+
+const DAY = 24 * 60 * 60 * 1000
+const MINUTE = 60 * 1000
+const grades = [Rating.Again, Rating.Hard, Rating.Good, Rating.Easy] as const
+
+type LegacyScheduler = ReturnType<typeof fsrs>
+
+function rawInterval(
+  scheduler: LegacyScheduler,
+  card: Card,
+  now: Date,
+  grade: Grade
+): number {
+  const elapsedDays = card.last_review
+    ? dateDiffInDays(card.last_review, now)
+    : 0
+  const nextMemoryState = scheduler.model.step({
+    memoryState: card,
+    elapsedDays,
+    rating: grade,
+    retrievability:
+      card.state === State.New
+        ? undefined
+        : scheduler.model.forgettingCurve(card, elapsedDays),
+  })
+
+  return Math.round(
+    scheduler.model.nextInterval(
+      nextMemoryState,
+      scheduler.parameters.request_retention
+    )
+  )
+}
+
+function expectedLongTermSchedule(
+  scheduler: LegacyScheduler,
+  card: Card,
+  now: Date
+): number[] {
+  return calculateScheduleDays(
+    [
+      rawInterval(scheduler, card, now, Rating.Again),
+      rawInterval(scheduler, card, now, Rating.Hard),
+      rawInterval(scheduler, card, now, Rating.Good),
+      rawInterval(scheduler, card, now, Rating.Easy),
+    ],
+    scheduler.parameters.maximum_interval
+  )
+}
+
+function expectedShortTermReviewSchedule(
+  scheduler: LegacyScheduler,
+  card: Card,
+  now: Date
+): number[] {
+  return calculateScheduleDays(
+    [
+      rawInterval(scheduler, card, now, Rating.Hard),
+      rawInterval(scheduler, card, now, Rating.Good),
+      rawInterval(scheduler, card, now, Rating.Easy),
+    ],
+    scheduler.parameters.maximum_interval
+  )
+}
+
+function expectPublicDaySchedule(
+  scheduler: LegacyScheduler,
+  card: Card,
+  now: Date,
+  expected: readonly number[],
+  ratings: readonly Grade[] = grades
+): void {
+  const record = scheduler.repeat(card, now)
+
+  expect(ratings.map((rating) => record[rating].card.scheduled_days)).toEqual(
+    expected
+  )
+
+  ratings.forEach((rating, index) => {
+    const next = scheduler.next(card, now, rating)
+    expect(next).toEqual(record[rating])
+    expect(next.card.scheduled_days).toBe(expected[index])
+    expect(next.card.due.getTime() - now.getTime()).toBe(expected[index] * DAY)
+  })
+}
+
+describe('legacy FSRS monotonic interval integration', () => {
+  const start = new Date('2026-01-01T00:00:00.000Z')
+
+  it('keeps all long-term new-card ratings on the four-grade chain', () => {
+    const scheduler = fsrs({
+      enable_fuzz: false,
+      enable_short_term: false,
+    })
+    const card = createEmptyCard(start)
+    const expected = expectedLongTermSchedule(scheduler, card, start)
+
+    expect(expected).toEqual([1, 2, 3, 8])
+    expectPublicDaySchedule(scheduler, card, start, expected)
+  })
+
+  it('keeps all long-term review ratings on the four-grade chain', () => {
+    const scheduler = fsrs({
+      enable_fuzz: false,
+      enable_short_term: false,
+    })
+    const card = scheduler.next(createEmptyCard(start), start, Rating.Easy).card
+    const now = card.due
+    const expected = expectedLongTermSchedule(scheduler, card, now)
+
+    expect(expected).toEqual([1, 27, 39, 66])
+    expectPublicDaySchedule(scheduler, card, now, expected)
+  })
+
+  it('keeps fuzzing before the long-term monotonic chain', () => {
+    const scheduler = fsrs({
+      enable_fuzz: true,
+      enable_short_term: false,
+    })
+    const card = scheduler.next(createEmptyCard(start), start, Rating.Easy).card
+    const now = card.due
+
+    expectPublicDaySchedule(scheduler, card, now, [1, 28, 40, 68])
+  })
+
+  it('keeps Again outside the short-term Review day chain', () => {
+    const scheduler = fsrs({
+      enable_fuzz: false,
+      enable_short_term: true,
+      relearning_steps: ['10m'],
+    })
+    const card = scheduler.next(createEmptyCard(start), start, Rating.Easy).card
+    const now = card.due
+    const expected = expectedShortTermReviewSchedule(scheduler, card, now)
+
+    expect(expected).toEqual([27, 39, 66])
+    expectPublicDaySchedule(scheduler, card, now, expected, grades.slice(1))
+
+    const record = scheduler.repeat(card, now)
+    const nextAgain = scheduler.next(card, now, Rating.Again)
+    expect(nextAgain).toEqual(record[Rating.Again])
+    expect(nextAgain.card.state).toBe(State.Relearning)
+    expect(nextAgain.card.scheduled_days).toBe(0)
+    expect(nextAgain.card.due.getTime() - now.getTime()).toBe(10 * MINUTE)
+  })
+
+  it('saturates later long-term ratings at maximum_interval', () => {
+    const scheduler = fsrs({
+      enable_fuzz: false,
+      enable_short_term: false,
+      maximum_interval: 2,
+    })
+    const card = createEmptyCard(start)
+    const expected = expectedLongTermSchedule(scheduler, card, start)
+
+    expect(expected).toEqual([1, 2, 2, 2])
+    expectPublicDaySchedule(scheduler, card, start, expected)
+  })
+})

--- a/packages/fsrs/src/middlewares/monotonic-interval/legacy.spec.ts
+++ b/packages/fsrs/src/middlewares/monotonic-interval/legacy.spec.ts
@@ -1,3 +1,4 @@
+import { grades } from '@open-spaced-repetition/srs-kit'
 import { describe, expect, it } from 'vitest'
 import { createEmptyCard } from '../../default.js'
 import { fsrs } from '../../fsrs.js'
@@ -7,8 +8,6 @@ import { calculateScheduleDays } from './core.js'
 
 const DAY = 24 * 60 * 60 * 1000
 const MINUTE = 60 * 1000
-const grades = [Rating.Again, Rating.Hard, Rating.Good, Rating.Easy] as const
-
 type LegacyScheduler = ReturnType<typeof fsrs>
 
 function rawInterval(

--- a/packages/fsrs/src/middlewares/monotonic-interval/middleware.spec.ts
+++ b/packages/fsrs/src/middlewares/monotonic-interval/middleware.spec.ts
@@ -1,0 +1,331 @@
+import {
+  defineScheduler,
+  type Grade,
+  grades,
+  Rating,
+  State,
+} from '@open-spaced-repetition/srs-kit'
+import { dateChrono } from '@open-spaced-repetition/srs-kit/chrono/date'
+import { describe, expect, it, vi } from 'vitest'
+import { FSRS6_DEFAULT_WEIGHTS } from '../../models/fsrs-6/constants.js'
+import { FSRS6Model } from '../../models/fsrs-6/model.js'
+import { createSchedulerFuzzingMiddleware } from '../fuzzing/middleware.js'
+import { schedulerLearningStepsMiddleware } from '../learning-steps/middleware.js'
+import { calculateScheduleDays } from './core.js'
+import { schedulerMonotonicIntervalMiddleware } from './middleware.js'
+
+const DAY = 86_400_000
+const now = new Date('2026-01-01T00:00:00.000Z')
+const later = new Date('2026-01-10T00:00:00.000Z')
+const maximumInterval = 100
+const reviewHandler = schedulerMonotonicIntervalMiddleware.handlers?.review
+
+if (!reviewHandler)
+  throw new Error('Expected monotonic interval review handler')
+
+type ReviewContext = Parameters<typeof reviewHandler>[0]
+
+function createReviewContext({
+  grade,
+  intervals,
+  state = State.Review,
+  maximum = maximumInterval,
+  scheduledDays,
+}: {
+  readonly grade: Grade
+  readonly intervals: Readonly<Record<Grade, number>>
+  readonly state?: State
+  readonly maximum?: number
+  readonly scheduledDays?: number
+}) {
+  const step = vi.fn((rating: Grade) => ({ rating }))
+  const nextInterval = vi.fn(
+    (
+      memoryState: Readonly<Record<string, unknown>>,
+      _desiredRetention: number
+    ) => intervals[memoryState.rating as Grade]
+  )
+  const ctx = {
+    config: { maximumInterval: maximum },
+    input: {
+      card: { state, scheduleStatus: 'review' },
+      grade,
+      now,
+    },
+    desiredRetention: 0.9,
+    elapsedDays: 9,
+    scheduledDays,
+    candidate: { step, nextInterval },
+    result: { card: {}, revlog: {} },
+  } as unknown as ReviewContext
+
+  return { ctx, nextInterval, step }
+}
+
+function dueDays(dueAt: Date, reviewTime: Date): number {
+  return (dueAt.getTime() - reviewTime.getTime()) / DAY
+}
+
+describe('schedulerMonotonicIntervalMiddleware handler', () => {
+  const longTermIntervals = {
+    [Rating.Again]: 4,
+    [Rating.Hard]: 2,
+    [Rating.Good]: 8,
+    [Rating.Easy]: 7,
+  }
+
+  it.each([
+    [Rating.Again, 4, [Rating.Again]],
+    [Rating.Hard, 5, [Rating.Again, Rating.Hard]],
+    [Rating.Good, 8, [Rating.Again, Rating.Hard, Rating.Good]],
+    [Rating.Easy, 9, grades],
+  ] as const)('uses the required long-term candidates for grade %s', (grade, expected, expectedGrades) => {
+    const { ctx, nextInterval, step } = createReviewContext({
+      grade,
+      intervals: longTermIntervals,
+    })
+    const next = vi.fn()
+
+    reviewHandler(ctx, next)
+
+    expect(ctx.scheduledDays).toBe(expected)
+    expect(step.mock.calls.map(([rating]) => rating)).toEqual(expectedGrades)
+    expect(nextInterval).toHaveBeenCalledTimes(expectedGrades.length)
+    expect(
+      nextInterval.mock.calls.every(([, retention]) => retention === 0.9)
+    ).toBe(true)
+    expect(next).toHaveBeenCalledOnce()
+  })
+
+  it('uses the candidate interval resolver for every required grade', () => {
+    const { ctx, step } = createReviewContext({
+      grade: Rating.Good,
+      intervals: longTermIntervals,
+      scheduledDays: 2,
+    })
+
+    reviewHandler(ctx, vi.fn())
+
+    expect(ctx.scheduledDays).toBe(8)
+    expect(step.mock.calls.map(([rating]) => rating)).toEqual([
+      Rating.Again,
+      Rating.Hard,
+      Rating.Good,
+    ])
+  })
+
+  it.each([
+    State.New,
+    State.Learning,
+    State.Relearning,
+    State.Review,
+  ])('uses the same rating chain for card state %s', (state) => {
+    const { ctx, step } = createReviewContext({
+      grade: Rating.Easy,
+      intervals: longTermIntervals,
+      state,
+    })
+    const next = vi.fn()
+
+    reviewHandler(ctx, next)
+
+    expect(ctx.scheduledDays).toBe(9)
+    expect(step.mock.calls.map(([rating]) => rating)).toEqual(grades)
+    expect(next).toHaveBeenCalledOnce()
+  })
+
+  it('allows later ratings to share the maximum interval', () => {
+    const { ctx } = createReviewContext({
+      grade: Rating.Easy,
+      maximum: 100,
+      intervals: {
+        [Rating.Again]: 98,
+        [Rating.Hard]: 99,
+        [Rating.Good]: 100,
+        [Rating.Easy]: 101,
+      },
+    })
+
+    reviewHandler(ctx, vi.fn())
+
+    expect(ctx.scheduledDays).toBe(100)
+  })
+})
+
+describe('schedulerMonotonicIntervalMiddleware integration', () => {
+  it('uses the default maximum interval when it is omitted', () => {
+    const core = defineScheduler({ model: FSRS6Model, chrono: dateChrono })
+      .use(schedulerMonotonicIntervalMiddleware)
+      .create({
+        config: {
+          weights: [...FSRS6_DEFAULT_WEIGHTS],
+          enableShortTerm: false,
+          numRelearningSteps: 0,
+        },
+      })
+
+    expect(core.config.maximumInterval).toBe(36_500)
+  })
+
+  it('keeps long-term review and preview due dates aligned', () => {
+    const modelConfig = {
+      weights: [...FSRS6_DEFAULT_WEIGHTS],
+      enableShortTerm: false,
+      numRelearningSteps: 0,
+    }
+    const base = defineScheduler({
+      model: FSRS6Model,
+      chrono: dateChrono,
+    }).create({ config: modelConfig })
+    const core = defineScheduler({ model: FSRS6Model, chrono: dateChrono })
+      .use(schedulerMonotonicIntervalMiddleware)
+      .create({ config: { ...modelConfig, maximumInterval } })
+    const baseCard = base.newCard({ now })
+    const card = core.newCard({ now })
+    const raw = Array.from(base.preview({ card: baseCard, now }), (item) =>
+      dueDays(item.card.dueAt, now)
+    )
+    const expected = calculateScheduleDays(
+      [raw[0], raw[1], raw[2], raw[3]],
+      maximumInterval
+    )
+    const preview = Array.from(core.preview({ card, now }))
+
+    expect(preview.map((item) => dueDays(item.card.dueAt, now))).toEqual(
+      expected
+    )
+    for (const [index, grade] of grades.entries()) {
+      expect(dueDays(core.review({ card, grade, now }).card.dueAt, now)).toBe(
+        expected[index]
+      )
+    }
+  })
+
+  it('uses the full rating chain when short-term scheduling is enabled', () => {
+    const modelConfig = {
+      weights: [...FSRS6_DEFAULT_WEIGHTS],
+      enableShortTerm: true,
+      numRelearningSteps: 1,
+    }
+    const base = defineScheduler({
+      model: FSRS6Model,
+      chrono: dateChrono,
+    }).create({ config: modelConfig })
+    const core = defineScheduler({ model: FSRS6Model, chrono: dateChrono })
+      .use(schedulerMonotonicIntervalMiddleware)
+      .create({ config: { ...modelConfig, maximumInterval } })
+    const baseCard = base.review({
+      card: base.newCard({ now }),
+      grade: Rating.Easy,
+      now,
+    }).card
+    const card = core.review({
+      card: core.newCard({ now }),
+      grade: Rating.Easy,
+      now,
+    }).card
+    const raw = Array.from(
+      base.preview({ card: baseCard, now: later }),
+      (item) => dueDays(item.card.dueAt, later)
+    )
+    const expected = calculateScheduleDays(
+      [raw[0], raw[1], raw[2], raw[3]],
+      maximumInterval
+    )
+    const preview = Array.from(core.preview({ card, now: later }))
+
+    expect(preview.map((item) => dueDays(item.card.dueAt, later))).toEqual(
+      expected
+    )
+    for (const [index, grade] of grades.entries()) {
+      expect(
+        dueDays(core.review({ card, grade, now: later }).card.dueAt, later)
+      ).toBe(expected[index])
+    }
+  })
+
+  it('uses fuzzing output when fuzzing is registered before monotonic', () => {
+    const modelConfig = {
+      weights: [...FSRS6_DEFAULT_WEIGHTS],
+      enableShortTerm: false,
+      numRelearningSteps: 0,
+    }
+    const config = {
+      ...modelConfig,
+      enableFuzz: true,
+      maximumInterval,
+    }
+    const fuzzOnlyRng = vi.fn((_seed: string) => () => 0)
+    const combinedRng = vi.fn((_seed: string) => () => 0)
+    const fuzzOnly = defineScheduler({ model: FSRS6Model, chrono: dateChrono })
+      .use(
+        createSchedulerFuzzingMiddleware({
+          rng: fuzzOnlyRng,
+        })
+      )
+      .create({ config })
+    const core = defineScheduler({ model: FSRS6Model, chrono: dateChrono })
+      .use(
+        createSchedulerFuzzingMiddleware({
+          rng: combinedRng,
+        }),
+        schedulerMonotonicIntervalMiddleware
+      )
+      .create({ config })
+    const cardId = 'monotonic-fuzz'
+    const fuzzOnlyCard = fuzzOnly.newCard({ now, cardId })
+    const card = core.newCard({ now, cardId })
+    const fuzzed = Array.from(
+      fuzzOnly.preview({ card: fuzzOnlyCard, now }),
+      (item) => dueDays(item.card.dueAt, now)
+    )
+    const expected = calculateScheduleDays(
+      [fuzzed[0], fuzzed[1], fuzzed[2], fuzzed[3]],
+      maximumInterval
+    )
+    const preview = Array.from(core.preview({ card, now }))
+    const direct = core.review({ card, grade: Rating.Easy, now })
+
+    expect(preview.map((item) => dueDays(item.card.dueAt, now))).toEqual(
+      expected
+    )
+    expect(dueDays(direct.card.dueAt, now)).toBe(expected[3])
+    expect(fuzzOnlyRng).toHaveBeenCalled()
+    expect(combinedRng).toHaveBeenCalled()
+  })
+
+  it('lets learning steps own short-term due dates', () => {
+    const core = defineScheduler({ model: FSRS6Model, chrono: dateChrono })
+      .use(
+        createSchedulerFuzzingMiddleware({ rng: () => () => 0.5 }),
+        schedulerMonotonicIntervalMiddleware,
+        schedulerLearningStepsMiddleware
+      )
+      .create({
+        config: {
+          weights: [...FSRS6_DEFAULT_WEIGHTS],
+          enableShortTerm: true,
+          numRelearningSteps: 1,
+          enableFuzz: true,
+          maximumInterval,
+          learningSteps: ['1m', '10m'],
+          relearningSteps: ['10m'],
+        },
+      })
+    const card = core.newCard({ now, cardId: 'learning-step' })
+    const preview = new Map(
+      Array.from(core.preview({ card, now }), (item) => [item.grade, item])
+    )
+
+    expect(
+      preview.get(Rating.Again)!.card.dueAt.getTime() - now.getTime()
+    ).toBe(60_000)
+    expect(preview.get(Rating.Hard)!.card.dueAt.getTime() - now.getTime()).toBe(
+      6 * 60_000
+    )
+    expect(preview.get(Rating.Good)!.card.dueAt.getTime() - now.getTime()).toBe(
+      10 * 60_000
+    )
+    expect(preview.get(Rating.Easy)!.card.state).toBe(State.Review)
+  })
+})

--- a/packages/fsrs/src/middlewares/monotonic-interval/middleware.ts
+++ b/packages/fsrs/src/middlewares/monotonic-interval/middleware.ts
@@ -1,0 +1,56 @@
+import {
+  defineMiddleware,
+  type Grade,
+  Rating,
+} from '@open-spaced-repetition/srs-kit'
+import { calculateScheduleDay, type IntervalCandidates } from './core.js'
+import { monotonicIntervalConfigSchema } from './schema.js'
+
+/** Register after fuzzing, when present, and before learning steps. */
+export const schedulerMonotonicIntervalMiddleware = defineMiddleware({
+  name: Symbol('ts-fsrs.monotonic-interval'),
+  schema: {
+    config: monotonicIntervalConfigSchema,
+  },
+  handlers: {
+    review(ctx, next) {
+      const { grade } = ctx.input
+      const interval = (rating: Grade): number =>
+        ctx.candidate.nextInterval(
+          ctx.candidate.step(rating),
+          ctx.desiredRetention
+        )
+      const schedule = (...candidates: IntervalCandidates): number =>
+        calculateScheduleDay(candidates, ctx.config.maximumInterval)
+
+      switch (grade) {
+        case Rating.Again:
+          ctx.scheduledDays = schedule(interval(Rating.Again))
+          break
+        case Rating.Hard:
+          ctx.scheduledDays = schedule(
+            interval(Rating.Again),
+            interval(Rating.Hard)
+          )
+          break
+        case Rating.Good:
+          ctx.scheduledDays = schedule(
+            interval(Rating.Again),
+            interval(Rating.Hard),
+            interval(Rating.Good)
+          )
+          break
+        case Rating.Easy:
+          ctx.scheduledDays = schedule(
+            interval(Rating.Again),
+            interval(Rating.Hard),
+            interval(Rating.Good),
+            interval(Rating.Easy)
+          )
+          break
+      }
+
+      next()
+    },
+  },
+})

--- a/packages/fsrs/src/middlewares/monotonic-interval/schema.spec.ts
+++ b/packages/fsrs/src/middlewares/monotonic-interval/schema.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { monotonicIntervalConfigSchema } from './schema.js'
+
+describe('monotonicIntervalConfigSchema', () => {
+  it('parses maximumInterval', () => {
+    expect(
+      monotonicIntervalConfigSchema.parse({
+        maximumInterval: 365,
+      })
+    ).toEqual({ maximumInterval: 365 })
+  })
+
+  it('defaults maximumInterval when omitted', () => {
+    expect(monotonicIntervalConfigSchema.parse({})).toEqual({
+      maximumInterval: 36_500,
+    })
+  })
+
+  it.each([
+    null,
+    { maximumInterval: 0 },
+    { maximumInterval: -1 },
+    { maximumInterval: null },
+    { maximumInterval: Number.NaN },
+    { maximumInterval: Number.POSITIVE_INFINITY },
+  ])('rejects invalid config %#', (value) => {
+    expect(() => monotonicIntervalConfigSchema.parse(value)).toThrow()
+  })
+})

--- a/packages/fsrs/src/middlewares/monotonic-interval/schema.ts
+++ b/packages/fsrs/src/middlewares/monotonic-interval/schema.ts
@@ -1,0 +1,34 @@
+import { defineSchema, isObject } from '@open-spaced-repetition/srs-kit'
+
+export type MonotonicIntervalConfigInput = {
+  readonly maximumInterval?: number
+}
+
+export type MonotonicIntervalConfig = {
+  readonly maximumInterval: number
+}
+
+export const DEFAULT_MAXIMUM_INTERVAL = 36_500
+
+export const monotonicIntervalConfigSchema = defineSchema<
+  MonotonicIntervalConfigInput,
+  MonotonicIntervalConfig
+>((value) => {
+  if (!isObject(value)) {
+    return { issues: [{ message: 'Expected monotonic interval config' }] }
+  }
+
+  const maximumInterval =
+    value.maximumInterval === undefined
+      ? DEFAULT_MAXIMUM_INTERVAL
+      : value.maximumInterval
+  if (
+    typeof maximumInterval !== 'number' ||
+    !Number.isFinite(maximumInterval) ||
+    maximumInterval <= 0
+  ) {
+    return { issues: [{ message: 'Expected positive maximumInterval' }] }
+  }
+
+  return { value: { maximumInterval } }
+})


### PR DESCRIPTION
- https://github.com/open-spaced-repetition/ts-fsrs/issues/373
Adds a shared monotonic interval core and middleware, integrates legacy FSRS scheduling with fuzzing and learning steps, and includes regression tests and benchmarks. Validation: full tests, type checks, builds, coverage, and benchmarks passed.