### PR TITLE
feat(middleware): add configurable leech middleware

### DIFF
--- a/.changeset/leech-middleware.md
+++ b/.changeset/leech-middleware.md
@@ -1,0 +1,5 @@
+---
+"ts-fsrs": patch
+---
+
+feat(fsrs): add configurable leech suspension through scheduler middleware.

--- a/packages/fsrs/bench/leech.bench.ts
+++ b/packages/fsrs/bench/leech.bench.ts
@@ -1,0 +1,106 @@
+import {
+  defineScheduler,
+  Rating,
+  schedulerStatsMiddleware,
+} from '@open-spaced-repetition/srs-kit'
+import { dateChrono } from '@open-spaced-repetition/srs-kit/chrono/date'
+import { schedulerLeechMiddleware } from 'ts-fsrs/middlewares/leech/middleware'
+import { FSRS6_DEFAULT_WEIGHTS } from 'ts-fsrs/models/fsrs-6/constants'
+import { FSRS6Model } from 'ts-fsrs/models/fsrs-6/model'
+import { bench, describe } from 'vitest'
+
+let sink = 0
+
+function consume(lapses: number, scheduleStatus: string): void {
+  sink =
+    (sink + lapses + Number(scheduleStatus === 'suspend')) %
+    Number.MAX_SAFE_INTEGER
+}
+
+const now = new Date('2026-01-01T00:00:00.000Z')
+const later = new Date('2026-01-10T00:00:00.000Z')
+const modelConfig = {
+  weights: [...FSRS6_DEFAULT_WEIGHTS],
+  enableShortTerm: false,
+  numRelearningSteps: 0,
+}
+
+const statsCore = defineScheduler({ model: FSRS6Model, chrono: dateChrono })
+  .use(schedulerStatsMiddleware)
+  .create({ config: modelConfig })
+const disabledCore = defineScheduler({ model: FSRS6Model, chrono: dateChrono })
+  .use(schedulerLeechMiddleware, schedulerStatsMiddleware)
+  .create({ config: { ...modelConfig, leechThreshold: 0 } })
+const enabledCore = defineScheduler({ model: FSRS6Model, chrono: dateChrono })
+  .use(schedulerLeechMiddleware, schedulerStatsMiddleware)
+  .create({ config: { ...modelConfig, leechThreshold: 8 } })
+
+const statsCard = {
+  ...statsCore.review({
+    card: statsCore.newCard({ now }),
+    grade: Rating.Good,
+    now,
+  }).card,
+  lapses: 7,
+}
+const disabledCard = {
+  ...disabledCore.review({
+    card: disabledCore.newCard({ now }),
+    grade: Rating.Good,
+    now,
+  }).card,
+  lapses: 7,
+}
+const nonLeechCard = {
+  ...enabledCore.review({
+    card: enabledCore.newCard({ now }),
+    grade: Rating.Good,
+    now,
+  }).card,
+  lapses: 6,
+}
+const leechCard = { ...nonLeechCard, lapses: 7 }
+
+describe('leech scheduler', () => {
+  bench('review with stats only', () => {
+    const card = statsCore.review({
+      card: statsCard,
+      grade: Rating.Again,
+      now: later,
+    }).card
+    consume(card.lapses, card.scheduleStatus)
+  })
+
+  bench('review with leech disabled', () => {
+    const card = disabledCore.review({
+      card: disabledCard,
+      grade: Rating.Again,
+      now: later,
+    }).card
+    consume(card.lapses, card.scheduleStatus)
+  })
+
+  bench('review before leech threshold', () => {
+    const card = enabledCore.review({
+      card: nonLeechCard,
+      grade: Rating.Again,
+      now: later,
+    }).card
+    consume(card.lapses, card.scheduleStatus)
+  })
+
+  bench('review at leech threshold', () => {
+    const card = enabledCore.review({
+      card: leechCard,
+      grade: Rating.Again,
+      now: later,
+    }).card
+    consume(card.lapses, card.scheduleStatus)
+  })
+
+  bench('preview at leech threshold', () => {
+    for (const item of enabledCore.preview({ card: leechCard, now: later })) {
+      consume(item.card.lapses, item.card.scheduleStatus)
+    }
+  })
+})

--- a/packages/fsrs/src/middlewares/index.ts
+++ b/packages/fsrs/src/middlewares/index.ts
@@ -1,3 +1,4 @@
 export * from './fuzzing/index.js'
 export * from './learning-steps/index.js'
+export * from './leech/index.js'
 export * from './monotonic-interval/index.js'

--- a/packages/fsrs/src/middlewares/leech/index.ts
+++ b/packages/fsrs/src/middlewares/leech/index.ts
@@ -1,0 +1,49 @@
+/**
+ * Implemented by Codex 5.6 Sol Ultra.
+ *
+ * Prompt:
+ * Implement a minimal TypeScript leech scheduler middleware using only
+ * `@open-spaced-repetition/srs-kit`; do not import from `ts-fsrs`. A leech is
+ * a Review-state card that has been forgotten repeatedly.
+ *
+ * Create `schema.ts`, `middleware.ts`, `index.ts`, and focused tests with the
+ * following behavior:
+ *
+ * - Define `leechThreshold?: number`, resolve an omitted value to `0`, and
+ *   reject values that are not non-negative integers. A threshold of `0`
+ *   disables suspension.
+ * - Define and validate a card field `lapses` as a non-negative integer.
+ * - Use `defineMiddleware` with `scheduleStatus: ['suspend']`, the config and
+ *   card schemas, and no unnecessary factory or core abstraction.
+ * - Default new-card `lapses` to `0`. During forget, preserve the input value
+ *   only when the composed config has `clearStatsOnForget === false`;
+ *   otherwise reset it to `0`.
+ * - In the review handler, call `next()` first. A lapse occurs only when
+ *   `ctx.input.card.state === State.Review` and
+ *   `ctx.input.grade === Rating.Again`. Use an existing
+ *   `ctx.result.card.lapses` value when present; otherwise write the previous
+ *   lapses plus one for a lapse, or the unchanged value for any other review.
+ * - Set `ctx.result.card.scheduleStatus` to `'suspend'` only for a current
+ *   lapse when `leechThreshold > 0` and the resulting lapses count is an exact
+ *   multiple of the threshold.
+ * - In rollback, call `next()` first and fill a missing result lapses value by
+ *   reversing the same lapse condition, using `revlog.state` and
+ *   `revlog.rating`, without allowing the count to become negative.
+ * - Keep behavior identical with the stats middleware registered before the
+ *   leech middleware, after it, or not at all. Register leech before any
+ *   middleware whose post-`next()` logic can overwrite `scheduleStatus`.
+ * - Test schema validation, disabled/non-matching/matching thresholds,
+ *   positive threshold multiples, non-Review Again, non-Again reviews,
+ *   preview, both stats middleware orders, standalone operation, forget, and
+ *   rollback. Return the complete implementation and tests.
+ */
+
+export { schedulerLeechMiddleware } from './middleware.js'
+export {
+  DEFAULT_LEECH_THRESHOLD,
+  type LeechCardFields,
+  type LeechConfig,
+  type LeechConfigInput,
+  leechCardFieldsSchema,
+  leechConfigSchema,
+} from './schema.js'

--- a/packages/fsrs/src/middlewares/leech/middleware.spec.ts
+++ b/packages/fsrs/src/middlewares/leech/middleware.spec.ts
@@ -1,0 +1,290 @@
+import {
+  defineMiddleware,
+  defineScheduler,
+  Rating,
+  schedulerStatsMiddleware,
+} from '@open-spaced-repetition/srs-kit'
+import { dateChrono } from '@open-spaced-repetition/srs-kit/chrono/date'
+import { describe, expect, it } from 'vitest'
+import { FSRS6_DEFAULT_WEIGHTS } from '../../models/fsrs-6/constants.js'
+import { FSRS6Model } from '../../models/fsrs-6/model.js'
+import { schedulerLearningStepsMiddleware } from '../learning-steps/middleware.js'
+import { schedulerLeechMiddleware } from './middleware.js'
+import { leechCardFieldsSchema } from './schema.js'
+
+const now = new Date('2026-01-01T00:00:00.000Z')
+const later = new Date('2026-01-10T00:00:00.000Z')
+const modelConfig = {
+  weights: [...FSRS6_DEFAULT_WEIGHTS],
+  enableShortTerm: false,
+  numRelearningSteps: 0,
+}
+
+function createLeechCore(leechThreshold = 8) {
+  return defineScheduler({ model: FSRS6Model, chrono: dateChrono })
+    .use(schedulerLeechMiddleware)
+    .create({ config: { ...modelConfig, leechThreshold } })
+}
+
+function createReviewCard(core: ReturnType<typeof createLeechCore>) {
+  return core.review({
+    card: core.newCard({ now }),
+    grade: Rating.Good,
+    now,
+  }).card
+}
+
+describe('schedulerLeechMiddleware review', () => {
+  it('defaults new cards to zero lapses without stats middleware', () => {
+    const scheduler = defineScheduler({
+      model: FSRS6Model,
+      chrono: dateChrono,
+    }).use(schedulerLeechMiddleware)
+    const core = scheduler.create({ config: modelConfig })
+
+    expect(core.newCard({ now }).lapses).toBe(0)
+    expect(core.config.leechThreshold).toBe(0)
+    expect(scheduler.schema.scheduleStatus.parse('suspend')).toBe('suspend')
+  })
+
+  it.each([
+    [7, 8],
+    [15, 16],
+  ] as const)('suspends a review card at lapse multiple %s -> %s', (before, after) => {
+    const core = createLeechCore()
+    const card = { ...createReviewCard(core), lapses: before }
+
+    const result = core.review({ card, grade: Rating.Again, now: later })
+
+    expect(result.card.lapses).toBe(after)
+    expect(result.card.scheduleStatus).toBe('suspend')
+  })
+
+  it('does not suspend before the next threshold multiple', () => {
+    const core = createLeechCore()
+    const card = { ...createReviewCard(core), lapses: 8 }
+
+    const result = core.review({ card, grade: Rating.Again, now: later })
+
+    expect(result.card.lapses).toBe(9)
+    expect(result.card.scheduleStatus).toBe('review')
+  })
+
+  it('disables suspension at threshold zero while still tracking lapses', () => {
+    const core = createLeechCore(0)
+    const card = { ...createReviewCard(core), lapses: 7 }
+
+    const result = core.review({ card, grade: Rating.Again, now: later })
+
+    expect(result.card.lapses).toBe(8)
+    expect(result.card.scheduleStatus).toBe('review')
+  })
+
+  it('does not suspend when the current review is not a lapse', () => {
+    const core = createLeechCore()
+    const card = { ...createReviewCard(core), lapses: 8 }
+
+    const result = core.review({ card, grade: Rating.Good, now: later })
+
+    expect(result.card.lapses).toBe(8)
+    expect(result.card.scheduleStatus).toBe('review')
+  })
+
+  it('does not count Again outside the Review state as a lapse', () => {
+    const core = createLeechCore(1)
+
+    const result = core.review({
+      card: core.newCard({ now }),
+      grade: Rating.Again,
+      now,
+    })
+
+    expect(result.card.lapses).toBe(0)
+    expect(result.card.scheduleStatus).toBe('review')
+  })
+
+  it('only suspends the Again preview at the next threshold', () => {
+    const core = createLeechCore()
+    const card = { ...createReviewCard(core), lapses: 7 }
+    const preview = Array.from(core.preview({ card, now: later }))
+
+    expect(preview.map(({ card }) => card.lapses)).toEqual([8, 7, 7, 7])
+    expect(preview.map(({ card }) => card.scheduleStatus)).toEqual([
+      'suspend',
+      'review',
+      'review',
+      'review',
+    ])
+  })
+
+  it('is independent of stats middleware registration order', () => {
+    const config = { ...modelConfig, leechThreshold: 8 }
+    const leechFirst = defineScheduler({
+      model: FSRS6Model,
+      chrono: dateChrono,
+    })
+      .use(schedulerLeechMiddleware, schedulerStatsMiddleware)
+      .create({ config })
+    const statsFirst = defineScheduler({
+      model: FSRS6Model,
+      chrono: dateChrono,
+    })
+      .use(schedulerStatsMiddleware, schedulerLeechMiddleware)
+      .create({ config })
+    const leechFirstCard = {
+      ...leechFirst.review({
+        card: leechFirst.newCard({ now }),
+        grade: Rating.Good,
+        now,
+      }).card,
+      lapses: 7,
+    }
+    const statsFirstCard = {
+      ...statsFirst.review({
+        card: statsFirst.newCard({ now }),
+        grade: Rating.Good,
+        now,
+      }).card,
+      lapses: 7,
+    }
+
+    const leechFirstResult = leechFirst.review({
+      card: leechFirstCard,
+      grade: Rating.Again,
+      now: later,
+    })
+    const statsFirstResult = statsFirst.review({
+      card: statsFirstCard,
+      grade: Rating.Again,
+      now: later,
+    })
+
+    expect({
+      lapses: leechFirstResult.card.lapses,
+      scheduleStatus: leechFirstResult.card.scheduleStatus,
+    }).toEqual({ lapses: 8, scheduleStatus: 'suspend' })
+    expect({
+      lapses: statsFirstResult.card.lapses,
+      scheduleStatus: statsFirstResult.card.scheduleStatus,
+    }).toEqual({ lapses: 8, scheduleStatus: 'suspend' })
+  })
+
+  it('uses lapses already assigned by an earlier middleware', () => {
+    const assignedLapsesMiddleware = defineMiddleware({
+      name: 'test.assigned-lapses',
+      schema: { card: leechCardFieldsSchema },
+      handlers: {
+        review(ctx, next) {
+          ctx.result.card.lapses = 16
+          next()
+        },
+      },
+    })
+    const core = defineScheduler({ model: FSRS6Model, chrono: dateChrono })
+      .use(assignedLapsesMiddleware, schedulerLeechMiddleware)
+      .create({ config: { ...modelConfig, leechThreshold: 8 } })
+    const card = {
+      ...core.review({
+        card: core.newCard({ now }),
+        grade: Rating.Good,
+        now,
+      }).card,
+      lapses: 7,
+    }
+
+    const result = core.review({ card, grade: Rating.Again, now: later })
+
+    expect(result.card.lapses).toBe(16)
+    expect(result.card.scheduleStatus).toBe('suspend')
+  })
+
+  it('overrides learning steps when registered before them', () => {
+    const core = defineScheduler({ model: FSRS6Model, chrono: dateChrono })
+      .use(
+        schedulerLeechMiddleware,
+        schedulerLearningStepsMiddleware,
+        schedulerStatsMiddleware
+      )
+      .create({
+        config: {
+          ...modelConfig,
+          enableShortTerm: true,
+          numRelearningSteps: 1,
+          learningSteps: ['1m', '10m'],
+          relearningSteps: ['10m'],
+          leechThreshold: 1,
+        },
+      })
+    const reviewed = core.review({
+      card: core.newCard({ now }),
+      grade: Rating.Easy,
+      now,
+    }).card
+
+    const result = core.review({
+      card: reviewed,
+      grade: Rating.Again,
+      now: later,
+    })
+
+    expect(result.card.lapses).toBe(1)
+    expect(result.card.scheduleStatus).toBe('suspend')
+  })
+})
+
+describe('schedulerLeechMiddleware lifecycle', () => {
+  it('restores lapses and schedule status during rollback without stats', () => {
+    const core = createLeechCore()
+    const card = { ...createReviewCard(core), lapses: 7 }
+    const reviewed = core.review({ card, grade: Rating.Again, now: later })
+
+    const restored = core.rollback(reviewed)
+
+    expect(restored.lapses).toBe(7)
+    expect(restored.scheduleStatus).toBe('review')
+  })
+
+  it('keeps lapses when rolling back a non-lapse review', () => {
+    const core = createLeechCore()
+    const card = { ...createReviewCard(core), lapses: 7 }
+    const reviewed = core.review({ card, grade: Rating.Good, now: later })
+
+    expect(core.rollback(reviewed).lapses).toBe(7)
+  })
+
+  it('clears lapses on forget by default', () => {
+    const core = createLeechCore()
+    const card = { ...createReviewCard(core), lapses: 7 }
+
+    expect(core.forget({ card, now: later }).lapses).toBe(0)
+  })
+
+  it('preserves lapses with stats regardless of registration order', () => {
+    const config = {
+      ...modelConfig,
+      leechThreshold: 8,
+      clearStatsOnForget: false,
+    }
+    const leechFirst = defineScheduler({
+      model: FSRS6Model,
+      chrono: dateChrono,
+    })
+      .use(schedulerLeechMiddleware, schedulerStatsMiddleware)
+      .create({ config })
+    const statsFirst = defineScheduler({
+      model: FSRS6Model,
+      chrono: dateChrono,
+    })
+      .use(schedulerStatsMiddleware, schedulerLeechMiddleware)
+      .create({ config })
+    const leechFirstCard = { ...leechFirst.newCard({ now }), lapses: 7 }
+    const statsFirstCard = { ...statsFirst.newCard({ now }), lapses: 7 }
+
+    expect(leechFirst.forget({ card: leechFirstCard, now: later }).lapses).toBe(
+      7
+    )
+    expect(statsFirst.forget({ card: statsFirstCard, now: later }).lapses).toBe(
+      7
+    )
+  })
+})

--- a/packages/fsrs/src/middlewares/leech/middleware.ts
+++ b/packages/fsrs/src/middlewares/leech/middleware.ts
@@ -1,0 +1,51 @@
+import {
+  defineMiddleware,
+  Rating,
+  State,
+} from '@open-spaced-repetition/srs-kit'
+import { leechCardFieldsSchema, leechConfigSchema } from './schema.js'
+
+/** Register before middleware that writes scheduleStatus after next(). */
+export const schedulerLeechMiddleware = defineMiddleware({
+  name: Symbol('ts-fsrs.leech'),
+  scheduleStatus: ['suspend'],
+  schema: {
+    config: leechConfigSchema,
+    card: leechCardFieldsSchema,
+  },
+  defaultValue: {
+    card(ctx) {
+      return {
+        lapses:
+          ctx.operation === 'forget' && ctx.config.clearStatsOnForget === false
+            ? ctx.input.lapses
+            : 0,
+      }
+    },
+  },
+  handlers: {
+    review(ctx, next) {
+      next()
+      const card = ctx.input.card
+      const previousState = card.state
+      const isLapse =
+        previousState === State.Review && ctx.input.grade === Rating.Again
+
+      ctx.result.card.lapses ??= isLapse ? card.lapses + 1 : card.lapses
+      const { lapses } = ctx.result.card
+      const { leechThreshold } = ctx.config
+      if (isLapse && leechThreshold > 0 && lapses % leechThreshold === 0) {
+        ctx.result.card.scheduleStatus = 'suspend'
+      }
+    },
+
+    rollback(ctx, next) {
+      next()
+      const card = ctx.input.card
+      const revlog = ctx.input.revlog
+      const isLapse =
+        revlog.rating === Rating.Again && revlog.state === State.Review
+      ctx.result.card.lapses ??= Math.max(0, card.lapses - (isLapse ? 1 : 0))
+    },
+  },
+})

--- a/packages/fsrs/src/middlewares/leech/schema.spec.ts
+++ b/packages/fsrs/src/middlewares/leech/schema.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { leechCardFieldsSchema, leechConfigSchema } from './schema.js'
+
+describe('leechConfigSchema', () => {
+  it('defaults leechThreshold to disabled', () => {
+    expect(leechConfigSchema.parse({})).toEqual({ leechThreshold: 0 })
+  })
+
+  it.each([0, 1, 8])('accepts leechThreshold %s', (leechThreshold) => {
+    expect(leechConfigSchema.parse({ leechThreshold })).toEqual({
+      leechThreshold,
+    })
+  })
+
+  it.each([
+    null,
+    { leechThreshold: -1 },
+    { leechThreshold: 1.5 },
+    { leechThreshold: Number.NaN },
+    { leechThreshold: Number.POSITIVE_INFINITY },
+    { leechThreshold: '8' },
+  ])('rejects invalid config %#', (value) => {
+    expect(() => leechConfigSchema.parse(value)).toThrow()
+  })
+})
+
+describe('leechCardFieldsSchema', () => {
+  it('parses non-negative integer lapses', () => {
+    expect(leechCardFieldsSchema.parse({ lapses: 0 })).toEqual({ lapses: 0 })
+    expect(leechCardFieldsSchema.parse({ lapses: 8 })).toEqual({ lapses: 8 })
+  })
+
+  it.each([
+    null,
+    {},
+    { lapses: -1 },
+    { lapses: 1.5 },
+    { lapses: Number.NaN },
+    { lapses: Number.POSITIVE_INFINITY },
+    { lapses: '1' },
+  ])('rejects invalid lapses %#', (value) => {
+    expect(() => leechCardFieldsSchema.parse(value)).toThrow()
+  })
+})

--- a/packages/fsrs/src/middlewares/leech/schema.ts
+++ b/packages/fsrs/src/middlewares/leech/schema.ts
@@ -1,0 +1,52 @@
+import { defineSchema, isObject } from '@open-spaced-repetition/srs-kit'
+
+export type LeechConfigInput = {
+  readonly leechThreshold?: number
+}
+
+export type LeechConfig = {
+  readonly leechThreshold: number
+}
+
+export type LeechCardFields = {
+  readonly lapses: number
+}
+
+export const DEFAULT_LEECH_THRESHOLD = 0
+
+export const leechConfigSchema = defineSchema<LeechConfigInput, LeechConfig>(
+  (value) => {
+    if (!isObject(value)) {
+      return { issues: [{ message: 'Expected leech config object' }] }
+    }
+
+    const leechThreshold =
+      value.leechThreshold === undefined
+        ? DEFAULT_LEECH_THRESHOLD
+        : value.leechThreshold
+    if (
+      typeof leechThreshold !== 'number' ||
+      !Number.isInteger(leechThreshold) ||
+      leechThreshold < 0
+    ) {
+      return {
+        issues: [{ message: 'Expected non-negative integer leechThreshold' }],
+      }
+    }
+
+    return { value: { leechThreshold } }
+  }
+)
+
+export const leechCardFieldsSchema = defineSchema<LeechCardFields>((value) => {
+  if (!isObject(value)) {
+    return { issues: [{ message: 'Expected leech card fields' }] }
+  }
+
+  const { lapses } = value
+  if (typeof lapses !== 'number' || !Number.isInteger(lapses) || lapses < 0) {
+    return { issues: [{ message: 'Expected non-negative integer lapses' }] }
+  }
+
+  return { value: { lapses } }
+})


### PR DESCRIPTION
## Summary

- add a configurable leech scheduler middleware with a disabled-by-default `leechThreshold`
- suspend Review cards on current Again lapses when the resulting lapse count is an exact positive threshold multiple
- preserve correct lapse accounting with the stats middleware in either order, plus standalone review, forget, and rollback behavior
- add focused tests, a benchmark, a changeset, and a standalone reproduction prompt

## Reviewer focus

@Luc-Mcgrady This PR was written entirely by Codex 5.6 Sol Ultra. Please review only the core logic in `packages/fsrs/src/middlewares/leech/middleware.ts`, specifically the `review` and `rollback` handlers.

## Validation

- `pnpm --filter ts-fsrs test:coverage`
- `pnpm --filter ts-fsrs check`
- `pnpm --filter ts-fsrs typecheck`
- `pnpm --filter ts-fsrs build`
- `pnpm --filter ts-fsrs bench -- bench/leech.bench.ts`