### PR TITLE
feat(model): add FSRS-6 decay validation

### DIFF
--- a/.changeset/validate-fsrs6-decay.md
+++ b/.changeset/validate-fsrs6-decay.md
@@ -1,0 +1,5 @@
+---
+"ts-fsrs": patch
+---
+
+feat(model): add validation for FSRS-6 decay values.

--- a/packages/fsrs/src/models/fsrs-6/index.ts
+++ b/packages/fsrs/src/models/fsrs-6/index.ts
@@ -14,6 +14,7 @@ export type { FSRS6Config } from './parameters.js'
 export {
   checkFSRS6Parameters,
   clipFSRS6Parameters,
+  decaySchema,
   fsrs6ConfigSchema,
   migrateFSRS6Parameters,
 } from './parameters.js'

--- a/packages/fsrs/src/models/fsrs-6/parameters.spec.ts
+++ b/packages/fsrs/src/models/fsrs-6/parameters.spec.ts
@@ -1,8 +1,22 @@
 import { describe, expect, it } from 'vitest'
-import { FSRS6_DEFAULT_WEIGHTS } from './constants.js'
-import { checkFSRS6Parameters, clipFSRS6Parameters } from './parameters.js'
+import { FSRS6_DECAY, FSRS6_DEFAULT_WEIGHTS } from './constants.js'
+import {
+  checkFSRS6Parameters,
+  clipFSRS6Parameters,
+  decaySchema,
+} from './parameters.js'
 
 describe('FSRS-6 parameters', () => {
+  it('validates decay', () => {
+    expect(decaySchema.parse(FSRS6_DECAY)).toBe(FSRS6_DECAY)
+    expect(decaySchema.parse(0.1)).toBe(0.1)
+    expect(decaySchema.parse(0.8)).toBe(0.8)
+    expect(() => decaySchema.parse('0.1542')).toThrow()
+    expect(() => decaySchema.parse(0.09)).toThrow()
+    expect(() => decaySchema.parse(0.81)).toThrow()
+    expect(() => decaySchema.parse(Number.NaN)).toThrow()
+  })
+
   it('checks default weights with default options', () => {
     const weights = Array.from(FSRS6_DEFAULT_WEIGHTS)
 

--- a/packages/fsrs/src/models/fsrs-6/parameters.ts
+++ b/packages/fsrs/src/models/fsrs-6/parameters.ts
@@ -9,6 +9,12 @@ import {
   FSRS6ParameterBounds,
 } from './constants'
 
+export const decaySchema = defineSchema<unknown, number>((value) =>
+  typeof value === 'number' && value >= 0.1 && value <= 0.8
+    ? { value }
+    : { issues: [{ message: 'Expected decay between 0.1 and 0.8' }] }
+)
+
 export const clipFSRS6Parameters = (
   parameters: number[],
   numRelearningSteps = 0,


### PR DESCRIPTION
## Summary

- add a Standard Schema validator for FSRS-6 decay values
- accept the supported inclusive range from 0.1 to 0.8
- cover valid boundaries, invalid types, out-of-range values, and NaN
- add a patch changeset for `ts-fsrs`

## Background

When plotting forgetting curves, consumers should be able to rely on `ts-fsrs` to validate decay values instead of duplicating the supported range with the magic numbers `0.1` and `0.8` in application code. Providing a reusable schema keeps this constraint centralized and prevents invalid decay values from reaching forgetting-curve calculations.
<img width="1036" height="122" alt="image" src="https://github.com/user-attachments/assets/ae06b103-3d71-4003-9f59-d056e052f20c" />


## Validation

- `pnpm exec vitest run packages/fsrs/src/models/fsrs-4dot5/parameters.spec.ts packages/fsrs/src/models/fsrs-5/parameters.spec.ts packages/fsrs/src/models/fsrs-6/parameters.spec.ts --config=vitest.config.ts`
- `pnpm --filter ts-fsrs check`
- `git diff --check`