### PR TITLE
feat(middleware): optimize learning step scheduling

### DIFF
--- a/.changeset/optimize-learning-steps-middleware.md
+++ b/.changeset/optimize-learning-steps-middleware.md
@@ -1,0 +1,5 @@
+---
+"ts-fsrs": patch
+---
+
+feat(middleware): optimize learning step scheduling.

--- a/packages/fsrs/src/middlewares/learning-steps/middleware.ts
+++ b/packages/fsrs/src/middlewares/learning-steps/middleware.ts
@@ -1,4 +1,9 @@
-import { defineMiddleware, State } from '@open-spaced-repetition/srs-kit'
+import {
+  defineMiddleware,
+  type ReviewCandidateContext,
+  State,
+} from '@open-spaced-repetition/srs-kit'
+import type { Mutable } from '@open-spaced-repetition/srs-kit/schema'
 import { calculateLearningSteps } from './core.js'
 import {
   learningStepFieldsSchema,
@@ -7,7 +12,11 @@ import {
 import type { LearningStepsResult } from './types.js'
 
 const MINUTES_PER_DAY = 1440
-const resolvedSteps = new WeakMap<object, LearningStepsResult>()
+const resolvedStepsSymbol = Symbol('ts-fsrs.learning-steps.resolved')
+
+type LearningStepsCandidate = ReviewCandidateContext & {
+  [resolvedStepsSymbol]?: LearningStepsResult
+}
 
 export const schedulerLearningStepsMiddleware = defineMiddleware({
   name: Symbol('ts-fsrs.learning-steps'),
@@ -31,25 +40,26 @@ export const schedulerLearningStepsMiddleware = defineMiddleware({
         return
       }
 
-      let steps = resolvedSteps.get(card)
+      const candidate = ctx.candidate as Mutable<LearningStepsCandidate>
+      let steps = candidate[resolvedStepsSymbol]
       if (!steps) {
         steps = calculateLearningSteps(
           ctx.config,
           card.state,
           card.learningStep
         )
-        resolvedSteps.set(card, steps)
+        candidate[resolvedStepsSymbol] = steps
       }
       const step = steps[ctx.input.grade]
       const scheduledMinutes = step
         ? Math.max(0, step.scheduledMinutes)
         : undefined
 
+      next()
+
       if (scheduledMinutes !== undefined && scheduledMinutes > 0) {
         ctx.scheduledDays = Math.round(scheduledMinutes) / MINUTES_PER_DAY
       }
-
-      next()
 
       ctx.result.revlog.learningStep = card.learningStep
       ctx.result.card.learningStep = 0


### PR DESCRIPTION
## Summary

- Cache resolved learning steps on each review candidate instead of a shared `WeakMap`.
- Apply learning-step intervals after downstream middleware completes.
- Preserve existing learning and relearning state transitions.

Depends on #413.

## Validation

Validated with #413 applied:

- 10 focused tests
- 358 package tests passed, 1 skipped
- `pnpm check`
- `pnpm typecheck`
- Learning-steps benchmark
