### PR TITLE
ci: update preview package publishing to include preview version flag

### DIFF
--- a/.github/workflows/preview-package.yml
+++ b/.github/workflows/preview-package.yml
@@ -80,4 +80,4 @@ jobs:
         run: pnpm run test:coverage
 
       - name: Publish Preview Packages
-        run: pnpm dlx pkg-pr-new publish './packages/fsrs' './packages/binding' './packages/binding/npm/*' --compact --packageManager=pnpm
+        run: pnpm dlx pkg-pr-new@0.0.79 publish './packages/fsrs' './packages/binding' './packages/binding/npm/*' --previewVersion --compact --packageManager=pnpm

--- a/.github/workflows/preview-package.yml
+++ b/.github/workflows/preview-package.yml
@@ -80,4 +80,12 @@ jobs:
         run: pnpm run test:coverage
 
       - name: Publish Preview Packages
-        run: pnpm dlx pkg-pr-new@0.0.79 publish './packages/fsrs' './packages/binding' './packages/binding/npm/*' --previewVersion --compact --packageManager=pnpm
+        run: |
+          pnpm dlx pkg-pr-new@0.0.79 publish \
+            './packages/fsrs' \
+            './packages/srs-kit' \
+            './packages/binding' \
+            './packages/binding/npm/*' \
+            --previewVersion \
+            --compact \
+            --packageManager=pnpm


### PR DESCRIPTION
## Summary

This pull request updates the package publishing workflow to include the new `srs-kit` package and ensures preview versions are published. The main change is to the publish step in the GitHub Actions workflow.

**Workflow and publishing updates:**

* The `Publish Preview Packages` job in `.github/workflows/preview-package.yml` now includes `./packages/srs-kit` in the list of packages to publish, adds the `--previewVersion` flag, and pins the `pkg-pr-new` tool to version `0.0.79` for greater reliability and consistency.

## Related Issues

- Closes #

## Changes

- 

## Changeset

- [ ] Added a changeset with `pnpm changeset`
- [ ] Not needed because this change does not affect published package behavior or contents

