### PR TITLE
feat(kit): finalize scheduler chrono after middleware

### DIFF
--- a/.changeset/srs-kit-scheduler-finalization.md
+++ b/.changeset/srs-kit-scheduler-finalization.md
@@ -1,0 +1,5 @@
+---
+"@open-spaced-repetition/srs-kit": patch
+---
+
+feat(kit): apply chrono defaults after middleware handlers.

--- a/packages/srs-kit/src/scheduler/base.spec.ts
+++ b/packages/srs-kit/src/scheduler/base.spec.ts
@@ -707,6 +707,103 @@ describe('SchedulerCore.review', () => {
 })
 
 describe('SchedulerCore middleware handlers', () => {
+  it('applies review and preview chrono defaults after middleware unwinds', () => {
+    const seen: unknown[] = []
+    const middleware = defineMiddleware({
+      name: Symbol('review-chrono-order'),
+      handlers: {
+        review(ctx, next) {
+          next()
+          seen.push(structuredClone(ctx.result.card))
+          ctx.scheduledDays = 5
+        },
+      },
+    })
+    const dateCore = defineScheduler({
+      model: SM2Model,
+      chrono: dateChrono,
+    })
+      .use(middleware)
+      .create({ config })
+    const createdAt = new Date('2026-01-01T00:00:00.000Z')
+    const reviewedAt = new Date('2026-01-02T00:00:00.000Z')
+    const card = dateCore.newCard({ now: createdAt })
+
+    const result = dateCore.review({
+      card,
+      grade: Rating.Good,
+      now: reviewedAt,
+    })
+    const preview = Array.from(dateCore.preview({ card, now: reviewedAt }))
+
+    expect(seen).toHaveLength(5)
+    for (const draft of seen) expect(draft).not.toHaveProperty('dueAt')
+    expect(result.card.dueAt).toEqual(new Date('2026-01-07T00:00:00.000Z'))
+    expect(preview.map((item) => item.card.dueAt)).toEqual([
+      new Date('2026-01-07T00:00:00.000Z'),
+      new Date('2026-01-07T00:00:00.000Z'),
+      new Date('2026-01-07T00:00:00.000Z'),
+      new Date('2026-01-07T00:00:00.000Z'),
+    ])
+  })
+
+  it('requires short-circuiting review middleware to provide scheduledDays', () => {
+    const middleware = defineMiddleware({
+      name: Symbol('review-chrono-short-circuit'),
+      handlers: {
+        review() {},
+      },
+    })
+    const dateCore = defineScheduler({
+      model: SM2Model,
+      chrono: dateChrono,
+    })
+      .use(middleware)
+      .create({ config })
+    const now = new Date('2026-01-01T00:00:00.000Z')
+    const card = dateCore.newCard({ now })
+
+    expect(() => dateCore.review({ card, grade: Rating.Good, now })).toThrow(
+      'Expected scheduledDays after review middleware'
+    )
+    expect(() => Array.from(dateCore.preview({ card, now }))).toThrow(
+      'Expected scheduledDays after review middleware'
+    )
+  })
+
+  it('applies rollback chrono defaults after middleware unwinds', () => {
+    const seen: unknown[] = []
+    const middleware = defineMiddleware({
+      name: Symbol('rollback-chrono-order'),
+      handlers: {
+        rollback(ctx, next) {
+          next()
+          seen.push(structuredClone(ctx.result.card))
+        },
+      },
+    })
+    const dateCore = defineScheduler({
+      model: SM2Model,
+      chrono: dateChrono,
+    })
+      .use(middleware)
+      .create({ config })
+    const card = dateCore.newCard({
+      now: new Date('2026-01-01T00:00:00.000Z'),
+    })
+    const reviewed = dateCore.review({
+      card,
+      grade: Rating.Good,
+      now: new Date('2026-01-02T00:00:00.000Z'),
+    })
+
+    const restored = dateCore.rollback(reviewed)
+
+    expect(seen[0]).not.toHaveProperty('dueAt')
+    expect(restored.dueAt).toEqual(reviewed.revlog.reviewTime)
+    expect(restored.lastReviewAt).toEqual(reviewed.revlog.dueAt)
+  })
+
   it('throws when review middleware mutates input fields', () => {
     const card = core.newCard({ now: 0 })
 

--- a/packages/srs-kit/src/scheduler/base.ts
+++ b/packages/srs-kit/src/scheduler/base.ts
@@ -252,6 +252,7 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
     composeMiddleware(this.reviewHandlers, ctx, (ctx) =>
       this.finalizeReview(prepared, ctx)
     )
+    this.applyReviewChronoDefaults(prepared, ctx)
     return {
       card: parse(
         this.schema.card,
@@ -288,6 +289,7 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
       composeMiddleware(this.reviewHandlers, ctx, (ctx) =>
         this.finalizeReview(prepared, ctx)
       )
+      this.applyReviewChronoDefaults(prepared, ctx)
       return {
         grade,
         card: parse(
@@ -328,6 +330,7 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
     composeMiddleware(this.rollbackHandlers, ctx, (ctx) =>
       this.finalizeRollback(ctx)
     )
+    this.applyRollbackChronoDefaults(ctx.result, revlog)
 
     return parse(
       this.schema.card,
@@ -422,7 +425,6 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
       newMemoryState,
       ctx.desiredRetention
     )
-    const scheduledDays = ctx.scheduledDays
 
     Object.assign(result.card, newMemoryState, {
       state: State.Review,
@@ -433,8 +435,6 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
       state: prepared.card.state,
       scheduleStatus: prepared.card.scheduleStatus,
     })
-    this.applyChronoDefaults(result, prepared, scheduledDays)
-
     return result
   }
 
@@ -447,9 +447,18 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
     Object.assign(result.card, parse(this.model.schema.memoryState, revlog))
     result.card.state = revlog.state
     result.card.scheduleStatus = revlog.scheduleStatus
-    this.applyRollbackChronoDefaults(result, revlog)
 
     return result.card
+  }
+
+  private applyReviewChronoDefaults(
+    prepared: PreparedReview<Env>,
+    ctx: ReviewMiddlewareOperationContext<Env>
+  ): void {
+    if (ctx.scheduledDays === undefined) {
+      throw new Error('Expected scheduledDays after review middleware')
+    }
+    this.applyChronoDefaults(ctx.result, prepared, ctx.scheduledDays)
   }
 
   private applyChronoDefaults(


### PR DESCRIPTION
## Summary

- Apply review and rollback chrono defaults after middleware handlers unwind.
- Ensure review and preview due dates use the final `scheduledDays` value.
- Add regression coverage for middleware ordering and short-circuit behavior.

## Validation

- `pnpm test`
- `pnpm check`
- `pnpm build`
