### PR TITLE
feat(kit): expose model and chrono on ComposableScheduler

### DIFF
--- a/packages/srs-kit/src/scheduler/base.spec.ts
+++ b/packages/srs-kit/src/scheduler/base.spec.ts
@@ -62,6 +62,10 @@ describe('SchedulerCore.create', () => {
       chrono: {},
       clearStatsOnForget: true,
     })
+    expect(core.model).not.toBe(SM2Model)
+    expect(core.model.config).toEqual({ weights: SM2_DEFAULT_WEIGHTS })
+    expect(core.chrono).not.toBe(numericChrono)
+    expect(core.chrono.now).toBeTypeOf('function')
   })
 
   it('does not expose desiredRetention on config', () => {

--- a/packages/srs-kit/src/scheduler/base.ts
+++ b/packages/srs-kit/src/scheduler/base.ts
@@ -146,8 +146,8 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
 {
   readonly config: Readonly<SchedulerCoreEnv<Env>['config']>
 
-  private readonly model: AnyModel
-  private readonly chrono: AnyChrono
+  readonly model: AnyModel
+  readonly chrono: AnyChrono
   private readonly defaultValue: SchedulerDefaultValueFactory
   private readonly modelCore: AnyModelCore
   private readonly chronoCore: AnyChronoCore

--- a/packages/srs-kit/src/scheduler/base.ts
+++ b/packages/srs-kit/src/scheduler/base.ts
@@ -21,13 +21,14 @@ import {
   parse,
   withCache,
 } from '@/schema/index.js'
-import type { SchedulerDefaultValueFactory } from './default-value.js'
 import type {
   BlankSchedulerEnv,
   PreviewResult,
   ScheduleResult,
   SchedulerCore,
   SchedulerCoreEnv,
+  SchedulerDefaultValue,
+  SchedulerDefaultValueContext,
   SchedulerNewCardFn,
   SchedulerNewCardOptions,
   SchedulerSchema,
@@ -41,7 +42,7 @@ export interface BaseSchedulerContext<
   readonly model: M
   readonly chrono: C
   readonly schema: SchedulerSchema<Env>
-  readonly defaultValue: SchedulerDefaultValueFactory
+  readonly defaultValue: SchedulerDefaultValue<Env>
   readonly middlewares?: readonly AnyMiddleware[]
   readonly config: SchemaInput<Env['config']>
 }
@@ -161,7 +162,7 @@ export class BaseScheduler<
   readonly chrono: ReturnType<C['create']>
   private readonly modelDef: M
   private readonly chronoDef: C
-  private readonly defaultValue: SchedulerDefaultValueFactory
+  private readonly defaultValue: SchedulerDefaultValue<Env>
   private readonly schema: SchedulerSchema<Env>
   private readonly reviewHandlers: readonly (
     | ReviewRuntimeHandler<Env>
@@ -203,16 +204,19 @@ export class BaseScheduler<
   newCard: SchedulerNewCardFn<SchedulerCoreEnv<Env>> = (
     options?: SchedulerNewCardOptions<SchedulerCoreEnv<Env>>
   ): SchedulerCoreEnv<Env>['card']['output'] => {
-    const { now, input } = parse(
+    const { now, input } = parse<Env['cardInitInput']>(
       this.schema.cardInitInput,
       options === undefined ? {} : options
     )
 
-    return this.defaultValue.newCard<SchedulerCoreEnv<Env>['card']['output']>(
+    return this.defaultValue.newCard(
       {
         operation: 'newCard',
         config: this.config,
-        input,
+        input: input as Extract<
+          SchedulerDefaultValueContext<Env>,
+          { readonly operation: 'newCard' }
+        >['input'],
       },
       this.parseNow(now)
     )
@@ -228,7 +232,7 @@ export class BaseScheduler<
     ) as SchedulerCoreEnv<Env>['card']['output']
     const now = this.parseNow(input.now)
 
-    return this.defaultValue.newCard<SchedulerCoreEnv<Env>['card']['output']>(
+    return this.defaultValue.newCard(
       {
         operation: 'forget',
         config: this.config,

--- a/packages/srs-kit/src/scheduler/base.ts
+++ b/packages/srs-kit/src/scheduler/base.ts
@@ -1,13 +1,12 @@
 import type {
   AnyChrono,
-  AnyChronoCore,
   ChronoProjectionRuntimeSchema,
 } from '@/chrono/chrono.js'
 import type {
   AnyMiddleware,
   ReviewCandidateContext,
 } from '@/middleware/index.js'
-import type { AnyModel, AnyModelCore } from '@/model/model.js'
+import type { AnyModel } from '@/model/model.js'
 import { type Grade, gradeSchema, grades } from '@/primitives/rating.js'
 import { State } from '@/primitives/state.js'
 import {
@@ -34,9 +33,13 @@ import type {
   SchedulerSchema,
 } from './scheduler.js'
 
-export interface BaseSchedulerContext<Env extends BlankSchedulerEnv> {
-  readonly model: AnyModel
-  readonly chrono: AnyChrono
+export interface BaseSchedulerContext<
+  Env extends BlankSchedulerEnv,
+  M extends AnyModel,
+  C extends AnyChrono,
+> {
+  readonly model: M
+  readonly chrono: C
   readonly schema: SchedulerSchema<Env>
   readonly defaultValue: SchedulerDefaultValueFactory
   readonly middlewares?: readonly AnyMiddleware[]
@@ -141,16 +144,24 @@ class ReviewInput<Env extends BlankSchedulerEnv>
   }
 }
 
-export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
-  implements SchedulerCore<SchedulerCoreEnv<Env>>
+export class BaseScheduler<
+  Env extends BlankSchedulerEnv = BlankSchedulerEnv,
+  M extends AnyModel = AnyModel,
+  C extends AnyChrono = AnyChrono,
+> implements
+    SchedulerCore<
+      SchedulerCoreEnv<Env>,
+      ReturnType<M['create']>,
+      ReturnType<C['create']>
+    >
 {
   readonly config: Readonly<SchedulerCoreEnv<Env>['config']>
 
-  readonly model: AnyModel
-  readonly chrono: AnyChrono
+  readonly model: ReturnType<M['create']>
+  readonly chrono: ReturnType<C['create']>
+  private readonly modelDef: M
+  private readonly chronoDef: C
   private readonly defaultValue: SchedulerDefaultValueFactory
-  private readonly modelCore: AnyModelCore
-  private readonly chronoCore: AnyChronoCore
   private readonly schema: SchedulerSchema<Env>
   private readonly reviewHandlers: readonly (
     | ReviewRuntimeHandler<Env>
@@ -161,26 +172,26 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
     | undefined
   )[]
 
-  constructor(ctx: BaseSchedulerContext<Env>) {
+  constructor(ctx: BaseSchedulerContext<Env, M, C>) {
     const { model, chrono, schema, defaultValue, middlewares = [] } = ctx
-    this.model = model
-    this.chrono = chrono
+    this.modelDef = model
+    this.chronoDef = chrono
     this.schema = schema
     this.defaultValue = defaultValue
 
     const config = parse(schema.config, ctx.config)
 
     this.config = config
-    this.modelCore = model.create({
+    this.model = model.create({
       config: getAttachedValue<typeof parsedModelConfigSymbol, typeof config>(
         config,
         parsedModelConfigSymbol
       ),
       bypass: true,
-    })
-    this.chronoCore = Reflect.apply(chrono.create, chrono, [
+    }) as ReturnType<M['create']>
+    this.chrono = Reflect.apply(chrono.create, chrono, [
       { config: config.chrono },
-    ])
+    ]) as ReturnType<C['create']>
     this.reviewHandlers = middlewares.map(
       (middleware) => middleware.handlers?.review
     ) as readonly (ReviewRuntimeHandler<Env> | undefined)[]
@@ -355,20 +366,20 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
     }
 
     const card = Object.freeze(parsedCard)
-    const time = parse<ChronoProjectionRuntimeSchema>(this.chrono.projection, {
-      card,
-      time: now,
-    }) as PreparedReview<Env>['time']
+    const time = parse<ChronoProjectionRuntimeSchema>(
+      this.chronoDef.projection,
+      {
+        card,
+        time: now,
+      }
+    ) as PreparedReview<Env>['time']
 
-    const elapsedDays = this.chronoCore.difference(time.previous, time.current)
+    const elapsedDays = this.chrono.difference(time.previous, time.current)
 
-    const retrievability = this.modelCore.forgettingCurve(
-      memoryState,
-      elapsedDays
-    )
+    const retrievability = this.model.forgettingCurve(memoryState, elapsedDays)
     const step = withCache(
       (grade: Grade) =>
-        this.modelCore.step({
+        this.model.step({
           memoryState,
           rating: grade,
           elapsedDays,
@@ -392,10 +403,7 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
         inner = new Map()
         intervalCache.set(nextMemoryState, inner)
       }
-      const value = this.modelCore.nextInterval(
-        nextMemoryState,
-        desiredRetention
-      )
+      const value = this.model.nextInterval(nextMemoryState, desiredRetention)
       inner.set(desiredRetention, value)
       return value
     }
@@ -444,7 +452,7 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
     const result = ctx.result
     const revlog = ctx.input.revlog
 
-    Object.assign(result.card, parse(this.model.schema.memoryState, revlog))
+    Object.assign(result.card, parse(this.modelDef.schema.memoryState, revlog))
     result.card.state = revlog.state
     result.card.scheduleStatus = revlog.scheduleStatus
 
@@ -466,19 +474,19 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
     prepared: PreparedReview<Env>,
     scheduledDays: number
   ): void {
-    const chronoCardDefault = this.chrono.defaultValue?.card
+    const chronoCardDefault = this.chronoDef.defaultValue?.card
     if (chronoCardDefault) {
       Object.assign(
         result.card,
         chronoCardDefault({
           config: this.config.chrono,
-          time: this.chronoCore.add(prepared.time.current, scheduledDays),
+          time: this.chrono.add(prepared.time.current, scheduledDays),
           previous: prepared.time,
         })
       )
     }
 
-    const chronoRevlogDefault = this.chrono.defaultValue?.revlog
+    const chronoRevlogDefault = this.chronoDef.defaultValue?.revlog
     if (chronoRevlogDefault) {
       Object.assign(
         result.revlog,
@@ -495,17 +503,17 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
     result: RollbackResultDraft<Env>,
     revlog: Readonly<SchedulerCoreEnv<Env>['revlog']['output']>
   ): void {
-    const chronoCardSchema = this.chrono.schema.card
+    const chronoCardSchema = this.chronoDef.schema.card
     if (!chronoCardSchema) {
       return
     }
     const projection = parse<ChronoProjectionRuntimeSchema>(
-      this.chrono.projection,
+      this.chronoDef.projection,
       {
         revlog,
       }
     )
-    const cardFields = this.chrono.defaultValue?.card?.({
+    const cardFields = this.chronoDef.defaultValue?.card?.({
       config: this.config.chrono,
       previous: {
         previous: 0,
@@ -520,7 +528,7 @@ export class BaseScheduler<Env extends BlankSchedulerEnv = BlankSchedulerEnv>
 
   private parseNow(now?: unknown): SchedulerCoreEnv<Env>['chrono'] {
     return now === undefined
-      ? this.chronoCore.now()
-      : parse(this.chrono.schema.time, now)
+      ? this.chrono.now()
+      : parse(this.chronoDef.schema.time, now)
   }
 }

--- a/packages/srs-kit/src/scheduler/default-value.ts
+++ b/packages/srs-kit/src/scheduler/default-value.ts
@@ -1,3 +1,5 @@
+/** biome-ignore-all lint/suspicious/noExplicitAny: runtime generic dispatch */
+
 import type {
   AnyChrono,
   ChronoDefaultCtx,
@@ -7,27 +9,12 @@ import type { AnyMiddleware } from '@/middleware/index.js'
 import type { AnyModel } from '@/model/model.js'
 import { State } from '@/primitives/state.js'
 import { isFunction } from '@/schema/index.js'
+import type {
+  SchedulerDefaultValue,
+  SchedulerDefaultValueContext,
+} from './scheduler.js'
 
-type DefaultValueConfig = Record<PropertyKey, unknown>
-
-type DefaultValueContext =
-  | {
-      readonly operation: 'newCard'
-      readonly config: DefaultValueConfig
-      readonly input: Readonly<object>
-    }
-  | {
-      readonly operation: 'forget'
-      readonly config: DefaultValueConfig
-      readonly input: Readonly<Record<string, unknown>>
-    }
-
-export type SchedulerDefaultValueFactory = {
-  readonly newCard: <Card extends object = Record<string, unknown>>(
-    ctx: DefaultValueContext,
-    time: unknown
-  ) => Card
-}
+type DefaultValueContext = SchedulerDefaultValueContext<any>
 
 function applyMiddlewareCardDefaults(
   target: Record<string, unknown>,
@@ -74,15 +61,12 @@ export function useComposeDefaultValue(ctx: {
   readonly model: AnyModel
   readonly chrono: AnyChrono
   readonly middlewares: readonly AnyMiddleware[]
-}): SchedulerDefaultValueFactory {
+}): SchedulerDefaultValue<any> {
   const { model, chrono, middlewares } = ctx
   const chronoCardDefault = resolveChronoDefault(chrono.defaultValue?.card)
 
   return {
-    newCard<Card extends object = Record<string, unknown>>(
-      defaultValue: DefaultValueContext,
-      time: unknown
-    ) {
+    newCard(defaultValue, time) {
       const { config } = defaultValue
       const card: Record<string, unknown> = model.defaultValue.memoryState({
         config,
@@ -97,7 +81,7 @@ export function useComposeDefaultValue(ctx: {
         time,
       })
 
-      return card as Card
+      return card as ReturnType<SchedulerDefaultValue<any>['newCard']>
     },
   }
 }

--- a/packages/srs-kit/src/scheduler/define-scheduler.ts
+++ b/packages/srs-kit/src/scheduler/define-scheduler.ts
@@ -52,6 +52,7 @@ export function defineScheduler<
     name: model.name,
     modelDef: model,
     chronoDef: chrono,
+    defaultValue,
     schema: schedulerSchema,
     create(ctx) {
       locked = true

--- a/packages/srs-kit/src/scheduler/define-scheduler.ts
+++ b/packages/srs-kit/src/scheduler/define-scheduler.ts
@@ -50,12 +50,12 @@ export function defineScheduler<
     C
   > = {
     name: model.name,
-    model,
-    chrono,
+    modelDef: model,
+    chronoDef: chrono,
     schema: schedulerSchema,
     create(ctx) {
       locked = true
-      return new BaseScheduler<InitialSchedulerEnv<M, C>>({
+      return new BaseScheduler<InitialSchedulerEnv<M, C>, M, C>({
         model,
         chrono,
         schema: schedulerSchema,

--- a/packages/srs-kit/src/scheduler/define-scheduler.ts
+++ b/packages/srs-kit/src/scheduler/define-scheduler.ts
@@ -25,7 +25,7 @@ export function defineScheduler<
 >(definition: {
   readonly model: M
   readonly chrono: C
-}): ComposableScheduler<SchedulerNameOf<M>, InitialSchedulerEnv<M, C>> {
+}): ComposableScheduler<SchedulerNameOf<M>, InitialSchedulerEnv<M, C>, M, C> {
   const { model, chrono } = definition
 
   /**
@@ -45,9 +45,13 @@ export function defineScheduler<
   let locked = false
   const scheduler: ComposableScheduler<
     SchedulerNameOf<M>,
-    InitialSchedulerEnv<M, C>
+    InitialSchedulerEnv<M, C>,
+    M,
+    C
   > = {
     name: model.name,
+    model,
+    chrono,
     schema: schedulerSchema,
     create(ctx) {
       locked = true

--- a/packages/srs-kit/src/scheduler/scheduler.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.spec.ts
@@ -54,6 +54,23 @@ describe('defineScheduler', () => {
     expectTypeOf(scheduler.name).toEqualTypeOf<'sm2'>()
   })
 
+  it('exposes composed default values', () => {
+    const emptyCard = scheduler.defaultValue.newCard(
+      {
+        operation: 'newCard',
+        config: scheduler.schema.config.parse(config),
+        input: {},
+      },
+      0
+    )
+    expect(emptyCard).toMatchObject({
+      state: State.New,
+      interval: 0,
+      reps: 0,
+      lapses: 0,
+    })
+  })
+
   it('types new-card input declared by middleware', () => {
     usedCore.newCard({ source: 'injected-source' })
     const invalidNewCard = () => {

--- a/packages/srs-kit/src/scheduler/scheduler.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.ts
@@ -1,8 +1,8 @@
 /** biome-ignore-all lint/suspicious/noExplicitAny: type-level widening for AnyScheduler */
 
-import type { AnyChrono } from '@/chrono/chrono.js'
+import type { AnyChrono, AnyChronoCore } from '@/chrono/chrono.js'
 import type { AnyMiddleware } from '@/middleware/index.js'
-import type { AnyModel } from '@/model/model.js'
+import type { AnyModel, AnyModelCore } from '@/model/model.js'
 import type { Grade } from '@/primitives/rating.js'
 import type {
   AnyObjectSchema,
@@ -75,7 +75,11 @@ export type SchedulerNewCardFn<Env extends BlankSchedulerCoreEnv> =
 
 export interface SchedulerCore<
   Env extends BlankSchedulerCoreEnv = BlankSchedulerCoreEnv,
+  M extends AnyModelCore = AnyModelCore,
+  C extends AnyChronoCore = AnyChronoCore,
 > {
+  readonly model: M
+  readonly chrono: C
   readonly config: Readonly<Env['config']>
   readonly newCard: SchedulerNewCardFn<Env>
   readonly forget: (input: {
@@ -173,7 +177,12 @@ export type SchedulerUseFn<
   C extends AnyChrono = AnyChrono,
 > = <const AddedMWs extends readonly AnyMiddleware[]>(
   ...middlewares: AddedMWs
-) => ComposableScheduler<Name, Prettify<ExtendSchedulerEnv<Env, AddedMWs>>, M, C>
+) => ComposableScheduler<
+  Name,
+  Prettify<ExtendSchedulerEnv<Env, AddedMWs>>,
+  M,
+  C
+>
 
 export type SchedulerCoreEnv<Env extends BlankSchedulerEnv> = {
   readonly config: SchemaOutput<Env['config']>
@@ -190,10 +199,17 @@ export type SchedulerCoreEnv<Env extends BlankSchedulerEnv> = {
   readonly scheduleStatus: Env['scheduleStatus']
 }
 
-export type SchedulerCreate<Env extends BlankSchedulerEnv = BlankSchedulerEnv> =
-  (ctx: {
-    readonly config: SchemaInput<Env['config']>
-  }) => SchedulerCore<Prettify<SchedulerCoreEnv<Env>>>
+export type SchedulerCreate<
+  Env extends BlankSchedulerEnv = BlankSchedulerEnv,
+  M extends AnyModel = AnyModel,
+  C extends AnyChrono = AnyChrono,
+> = (ctx: {
+  readonly config: SchemaInput<Env['config']>
+}) => SchedulerCore<
+  Prettify<SchedulerCoreEnv<Env>>,
+  ReturnType<M['create']>,
+  ReturnType<C['create']>
+>
 
 /**
  * Scheduler definition that can be extended with middleware before it is
@@ -206,10 +222,10 @@ export interface ComposableScheduler<
   C extends AnyChrono = AnyChrono,
 > {
   readonly name: Name
-  readonly model: M
-  readonly chrono: C
+  readonly modelDef: M
+  readonly chronoDef: C
   readonly schema: SchedulerSchema<Env>
-  readonly create: SchedulerCreate<Env>
+  readonly create: SchedulerCreate<Env, M, C>
 
   /**
    * Adds middleware to this scheduler instance.

--- a/packages/srs-kit/src/scheduler/scheduler.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.ts
@@ -1,6 +1,8 @@
 /** biome-ignore-all lint/suspicious/noExplicitAny: type-level widening for AnyScheduler */
 
+import type { AnyChrono } from '@/chrono/chrono.js'
 import type { AnyMiddleware } from '@/middleware/index.js'
+import type { AnyModel } from '@/model/model.js'
 import type { Grade } from '@/primitives/rating.js'
 import type {
   AnyObjectSchema,
@@ -167,9 +169,11 @@ export interface SchedulerSchema<
 export type SchedulerUseFn<
   Name extends string | symbol,
   Env extends BlankSchedulerEnv,
+  M extends AnyModel = AnyModel,
+  C extends AnyChrono = AnyChrono,
 > = <const AddedMWs extends readonly AnyMiddleware[]>(
   ...middlewares: AddedMWs
-) => ComposableScheduler<Name, Prettify<ExtendSchedulerEnv<Env, AddedMWs>>>
+) => ComposableScheduler<Name, Prettify<ExtendSchedulerEnv<Env, AddedMWs>>, M, C>
 
 export type SchedulerCoreEnv<Env extends BlankSchedulerEnv> = {
   readonly config: SchemaOutput<Env['config']>
@@ -198,8 +202,12 @@ export type SchedulerCreate<Env extends BlankSchedulerEnv = BlankSchedulerEnv> =
 export interface ComposableScheduler<
   Name extends string | symbol = string | symbol,
   Env extends BlankSchedulerEnv = BlankSchedulerEnv,
+  M extends AnyModel = AnyModel,
+  C extends AnyChrono = AnyChrono,
 > {
   readonly name: Name
+  readonly model: M
+  readonly chrono: C
   readonly schema: SchedulerSchema<Env>
   readonly create: SchedulerCreate<Env>
 
@@ -209,7 +217,7 @@ export interface ComposableScheduler<
    * Must be called before the first create() call. Once create() has been
    * called, the scheduler is locked and use() throws.
    */
-  readonly use: SchedulerUseFn<Name, Env>
+  readonly use: SchedulerUseFn<Name, Env, M, C>
 }
 
-export type AnyScheduler = ComposableScheduler<any, any>
+export type AnyScheduler = ComposableScheduler<any, any, any, any>

--- a/packages/srs-kit/src/scheduler/scheduler.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.ts
@@ -199,6 +199,25 @@ export type SchedulerCoreEnv<Env extends BlankSchedulerEnv> = {
   readonly scheduleStatus: Env['scheduleStatus']
 }
 
+export type SchedulerDefaultValueContext<Env extends BlankSchedulerEnv> =
+  | {
+      readonly operation: 'newCard'
+      readonly config: Readonly<SchemaOutput<Env['config']>>
+      readonly input: Readonly<SchemaOutput<Env['cardInitInput']>['input']>
+    }
+  | {
+      readonly operation: 'forget'
+      readonly config: Readonly<SchemaOutput<Env['config']>>
+      readonly input: Readonly<SchedulerCoreEnv<Env>['card']['output']>
+    }
+
+export interface SchedulerDefaultValue<Env extends BlankSchedulerEnv> {
+  readonly newCard: (
+    ctx: SchedulerDefaultValueContext<Env>,
+    time: Env['chrono']
+  ) => SchedulerCoreEnv<Env>['card']['output']
+}
+
 export type SchedulerCreate<
   Env extends BlankSchedulerEnv = BlankSchedulerEnv,
   M extends AnyModel = AnyModel,
@@ -224,6 +243,7 @@ export interface ComposableScheduler<
   readonly name: Name
   readonly modelDef: M
   readonly chronoDef: C
+  readonly defaultValue: SchedulerDefaultValue<Env>
   readonly schema: SchedulerSchema<Env>
   readonly create: SchedulerCreate<Env, M, C>
 

--- a/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
@@ -21,6 +21,8 @@ const sm2NumericCore = sm2NumericScheduler.create({
   config: { weights: SM2_DEFAULT_WEIGHTS },
 })
 
+const { model, chrono } = sm2NumericCore
+
 const sourceCardSchema = defineStringFieldOutputSchema({
   field: 'source',
   message: 'Expected source',
@@ -390,7 +392,16 @@ describe('defineScheduler type display', () => {
     };
     readonly chrono: number;
     readonly scheduleStatus: "new" | "learning" | "review";
-}>`,
+}, ModelCore<{
+    readonly config: {
+        readonly weights: readonly number[];
+    };
+    readonly memoryState: {
+        readonly interval: number;
+        readonly easeFactor: number;
+        readonly reviewStep: number;
+    };
+}>, ChronoCore<number>>`,
     sm2NumericCore: `const sm2NumericCore: SchedulerCore<{
     readonly config: {
         readonly weights: readonly number[];
@@ -440,7 +451,16 @@ describe('defineScheduler type display', () => {
     };
     readonly chrono: number;
     readonly scheduleStatus: "new" | "learning" | "review";
-}>`,
+}, ModelCore<{
+    readonly config: {
+        readonly weights: readonly number[];
+    };
+    readonly memoryState: {
+        readonly interval: number;
+        readonly easeFactor: number;
+        readonly reviewStep: number;
+    };
+}>, ChronoCore<number>>`,
   }
 
   const expectedSuspend = {
@@ -564,7 +584,16 @@ describe('defineScheduler type display', () => {
     };
     readonly chrono: number;
     readonly scheduleStatus: "new" | "learning" | "review" | "suspend";
-}>`,
+}, ModelCore<{
+    readonly config: {
+        readonly weights: readonly number[];
+    };
+    readonly memoryState: {
+        readonly interval: number;
+        readonly easeFactor: number;
+        readonly reviewStep: number;
+    };
+}>, ChronoCore<number>>`,
   }
 
   const expectedMiddlewares = {

--- a/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
@@ -137,7 +137,35 @@ describe('defineScheduler type display', () => {
             rating: Grade;
         };
     }>;
-}>`,
+}, Model<{
+    readonly name: "sm2";
+    readonly config: SRSSchema<{
+        input: {
+            readonly weights: readonly number[];
+        };
+        output: {
+            readonly weights: readonly number[];
+        };
+    }>;
+    readonly memoryState: SRSSchema<{
+        input: {
+            readonly interval: number;
+            readonly easeFactor: number;
+            readonly reviewStep: number;
+        };
+        output: {
+            readonly interval: number;
+            readonly easeFactor: number;
+            readonly reviewStep: number;
+        };
+    }>;
+}>, Chrono<{
+    readonly time: SRSSchema<{
+        input: {};
+        output: number;
+    }>;
+    readonly fields: {};
+}>>`,
     sm2NumericScheduler: `const sm2NumericScheduler: ComposableScheduler<"sm2", {
     readonly chrono: number;
     readonly scheduleStatus: "new" | "learning" | "review";
@@ -191,7 +219,35 @@ describe('defineScheduler type display', () => {
             rating: Grade;
         };
     }>;
-}>`,
+}, Model<{
+    readonly name: "sm2";
+    readonly config: SRSSchema<{
+        input: {
+            readonly weights: readonly number[];
+        };
+        output: {
+            readonly weights: readonly number[];
+        };
+    }>;
+    readonly memoryState: SRSSchema<{
+        input: {
+            readonly interval: number;
+            readonly easeFactor: number;
+            readonly reviewStep: number;
+        };
+        output: {
+            readonly interval: number;
+            readonly easeFactor: number;
+            readonly reviewStep: number;
+        };
+    }>;
+}>, Chrono<{
+    readonly time: SRSSchema<{
+        input: {};
+        output: number;
+    }>;
+    readonly fields: {};
+}>>`,
     sm2NumericSchedulerWithMiddleware: `const sm2NumericSchedulerWithMiddleware: ComposableScheduler<"sm2", {
     readonly chrono: number;
     readonly scheduleStatus: "new" | "learning" | "review";
@@ -249,7 +305,35 @@ describe('defineScheduler type display', () => {
             rating: Grade;
         };
     }>;
-}>`,
+}, Model<{
+    readonly name: "sm2";
+    readonly config: SRSSchema<{
+        input: {
+            readonly weights: readonly number[];
+        };
+        output: {
+            readonly weights: readonly number[];
+        };
+    }>;
+    readonly memoryState: SRSSchema<{
+        input: {
+            readonly interval: number;
+            readonly easeFactor: number;
+            readonly reviewStep: number;
+        };
+        output: {
+            readonly interval: number;
+            readonly easeFactor: number;
+            readonly reviewStep: number;
+        };
+    }>;
+}>, Chrono<{
+    readonly time: SRSSchema<{
+        input: {};
+        output: number;
+    }>;
+    readonly fields: {};
+}>>`,
   }
 
   const expectedCores = {
@@ -407,7 +491,35 @@ describe('defineScheduler type display', () => {
             rating: Grade;
         };
     }>;
-}>`,
+}, Model<{
+    readonly name: "sm2";
+    readonly config: SRSSchema<{
+        input: {
+            readonly weights: readonly number[];
+        };
+        output: {
+            readonly weights: readonly number[];
+        };
+    }>;
+    readonly memoryState: SRSSchema<{
+        input: {
+            readonly interval: number;
+            readonly easeFactor: number;
+            readonly reviewStep: number;
+        };
+        output: {
+            readonly interval: number;
+            readonly easeFactor: number;
+            readonly reviewStep: number;
+        };
+    }>;
+}>, Chrono<{
+    readonly time: SRSSchema<{
+        input: {};
+        output: number;
+    }>;
+    readonly fields: {};
+}>>`,
     sm2WithSuspendCore: `const sm2WithSuspendCore: SchedulerCore<{
     readonly config: {
         readonly weights: readonly number[];

--- a/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
@@ -86,6 +86,18 @@ const sm2NumericCoreWithMiddleware = sm2NumericSchedulerWithMiddleware.create({
   config: { weights: SM2_DEFAULT_WEIGHTS },
 })
 
+const defaultNewCard = sm2NumericSchedulerWithMiddleware.defaultValue.newCard(
+  {
+    operation: 'newCard',
+    config: sm2NumericSchedulerWithMiddleware.schema.config.parse({
+      weights: SM2_DEFAULT_WEIGHTS,
+    }),
+    input: sm2NumericSchedulerWithMiddleware.schema.cardInitInput.parse({})
+      .input,
+  },
+  0
+)
+
 const SELF = 'src/scheduler/scheduler.type-display.spec.ts'
 
 describe('defineScheduler type display', () => {
@@ -463,6 +475,19 @@ describe('defineScheduler type display', () => {
 }>, ChronoCore<number>>`,
   }
 
+  const expectedDefaultValues = {
+    defaultNewCard: `const defaultNewCard: {
+    source: string;
+    interval: number;
+    easeFactor: number;
+    reviewStep: number;
+    reps: number;
+    lapses: number;
+    state: State;
+    scheduleStatus: "new" | "learning" | "review";
+}`,
+  }
+
   const expectedSuspend = {
     sm2WithSuspend: `const sm2WithSuspend: ComposableScheduler<"sm2", {
     readonly chrono: number;
@@ -621,6 +646,12 @@ describe('defineScheduler type display', () => {
 
   it('shows SchedulerCore<T> for scheduler.create()', () => {
     for (const [marker, expected] of Object.entries(expectedCores)) {
+      expect(quickInfoAt(service, SELF, marker)).toBe(expected)
+    }
+  })
+
+  it('shows the composed card type for defaultValue.newCard()', () => {
+    for (const [marker, expected] of Object.entries(expectedDefaultValues)) {
       expect(quickInfoAt(service, SELF, marker)).toBe(expected)
     }
   })


### PR DESCRIPTION
## Summary
- Expose typed `modelDef` and `chronoDef` fields on `ComposableScheduler`
- Expose the created `model` and `chrono` runtimes on `BaseScheduler`
- Thread model and chrono generics through scheduler creation and middleware composition
- Expose composed scheduler default values through `ComposableScheduler.defaultValue`
- Infer `defaultValue.newCard()` config, card-init input, time, and returned card types from the composed scheduler environment, including middleware-contributed fields
- Add runtime and IDE type-display coverage for composed default values

## Test plan
- [x] `pnpm --filter @open-spaced-repetition/srs-kit check`
- [x] 108 scheduler tests pass
- [x] Type-display assertions pass
- [x] `pnpm --filter @open-spaced-repetition/srs-kit build`