### PR TITLE
feat(middleware): add scheduled days middleware

### DIFF
--- a/.changeset/scheduled-days-middleware-fields.md
+++ b/.changeset/scheduled-days-middleware-fields.md
@@ -1,0 +1,5 @@
+---
+'ts-fsrs': patch
+---
+
+feat(middleware): add scheduled days middleware.

--- a/packages/fsrs/src/middlewares/index.ts
+++ b/packages/fsrs/src/middlewares/index.ts
@@ -1,3 +1,4 @@
 export * from './fuzzing/index.js'
 export * from './learning-steps/index.js'
 export * from './monotonic-interval/index.js'
+export * from './scheduled-days/index.js'

--- a/packages/fsrs/src/middlewares/learning-steps/middleware.spec.ts
+++ b/packages/fsrs/src/middlewares/learning-steps/middleware.spec.ts
@@ -156,8 +156,13 @@ describe('schedulerLearningStepsMiddleware integration', () => {
     )
   })
 
-  it('keeps the raw threshold but rounds decimal minutes for chrono', () => {
-    const core = createCore({ learningSteps: ['1439.6m'] })
+  it.each([
+    ['0.6m', State.Learning, 'learning', 1],
+    ['1439.4m', State.Learning, 'learning', 1439],
+    ['1439.6m', State.Review, 'review', 1440],
+    ['1440m', State.Review, 'review', 1440],
+  ] as const)('rounds %s before applying the day threshold', (step, state, scheduleStatus, scheduledMinutes) => {
+    const core = createCore({ learningSteps: [step] })
     const now = new Date(2022, 11, 29, 12, 30)
     const result = core.review({
       card: core.newCard({ now }),
@@ -165,9 +170,11 @@ describe('schedulerLearningStepsMiddleware integration', () => {
       now,
     })
 
-    expect(result.card.state).toBe(State.Learning)
-    expect(result.card.scheduleStatus).toBe('learning')
-    expect(result.card.dueAt.getTime() - now.getTime()).toBe(1440 * 60_000)
+    expect(result.card.state).toBe(state)
+    expect(result.card.scheduleStatus).toBe(scheduleStatus)
+    expect(result.card.dueAt.getTime() - now.getTime()).toBe(
+      scheduledMinutes * 60_000
+    )
   })
 
   it('graduates long learning delays while preserving the exact due time', () => {
@@ -185,8 +192,11 @@ describe('schedulerLearningStepsMiddleware integration', () => {
     expect(result.card.dueAt.getTime() - now.getTime()).toBe(2160 * 60_000)
   })
 
-  it('falls back to the model interval for a zero-minute step', () => {
-    const core = createCore({ learningSteps: ['0m'] })
+  it.each([
+    '0m',
+    '0.4m',
+  ] as const)('falls back to the model interval when %s rounds to zero minutes', (step) => {
+    const core = createCore({ learningSteps: [step] })
     const now = new Date(2022, 11, 29, 12, 30)
     const result = core.review({
       card: core.newCard({ now }),

--- a/packages/fsrs/src/middlewares/learning-steps/middleware.ts
+++ b/packages/fsrs/src/middlewares/learning-steps/middleware.ts
@@ -52,13 +52,13 @@ export const schedulerLearningStepsMiddleware = defineMiddleware({
       }
       const step = steps[ctx.input.grade]
       const scheduledMinutes = step
-        ? Math.max(0, step.scheduledMinutes)
+        ? Math.round(Math.max(0, step.scheduledMinutes))
         : undefined
 
       next()
 
       if (scheduledMinutes !== undefined && scheduledMinutes > 0) {
-        ctx.scheduledDays = Math.round(scheduledMinutes) / MINUTES_PER_DAY
+        ctx.scheduledDays = scheduledMinutes / MINUTES_PER_DAY
       }
 
       ctx.result.revlog.learningStep = card.learningStep

--- a/packages/fsrs/src/middlewares/scheduled-days/index.ts
+++ b/packages/fsrs/src/middlewares/scheduled-days/index.ts
@@ -1,0 +1,5 @@
+export { schedulerScheduledDaysMiddleware } from './middleware.js'
+export {
+  type ScheduledDaysFields,
+  scheduledDaysFieldsSchema,
+} from './schema.js'

--- a/packages/fsrs/src/middlewares/scheduled-days/middleware.spec.ts
+++ b/packages/fsrs/src/middlewares/scheduled-days/middleware.spec.ts
@@ -1,0 +1,102 @@
+import {
+  defineMiddleware,
+  defineScheduler,
+  Rating,
+} from '@open-spaced-repetition/srs-kit'
+import { dateChrono } from '@open-spaced-repetition/srs-kit/chrono/date'
+import { describe, expect, it } from 'vitest'
+import { FSRS6_DEFAULT_WEIGHTS } from '../../models/fsrs-6/constants.js'
+import { FSRS6Model } from '../../models/fsrs-6/model.js'
+import { schedulerScheduledDaysMiddleware } from './middleware.js'
+
+const now = new Date('2026-01-01T00:00:00.000Z')
+
+function createCore(scheduledDays = 2.9) {
+  const fixedIntervalMiddleware = defineMiddleware({
+    name: 'test.scheduled-days.interval',
+    handlers: {
+      review(ctx, next) {
+        ctx.scheduledDays = scheduledDays
+        next()
+      },
+    },
+  })
+
+  return defineScheduler({ model: FSRS6Model, chrono: dateChrono })
+    .use(fixedIntervalMiddleware, schedulerScheduledDaysMiddleware)
+    .create({
+      config: {
+        weights: [...FSRS6_DEFAULT_WEIGHTS],
+        enableShortTerm: false,
+        numRelearningSteps: 0,
+      },
+    })
+}
+
+describe('schedulerScheduledDaysMiddleware', () => {
+  it('defaults a new card scheduledDays to zero', () => {
+    expect(createCore().newCard({ now }).scheduledDays).toBe(0)
+  })
+
+  it('stores the floored scheduled interval and logs the input interval', () => {
+    const core = createCore()
+    const card = { ...core.newCard({ now }), scheduledDays: 7.5 }
+
+    const result = core.review({ card, grade: Rating.Easy, now })
+
+    expect(result.card.scheduledDays).toBe(2)
+    expect(result.revlog.scheduledDays).toBe(7.5)
+  })
+
+  it('stores an interval selected by a later middleware during unwind', () => {
+    const intervalMiddleware = defineMiddleware({
+      name: 'test.scheduled-days.post-interval',
+      handlers: {
+        review(ctx, next) {
+          next()
+          ctx.scheduledDays = 4.9
+        },
+      },
+    })
+    const core = defineScheduler({ model: FSRS6Model, chrono: dateChrono })
+      .use(schedulerScheduledDaysMiddleware, intervalMiddleware)
+      .create({
+        config: {
+          weights: [...FSRS6_DEFAULT_WEIGHTS],
+          enableShortTerm: false,
+          numRelearningSteps: 0,
+        },
+      })
+
+    const result = core.review({
+      card: core.newCard({ now }),
+      grade: Rating.Good,
+      now,
+    })
+
+    expect(result.card.scheduledDays).toBe(4)
+    expect(result.card.dueAt.getTime() - now.getTime()).toBe(
+      Math.trunc(4.9 * 24 * 60 * 60 * 1000)
+    )
+  })
+
+  it('clamps a negative scheduled interval to zero', () => {
+    const core = createCore(-1.2)
+    const result = core.review({
+      card: core.newCard({ now }),
+      grade: Rating.Again,
+      now,
+    })
+
+    expect(result.card.scheduledDays).toBe(0)
+  })
+
+  it('restores scheduledDays during rollback', () => {
+    const core = createCore()
+    const card = { ...core.newCard({ now }), scheduledDays: -1.5 }
+    const result = core.review({ card, grade: Rating.Easy, now })
+
+    expect(result.revlog.scheduledDays).toBe(-1.5)
+    expect(core.rollback(result).scheduledDays).toBe(-1.5)
+  })
+})

--- a/packages/fsrs/src/middlewares/scheduled-days/middleware.spec.ts
+++ b/packages/fsrs/src/middlewares/scheduled-days/middleware.spec.ts
@@ -2,11 +2,13 @@ import {
   defineMiddleware,
   defineScheduler,
   Rating,
+  State,
 } from '@open-spaced-repetition/srs-kit'
 import { dateChrono } from '@open-spaced-repetition/srs-kit/chrono/date'
 import { describe, expect, it } from 'vitest'
 import { FSRS6_DEFAULT_WEIGHTS } from '../../models/fsrs-6/constants.js'
 import { FSRS6Model } from '../../models/fsrs-6/model.js'
+import { schedulerLearningStepsMiddleware } from '../learning-steps/middleware.js'
 import { schedulerScheduledDaysMiddleware } from './middleware.js'
 
 const now = new Date('2026-01-01T00:00:00.000Z')
@@ -89,6 +91,30 @@ describe('schedulerScheduledDaysMiddleware', () => {
     })
 
     expect(result.card.scheduledDays).toBe(0)
+  })
+
+  it('stores a rounded learning interval at the day threshold', () => {
+    const core = defineScheduler({ model: FSRS6Model, chrono: dateChrono })
+      .use(schedulerScheduledDaysMiddleware, schedulerLearningStepsMiddleware)
+      .create({
+        config: {
+          weights: [...FSRS6_DEFAULT_WEIGHTS],
+          enableShortTerm: true,
+          numRelearningSteps: 0,
+          learningSteps: ['1439.6m'],
+          relearningSteps: [],
+        },
+      })
+
+    const result = core.review({
+      card: core.newCard({ now }),
+      grade: Rating.Again,
+      now,
+    })
+
+    expect(result.card.state).toBe(State.Review)
+    expect(result.card.scheduledDays).toBe(1)
+    expect(result.card.dueAt.getTime() - now.getTime()).toBe(1440 * 60_000)
   })
 
   it('restores scheduledDays during rollback', () => {

--- a/packages/fsrs/src/middlewares/scheduled-days/middleware.ts
+++ b/packages/fsrs/src/middlewares/scheduled-days/middleware.ts
@@ -1,0 +1,33 @@
+import { defineMiddleware } from '@open-spaced-repetition/srs-kit'
+import { scheduledDaysFieldsSchema } from './schema.js'
+
+/** Register before interval middleware so it records their final value on unwind. */
+export const schedulerScheduledDaysMiddleware = defineMiddleware({
+  name: Symbol('ts-fsrs.scheduled-days'),
+  schema: {
+    card: scheduledDaysFieldsSchema,
+    revlog: scheduledDaysFieldsSchema,
+  },
+  defaultValue: {
+    card() {
+      return { scheduledDays: 0 }
+    },
+  },
+  handlers: {
+    review(ctx, next) {
+      const previousScheduledDays = ctx.input.card.scheduledDays
+      next()
+
+      ctx.result.card.scheduledDays = Math.max(
+        0,
+        Math.floor(ctx.scheduledDays ?? 0)
+      )
+      ctx.result.revlog.scheduledDays = previousScheduledDays
+    },
+
+    rollback(ctx, next) {
+      next()
+      ctx.result.card.scheduledDays = ctx.input.revlog.scheduledDays
+    },
+  },
+})

--- a/packages/fsrs/src/middlewares/scheduled-days/schema.spec.ts
+++ b/packages/fsrs/src/middlewares/scheduled-days/schema.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { scheduledDaysFieldsSchema } from './schema.js'
+
+describe('scheduledDaysFieldsSchema', () => {
+  it.each([
+    0, 12, 1.5, -1,
+  ])('accepts finite scheduledDays %s', (scheduledDays) => {
+    expect(scheduledDaysFieldsSchema.parse({ scheduledDays })).toEqual({
+      scheduledDays,
+    })
+  })
+
+  it.each([
+    null,
+    {},
+    { scheduledDays: '1' },
+    { scheduledDays: Number.NaN },
+    { scheduledDays: Number.POSITIVE_INFINITY },
+  ])('rejects invalid scheduledDays %#', (value) => {
+    expect(() => scheduledDaysFieldsSchema.parse(value)).toThrow(
+      'Expected finite scheduledDays'
+    )
+  })
+})

--- a/packages/fsrs/src/middlewares/scheduled-days/schema.ts
+++ b/packages/fsrs/src/middlewares/scheduled-days/schema.ts
@@ -1,0 +1,21 @@
+import { defineSchema, isObject } from '@open-spaced-repetition/srs-kit'
+
+export type ScheduledDaysFields = {
+  readonly scheduledDays: number
+}
+
+export const scheduledDaysFieldsSchema = defineSchema<ScheduledDaysFields>(
+  (value) => {
+    if (
+      !isObject(value) ||
+      typeof value.scheduledDays !== 'number' ||
+      !Number.isFinite(value.scheduledDays)
+    ) {
+      return {
+        issues: [{ message: 'Expected finite scheduledDays' }],
+      }
+    }
+
+    return { value: { scheduledDays: value.scheduledDays } }
+  }
+)


### PR DESCRIPTION
## Summary

- Add `scheduledDays` card and revlog schemas plus scheduler middleware.
- Store floored next intervals, log the previous interval, and restore it on rollback.
- Export the middleware from the middleware index.

Depends on #413.

## Validation

Validated with #413 applied:

- 14 focused tests
- 372 package tests passed, 1 skipped
- `pnpm typecheck`
- `pnpm build`
- Biome check
