### PR TITLE
fix(kit): infer schedule status unions in middleware handlers

### DIFF
--- a/.changeset/middleware-handler-schedule-status.md
+++ b/.changeset/middleware-handler-schedule-status.md
@@ -1,0 +1,5 @@
+---
+"@open-spaced-repetition/srs-kit": patch
+---
+
+fix(kit): infer schedule status unions in middleware handlers.

--- a/packages/srs-kit/src/middleware/middleware.ts
+++ b/packages/srs-kit/src/middleware/middleware.ts
@@ -1,6 +1,7 @@
 /** biome-ignore-all lint/suspicious/noExplicitAny: type-level widening for AnyMiddleware */
 
 import type { Grade } from '@/primitives/rating.js'
+import type { ScheduleStatus } from '@/primitives/status.js'
 import type {
   AnyObjectSchema,
   Assign,
@@ -151,6 +152,23 @@ type MiddlewareDefinitionEnv<
   never
 >
 
+type MiddlewareStatusContext<
+  Status extends string,
+  InputKey extends 'card' | 'revlog',
+  ResultKey extends 'card' | 'revlog',
+> = {
+  readonly input: {
+    readonly [Key in InputKey]: {
+      readonly scheduleStatus: ScheduleStatus | Status
+    }
+  }
+  readonly result: {
+    readonly [Key in ResultKey]: {
+      scheduleStatus?: ScheduleStatus | Status
+    }
+  }
+}
+
 type MiddlewareDefinition<
   Schema extends MiddlewareDefinitionSchema,
   Name extends PropertyKey,
@@ -165,10 +183,12 @@ type MiddlewareDefinition<
   >['defaultValue']
   readonly handlers?: {
     readonly review?: MiddlewareHandler<
-      ReviewMiddlewareContext<MiddlewareDefinitionEnv<Schema, Status>>
+      ReviewMiddlewareContext<MiddlewareDefinitionEnv<Schema, Status>> &
+        MiddlewareStatusContext<Status, 'card', 'card' | 'revlog'>
     >
     readonly rollback?: MiddlewareHandler<
-      RollbackMiddlewareContext<MiddlewareDefinitionEnv<Schema, Status>>
+      RollbackMiddlewareContext<MiddlewareDefinitionEnv<Schema, Status>> &
+        MiddlewareStatusContext<Status, 'card' | 'revlog', 'card'>
     >
   }
 }

--- a/packages/srs-kit/src/middleware/middleware.type-display.spec.ts
+++ b/packages/srs-kit/src/middleware/middleware.type-display.spec.ts
@@ -49,6 +49,12 @@ const cardInitInputMiddleware = defineMiddleware({
       return { source: forgetCardHoverTarget.source }
     },
   },
+  handlers: {
+    review(ctx, next) {
+      const defaultReviewStatusHoverTarget = ctx.input.card.scheduleStatus
+      next()
+    },
+  },
 })
 
 const cardInitInputMiddlewareHoverTarget = cardInitInputMiddleware
@@ -73,16 +79,19 @@ const displayMiddleware = defineMiddleware({
   handlers: {
     review(ctx, next) {
       const reviewConfigHoverTarget = ctx.config
-      const reviewCardHoverTarget = ctx.input.card
-      const reviewResultRevlogHoverTarget = ctx.result.revlog
+      const reviewCardSourceHoverTarget = ctx.input.card.source
+      const reviewStatusHoverTarget = ctx.input.card.scheduleStatus
+      const reviewResultAuditHoverTarget = ctx.result.revlog.audit
+      const reviewResultStatusHoverTarget = ctx.result.revlog.scheduleStatus
       next()
       ctx.result.card.source = reviewConfigHoverTarget.source
       ctx.result.revlog.audit = reviewConfigHoverTarget.source
     },
     rollback(ctx, next) {
-      const rollbackRevlogHoverTarget = ctx.input.revlog
+      const rollbackAuditHoverTarget = ctx.input.revlog.audit
+      const rollbackStatusHoverTarget = ctx.input.revlog.scheduleStatus
       next()
-      ctx.result.card.source = rollbackRevlogHoverTarget.audit
+      ctx.result.card.source = rollbackAuditHoverTarget
     },
   },
 })
@@ -120,6 +129,7 @@ describe('middleware type display', () => {
     readonly state: State;
     readonly scheduleStatus: string;
 }`,
+    defaultReviewStatusHoverTarget: `const defaultReviewStatusHoverTarget: "new" | "learning" | "review"`,
     middlewareHoverTarget: `const middlewareHoverTarget: Middleware<typeof displayMiddlewareName, {
     readonly scheduleStatus: "paused";
     readonly config: SRSSchema<{
@@ -189,24 +199,12 @@ describe('middleware type display', () => {
         };
     }>;
 }>`,
-    reviewCardHoverTarget: `const reviewCardHoverTarget: {
-    readonly source: string;
-    readonly state: State;
-    readonly scheduleStatus: string;
-}`,
-    reviewResultRevlogHoverTarget: `const reviewResultRevlogHoverTarget: {
-    [x: string]: unknown;
-    audit?: string | undefined;
-    state?: 0 | 1 | 2 | 3 | undefined;
-    scheduleStatus?: string | undefined;
-    rating?: 1 | 2 | 3 | 4 | undefined;
-}`,
-    rollbackRevlogHoverTarget: `const rollbackRevlogHoverTarget: {
-    readonly audit: string;
-    readonly state: State;
-    readonly scheduleStatus: string;
-    readonly rating: Grade;
-}`,
+    reviewCardSourceHoverTarget: `const reviewCardSourceHoverTarget: string`,
+    reviewStatusHoverTarget: `const reviewStatusHoverTarget: "new" | "learning" | "review" | "paused"`,
+    reviewResultAuditHoverTarget: `const reviewResultAuditHoverTarget: string | undefined`,
+    reviewResultStatusHoverTarget: `const reviewResultStatusHoverTarget: "new" | "learning" | "review" | "paused" | undefined`,
+    rollbackAuditHoverTarget: `const rollbackAuditHoverTarget: string`,
+    rollbackStatusHoverTarget: `const rollbackStatusHoverTarget: "new" | "learning" | "review" | "paused"`,
     scheduleStatusHoverTarget: `const scheduleStatusHoverTarget: readonly "paused"[] | undefined`,
   }
 


### PR DESCRIPTION
## Summary

- Infer built-in and middleware-defined `scheduleStatus` unions in `review` and `rollback` handler contexts.
- Apply narrowed status types to input cards and revlogs, as well as optional result cards and revlogs.
- Preserve middleware-specific fields when composing handler context types.
- Extend type-display coverage for default statuses and custom statuses such as `paused`.
- Add a patch changeset for `@open-spaced-repetition/srs-kit`.

## Motivation

Middleware handler `scheduleStatus` values were previously widened to `string`, which prevented TypeScript from accurately representing standard scheduler statuses together with middleware-defined custom statuses. This change restores precise type inference, autocomplete, and type checking.