### PR TITLE
feat(middleware): optimize monotonic interval scheduling

### DIFF
--- a/.changeset/optimize-monotonic-interval-middleware.md
+++ b/.changeset/optimize-monotonic-interval-middleware.md
@@ -1,0 +1,5 @@
+---
+'ts-fsrs': patch
+---
+
+feat(middleware): optimize monotonic interval scheduling.

--- a/packages/fsrs/src/middlewares/monotonic-interval/core.spec.ts
+++ b/packages/fsrs/src/middlewares/monotonic-interval/core.spec.ts
@@ -13,6 +13,12 @@ describe('calculateScheduleDays', () => {
     expect(calculateScheduleDays([2, 4, 8, 16], 100)).toEqual([2, 4, 8, 16])
   })
 
+  it('allows zero-day intervals to remain equal', () => {
+    expect(calculateScheduleDays([0, 0, 2, 3], 100)).toEqual([0, 0, 2, 3])
+    expect(calculateScheduleDays([0, 0, 0, 0], 100)).toEqual([0, 0, 0, 0])
+    expect(calculateScheduleDays([0, 1, 1, 1], 100)).toEqual([0, 1, 2, 3])
+  })
+
   it('allows equal intervals once the maximum is reached', () => {
     expect(calculateScheduleDays([98, 99, 100, 101], 100)).toEqual([
       98, 99, 100, 100,

--- a/packages/fsrs/src/middlewares/monotonic-interval/core.ts
+++ b/packages/fsrs/src/middlewares/monotonic-interval/core.ts
@@ -13,9 +13,10 @@ type ScheduledDays<T extends readonly number[]> = Mutable<{
 /**
  * Keeps rating intervals monotonic after rounding and fuzzing.
  *
- * The first interval is capped at the maximum. Each later interval is kept at
- * least one day after the previous result until the maximum is reached. The
- * input tuple is never mutated.
+ * The first interval is capped at the maximum. Zero-day intervals may remain
+ * equal; after a positive result, each later interval is kept at least one day
+ * after the previous result until the maximum is reached. The input tuple is
+ * never mutated.
  */
 export function calculateScheduleDays<const T extends IntervalCandidates>(
   candidates: T,
@@ -26,17 +27,26 @@ export function calculateScheduleDays<const T extends IntervalCandidates>(
     return [first] as ScheduledDays<T>
   }
 
-  const second = Math.min(Math.max(candidates[1], first + 1), maximumInterval)
+  const second = Math.min(
+    Math.max(candidates[1], first === 0 ? 0 : first + 1),
+    maximumInterval
+  )
   if (candidates.length === 2) {
     return [first, second] as ScheduledDays<T>
   }
 
-  const third = Math.min(Math.max(candidates[2], second + 1), maximumInterval)
+  const third = Math.min(
+    Math.max(candidates[2], second === 0 ? 0 : second + 1),
+    maximumInterval
+  )
   if (candidates.length === 3) {
     return [first, second, third] as ScheduledDays<T>
   }
 
-  const fourth = Math.min(Math.max(candidates[3], third + 1), maximumInterval)
+  const fourth = Math.min(
+    Math.max(candidates[3], third === 0 ? 0 : third + 1),
+    maximumInterval
+  )
   return [first, second, third, fourth] as ScheduledDays<T>
 }
 

--- a/packages/fsrs/src/middlewares/monotonic-interval/middleware.spec.ts
+++ b/packages/fsrs/src/middlewares/monotonic-interval/middleware.spec.ts
@@ -58,8 +58,11 @@ function createReviewContext({
     candidate: { step, nextInterval },
     result: { card: {}, revlog: {} },
   } as unknown as ReviewContext
+  const next = vi.fn(() => {
+    ctx.scheduledDays ??= intervals[grade]
+  })
 
-  return { ctx, nextInterval, step }
+  return { ctx, next, nextInterval, step }
 }
 
 function dueDays(dueAt: Date, reviewTime: Date): number {
@@ -68,23 +71,22 @@ function dueDays(dueAt: Date, reviewTime: Date): number {
 
 describe('schedulerMonotonicIntervalMiddleware handler', () => {
   const longTermIntervals = {
-    [Rating.Again]: 4,
-    [Rating.Hard]: 2,
-    [Rating.Good]: 8,
+    [Rating.Again]: 2,
+    [Rating.Hard]: 4,
+    [Rating.Good]: 3,
     [Rating.Easy]: 7,
   }
 
   it.each([
-    [Rating.Again, 4, [Rating.Again]],
-    [Rating.Hard, 5, [Rating.Again, Rating.Hard]],
-    [Rating.Good, 8, [Rating.Again, Rating.Hard, Rating.Good]],
-    [Rating.Easy, 9, grades],
+    [Rating.Again, 2, []],
+    [Rating.Hard, 4, [Rating.Again]],
+    [Rating.Good, 5, [Rating.Again, Rating.Hard]],
+    [Rating.Easy, 7, [Rating.Again, Rating.Hard, Rating.Good]],
   ] as const)('uses the required long-term candidates for grade %s', (grade, expected, expectedGrades) => {
-    const { ctx, nextInterval, step } = createReviewContext({
+    const { ctx, next, nextInterval, step } = createReviewContext({
       grade,
       intervals: longTermIntervals,
     })
-    const next = vi.fn()
 
     reviewHandler(ctx, next)
 
@@ -97,45 +99,48 @@ describe('schedulerMonotonicIntervalMiddleware handler', () => {
     expect(next).toHaveBeenCalledOnce()
   })
 
-  it('uses the candidate interval resolver for every required grade', () => {
-    const { ctx, step } = createReviewContext({
+  it('normalizes an interval selected by an earlier middleware', () => {
+    const { ctx, next, step } = createReviewContext({
       grade: Rating.Good,
       intervals: longTermIntervals,
       scheduledDays: 2,
     })
 
-    reviewHandler(ctx, vi.fn())
+    reviewHandler(ctx, next)
 
-    expect(ctx.scheduledDays).toBe(8)
+    expect(ctx.scheduledDays).toBe(5)
     expect(step.mock.calls.map(([rating]) => rating)).toEqual([
       Rating.Again,
       Rating.Hard,
-      Rating.Good,
     ])
+    expect(next).toHaveBeenCalledOnce()
   })
 
   it.each([
     State.New,
     State.Learning,
-    State.Relearning,
     State.Review,
-  ])('uses the same rating chain for card state %s', (state) => {
-    const { ctx, step } = createReviewContext({
+    State.Relearning,
+  ])('uses the full rating chain for card state %s', (state) => {
+    const { ctx, next, step } = createReviewContext({
       grade: Rating.Easy,
       intervals: longTermIntervals,
       state,
     })
-    const next = vi.fn()
 
     reviewHandler(ctx, next)
 
-    expect(ctx.scheduledDays).toBe(9)
-    expect(step.mock.calls.map(([rating]) => rating)).toEqual(grades)
+    expect(ctx.scheduledDays).toBe(7)
+    expect(step.mock.calls.map(([rating]) => rating)).toEqual([
+      Rating.Again,
+      Rating.Hard,
+      Rating.Good,
+    ])
     expect(next).toHaveBeenCalledOnce()
   })
 
   it('allows later ratings to share the maximum interval', () => {
-    const { ctx } = createReviewContext({
+    const { ctx, next } = createReviewContext({
       grade: Rating.Easy,
       maximum: 100,
       intervals: {
@@ -146,7 +151,7 @@ describe('schedulerMonotonicIntervalMiddleware handler', () => {
       },
     })
 
-    reviewHandler(ctx, vi.fn())
+    reviewHandler(ctx, next)
 
     expect(ctx.scheduledDays).toBe(100)
   })
@@ -298,8 +303,8 @@ describe('schedulerMonotonicIntervalMiddleware integration', () => {
     const core = defineScheduler({ model: FSRS6Model, chrono: dateChrono })
       .use(
         createSchedulerFuzzingMiddleware({ rng: () => () => 0.5 }),
-        schedulerMonotonicIntervalMiddleware,
-        schedulerLearningStepsMiddleware
+        schedulerLearningStepsMiddleware,
+        schedulerMonotonicIntervalMiddleware
       )
       .create({
         config: {

--- a/packages/fsrs/src/middlewares/monotonic-interval/middleware.ts
+++ b/packages/fsrs/src/middlewares/monotonic-interval/middleware.ts
@@ -6,7 +6,7 @@ import {
 import { calculateScheduleDay, type IntervalCandidates } from './core.js'
 import { monotonicIntervalConfigSchema } from './schema.js'
 
-/** Register after fuzzing, when present, and before learning steps. */
+/** Register after fuzzing and learning steps, when present. */
 export const schedulerMonotonicIntervalMiddleware = defineMiddleware({
   name: Symbol('ts-fsrs.monotonic-interval'),
   schema: {
@@ -23,21 +23,22 @@ export const schedulerMonotonicIntervalMiddleware = defineMiddleware({
       const schedule = (...candidates: IntervalCandidates): number =>
         calculateScheduleDay(candidates, ctx.config.maximumInterval)
 
+      next()
+
+      const scheduledDays = ctx.scheduledDays!
+
       switch (grade) {
         case Rating.Again:
-          ctx.scheduledDays = schedule(interval(Rating.Again))
+          ctx.scheduledDays = schedule(scheduledDays)
           break
         case Rating.Hard:
-          ctx.scheduledDays = schedule(
-            interval(Rating.Again),
-            interval(Rating.Hard)
-          )
+          ctx.scheduledDays = schedule(interval(Rating.Again), scheduledDays)
           break
         case Rating.Good:
           ctx.scheduledDays = schedule(
             interval(Rating.Again),
             interval(Rating.Hard),
-            interval(Rating.Good)
+            scheduledDays
           )
           break
         case Rating.Easy:
@@ -45,12 +46,10 @@ export const schedulerMonotonicIntervalMiddleware = defineMiddleware({
             interval(Rating.Again),
             interval(Rating.Hard),
             interval(Rating.Good),
-            interval(Rating.Easy)
+            scheduledDays
           )
           break
       }
-
-      next()
     },
   },
 })


### PR DESCRIPTION
## Summary

- Apply monotonic normalization after downstream middleware resolves the active rating interval.
- Reuse the resolved `scheduledDays` value instead of recomputing the active grade.
- Allow equal zero-day intervals while keeping positive intervals strictly increasing.

Depends on #413 and #415.

## Validation

Validated with #413 and #415 applied:

- 22 focused tests
- 359 package tests passed, 1 skipped
- `pnpm check`
- `pnpm typecheck`
- `pnpm build`
- Monotonic benchmark
