### PR TITLE
feat(kit): enhance middleware composition and fix TS2590

### DIFF
--- a/.changeset/immutable-scheduler.md
+++ b/.changeset/immutable-scheduler.md
@@ -1,0 +1,5 @@
+---
+"@open-spaced-repetition/srs-kit": minor
+---
+
+feat(kit): make scheduler middleware composition immutable.

--- a/.changeset/scheduler-ts2590.md
+++ b/.changeset/scheduler-ts2590.md
@@ -1,0 +1,5 @@
+---
+"@open-spaced-repetition/srs-kit": patch
+---
+
+fix(kit): avoid TypeScript 7 TS2590 errors in scheduler type inference.

--- a/packages/srs-kit/bench/scheduler.bench.ts
+++ b/packages/srs-kit/bench/scheduler.bench.ts
@@ -7,8 +7,12 @@ import { defineScheduler } from '@/scheduler/index.js'
 
 let _schedulerSink: unknown
 
-function consumeSchedulerName(value: string | symbol): void {
+function consumeScheduler<T>(value: T): void {
   _schedulerSink = value
+}
+
+const config = {
+  weights: SM2_DEFAULT_WEIGHTS,
 }
 
 describe('SM2 numeric scheduler', () => {
@@ -17,9 +21,6 @@ describe('SM2 numeric scheduler', () => {
     chrono: numericChrono,
   }).use(schedulerStatsMiddleware)
 
-  const config = {
-    weights: SM2_DEFAULT_WEIGHTS,
-  }
   const core = scheduler.create({ config })
   const newCard = core.newCard({ now: 0 })
   const reviewCard = core.review({
@@ -62,19 +63,100 @@ describe('SM2 numeric scheduler', () => {
 })
 
 describe('defineScheduler composition', () => {
-  bench('defineScheduler()', () => {
-    const scheduler = defineScheduler({
-      model: SM2Model,
-      chrono: numericChrono,
-    })
-    consumeSchedulerName(scheduler.name)
+  const cachedScheduler = defineScheduler({
+    model: SM2Model,
+    chrono: numericChrono,
+  }).use(schedulerStatsMiddleware)
+  cachedScheduler.create({ config })
+
+  const cachedBaseScheduler = defineScheduler({
+    model: SM2Model,
+    chrono: numericChrono,
+  })
+  cachedBaseScheduler.create({ config })
+
+  type RuntimeBranch = {
+    use(...middlewares: (typeof schedulerStatsMiddleware)[]): RuntimeBranch
+  }
+  const runtimeBaseScheduler = cachedBaseScheduler as unknown as RuntimeBranch
+  let deepScheduler = runtimeBaseScheduler
+  for (let depth = 0; depth < 8; depth++) {
+    deepScheduler = deepScheduler.use(schedulerStatsMiddleware)
+  }
+
+  bench('use branch (base)', () => {
+    consumeScheduler(cachedBaseScheduler.use(schedulerStatsMiddleware))
   })
 
-  bench('defineScheduler().use(stats)', () => {
-    const scheduler = defineScheduler({
-      model: SM2Model,
-      chrono: numericChrono,
-    }).use(schedulerStatsMiddleware)
-    consumeSchedulerName(scheduler.name)
+  bench('use branch (8 ancestors)', () => {
+    consumeScheduler(deepScheduler.use(schedulerStatsMiddleware))
+  })
+
+  bench('use branch (4 added)', () => {
+    consumeScheduler(
+      runtimeBaseScheduler.use(
+        schedulerStatsMiddleware,
+        schedulerStatsMiddleware,
+        schedulerStatsMiddleware,
+        schedulerStatsMiddleware
+      )
+    )
+  })
+
+  bench('define/use (unmaterialized)', () => {
+    consumeScheduler(
+      defineScheduler({
+        model: SM2Model,
+        chrono: numericChrono,
+      }).use(schedulerStatsMiddleware)
+    )
+  })
+
+  bench('define/use (name-only legacy workload)', () => {
+    consumeScheduler(
+      defineScheduler({
+        model: SM2Model,
+        chrono: numericChrono,
+      }).use(schedulerStatsMiddleware).name
+    )
+  })
+
+  bench('define/use/create (cold)', () => {
+    consumeScheduler(
+      defineScheduler({
+        model: SM2Model,
+        chrono: numericChrono,
+      })
+        .use(schedulerStatsMiddleware)
+        .create({ config })
+    )
+  })
+
+  bench('create (cached composition)', () => {
+    consumeScheduler(cachedScheduler.create({ config }))
+  })
+
+  bench('schema getter (cached)', () => {
+    consumeScheduler(cachedScheduler.schema)
+  })
+
+  bench('defaultValue getter (cached)', () => {
+    consumeScheduler(cachedScheduler.defaultValue)
+  })
+
+  bench('schema getter (cold branch)', () => {
+    consumeScheduler(cachedBaseScheduler.use(schedulerStatsMiddleware).schema)
+  })
+
+  bench('defaultValue getter (cold branch)', () => {
+    consumeScheduler(
+      cachedBaseScheduler.use(schedulerStatsMiddleware).defaultValue
+    )
+  })
+
+  bench('use/create branch (cached base)', () => {
+    consumeScheduler(
+      cachedBaseScheduler.use(schedulerStatsMiddleware).create({ config })
+    )
   })
 })

--- a/packages/srs-kit/src/scheduler/base.spec.ts
+++ b/packages/srs-kit/src/scheduler/base.spec.ts
@@ -15,7 +15,6 @@ import { defineSchema, isObject, numberSchema } from '@/schema/index.js'
 import { BaseScheduler } from './base.js'
 import { useComposeDefaultValue } from './default-value.js'
 import { defineScheduler } from './define-scheduler.js'
-import { SRSSchedulerError } from './error.js'
 import {
   config,
   createSM2NumericScheduler,
@@ -66,6 +65,13 @@ describe('SchedulerCore.create', () => {
     expect(core.model.config).toEqual({ weights: SM2_DEFAULT_WEIGHTS })
     expect(core.chrono).not.toBe(numericChrono)
     expect(core.chrono.now).toBeTypeOf('function')
+  })
+
+  it('supports destructured create()', () => {
+    const { create } = createSM2NumericScheduler()
+    const destructuredCore = create({ config })
+
+    expect(destructuredCore.newCard()).toHaveProperty('state', State.New)
   })
 
   it('does not expose desiredRetention on config', () => {
@@ -173,20 +179,48 @@ describe('SchedulerCore.newCard', () => {
     expect(secondCard).toStrictEqual(firstCard)
   })
 
-  it('rejects middleware added after create()', () => {
-    const dynamicScheduler = createSM2NumericScheduler()
-    const dynamicCore = dynamicScheduler.create({ config })
+  it('keeps created cores isolated when deriving a middleware scheduler', () => {
+    const baseScheduler = createSM2NumericScheduler()
+    const baseCoreBefore = baseScheduler.create({ config })
+    const derivedCore = baseScheduler
+      .use(sourceMiddleware, schedulerStatsMiddleware)
+      .create({
+        config: {
+          ...config,
+          source: 'derived-source',
+        },
+      })
+    const baseCoreAfter = baseScheduler.create({ config })
 
-    expect(dynamicCore.newCard()).toHaveProperty('state', State.New)
+    const beforeCard = baseCoreBefore.newCard()
+    const derivedCard = derivedCore.newCard()
+    const afterCard = baseCoreAfter.newCard()
+    const beforeReview = baseCoreBefore.review({
+      card: beforeCard,
+      grade: Rating.Good,
+      now: 1,
+    })
+    const derivedReview = derivedCore.review({
+      card: derivedCard,
+      grade: Rating.Good,
+      now: 1,
+    })
+    const afterReview = baseCoreAfter.review({
+      card: afterCard,
+      grade: Rating.Good,
+      now: 1,
+    })
 
-    expect(() => dynamicScheduler.use(schedulerStatsMiddleware)).toThrow(
-      SRSSchedulerError
-    )
-    expect(() => dynamicScheduler.use(schedulerStatsMiddleware)).toThrow(
-      /Cannot add middleware after scheduler\.create\(\)/
-    )
-
-    expect(dynamicCore.newCard()).toHaveProperty('state', State.New)
+    expect(beforeReview.card).not.toHaveProperty('source')
+    expect(beforeReview.card).not.toHaveProperty('reps')
+    expect(derivedReview.card).toMatchObject({
+      source: 'derived-source',
+      reps: 1,
+      lapses: 0,
+    })
+    expect(derivedReview.revlog).toHaveProperty('audit', 'derived-source')
+    expect(afterReview.card).not.toHaveProperty('source')
+    expect(afterReview.card).not.toHaveProperty('reps')
   })
 
   it('creates distinct cards for different now input', () => {
@@ -1506,7 +1540,8 @@ describe('card schema validation', () => {
           : { issues: [{ message: 'Expected card object' }] }
     )
     const scheduler = createSM2NumericScheduler()
-    const unmarkedCore = new BaseScheduler({
+    // biome-ignore lint/suspicious/noExplicitAny: malformed schema runtime test
+    const unmarkedCore = new BaseScheduler<any>({
       model: SM2Model,
       chrono: numericChrono,
       schema: {

--- a/packages/srs-kit/src/scheduler/define-scheduler.ts
+++ b/packages/srs-kit/src/scheduler/define-scheduler.ts
@@ -1,5 +1,3 @@
-/** biome-ignore-all lint/suspicious/noExplicitAny: runtime generic dispatch */
-
 import type { AnyChrono } from '@/chrono/chrono.js'
 import type { AnyMiddleware } from '@/middleware/index.js'
 import type { AnyModel } from '@/model/model.js'
@@ -7,13 +5,40 @@ import type { Prettify } from '@/schema/index.js'
 import { BaseScheduler } from './base.js'
 import { composeSchema } from './compose-schema.js'
 import { useComposeDefaultValue } from './default-value.js'
-import { SRSSchedulerError } from './error.js'
 import type { SchedulerEnvFor, SchedulerNameOf } from './infer.js'
-import type { ComposableScheduler } from './scheduler.js'
+import type { ComposableScheduler, SchedulerCreate } from './scheduler.js'
 
 type InitialSchedulerEnv<M extends AnyModel, C extends AnyChrono> = Prettify<
   SchedulerEnvFor<M, C, readonly []>
 >
+
+type MiddlewareNode = {
+  readonly parent: MiddlewareNode | undefined
+  readonly middleware: AnyMiddleware
+  readonly length: number
+}
+
+const emptyMiddlewares: readonly AnyMiddleware[] = []
+
+function flattenMiddlewares(
+  node: MiddlewareNode | undefined
+): readonly AnyMiddleware[] {
+  if (!node) {
+    return emptyMiddlewares
+  }
+
+  const middlewares = new Array<AnyMiddleware>(node.length)
+  let index = node.length
+  for (
+    let current: MiddlewareNode | undefined = node;
+    current;
+    current = current.parent
+  ) {
+    middlewares[--index] = current.middleware
+  }
+
+  return middlewares
+}
 
 // ============
 // defineScheduler
@@ -28,53 +53,74 @@ export function defineScheduler<
 }): ComposableScheduler<SchedulerNameOf<M>, InitialSchedulerEnv<M, C>, M, C> {
   const { model, chrono } = definition
 
-  /**
-   * Shared middleware pointer used by schema/core/defaultValue composition.
-   * use() mutates this array so existing composed runtime objects can observe
-   * newly registered middleware without rebuilding schemas or core factories.
-   */
-  const middlewares: AnyMiddleware[] = []
+  function build(node?: MiddlewareNode): object {
+    let middlewares: readonly AnyMiddleware[] | undefined
+    let defaultValue: ReturnType<typeof useComposeDefaultValue> | undefined
+    let schedulerSchema: ReturnType<typeof composeSchema> | undefined
+    let compositionReady = false
 
-  const defaultValue = useComposeDefaultValue({
-    model,
-    chrono,
-    middlewares,
-  })
+    const getMiddlewares = () => {
+      middlewares ??= flattenMiddlewares(node)
+      return middlewares
+    }
 
-  const schedulerSchema = composeSchema({ model, chrono, middlewares })
-  let locked = false
-  const scheduler: ComposableScheduler<
-    SchedulerNameOf<M>,
-    InitialSchedulerEnv<M, C>,
-    M,
-    C
-  > = {
-    name: model.name,
-    modelDef: model,
-    chronoDef: chrono,
-    defaultValue,
-    schema: schedulerSchema,
-    create(ctx) {
-      locked = true
-      return new BaseScheduler<InitialSchedulerEnv<M, C>, M, C>({
-        model,
-        chrono,
-        schema: schedulerSchema,
-        defaultValue,
-        middlewares,
-        config: ctx.config,
-      })
-    },
-    use(...added) {
-      if (locked) {
-        throw new SRSSchedulerError(
-          'Cannot add middleware after scheduler.create()'
-        )
-      }
-      middlewares.push(...added)
-      return scheduler as never
-    },
+    const scheduler = {
+      name: model.name,
+      modelDef: model,
+      chronoDef: chrono,
+      get defaultValue() {
+        defaultValue ??= useComposeDefaultValue({
+          model,
+          chrono,
+          middlewares: getMiddlewares(),
+        })
+        return defaultValue
+      },
+      get schema() {
+        schedulerSchema ??= composeSchema({
+          model,
+          chrono,
+          middlewares: getMiddlewares(),
+        })
+        return schedulerSchema
+      },
+      create(ctx: Parameters<SchedulerCreate<InitialSchedulerEnv<M, C>>>[0]) {
+        if (!compositionReady) {
+          schedulerSchema = scheduler.schema
+          defaultValue = scheduler.defaultValue
+          compositionReady = true
+        }
+
+        // biome-ignore lint/suspicious/noExplicitAny: runtime Env avoids TS7 TS2590
+        return new BaseScheduler<any, M, C>({
+          model,
+          chrono,
+          schema: schedulerSchema!,
+          defaultValue: defaultValue!,
+          middlewares: middlewares!,
+          config: ctx.config,
+        })
+      },
+      use(...added: AnyMiddleware[]): object {
+        if (added.length === 0) {
+          return scheduler
+        }
+
+        let child = node
+        let length = node?.length ?? 0
+        for (const middleware of added) {
+          child = {
+            parent: child,
+            middleware,
+            length: ++length,
+          }
+        }
+        return build(child)
+      },
+    } satisfies Record<keyof ComposableScheduler, unknown>
+
+    return scheduler
   }
 
-  return scheduler
+  return build() as never
 }

--- a/packages/srs-kit/src/scheduler/error.ts
+++ b/packages/srs-kit/src/scheduler/error.ts
@@ -1,7 +1,0 @@
-export class SRSSchedulerError extends Error {
-  constructor(message: string) {
-    super(message)
-    this.name = 'SRSSchedulerError'
-    Error?.captureStackTrace?.(this, SRSSchedulerError)
-  }
-}

--- a/packages/srs-kit/src/scheduler/infer.ts
+++ b/packages/srs-kit/src/scheduler/infer.ts
@@ -22,6 +22,7 @@ import type { AnyModel } from '@/model/model.js'
 import type { ScheduleStatus } from '@/primitives/status.js'
 import type {
   Assign,
+  HasSchema,
   MergeAllObjects,
   MergePart,
   Mutable,
@@ -36,13 +37,9 @@ import type {
   SchedulerCoreFields,
   SchedulerRevlogCoreFields,
 } from './fields.js'
-import type {
-  AnyScheduler,
-  BlankSchedulerEnv,
-  SchedulerCardInitSchema,
-} from './scheduler.js'
+import type { BlankSchedulerEnv, SchedulerCardInitSchema } from './scheduler.js'
 
-export type SchedulerConfigOf<T extends AnyScheduler> = SchemaOutputOf<
+export type SchedulerConfigOf<T extends HasSchema<'config'>> = SchemaOutputOf<
   T,
   'config'
 >
@@ -259,34 +256,31 @@ export type ExtendSchedulerEnv<
   }>
 }
 
-export type SchedulerCardOf<T extends AnyScheduler> = SchemaOutputOf<T, 'card'>
-
-export type SchedulerCardInitInputOf<T extends AnyScheduler> = SchemaInputOf<
-  T,
-  'cardInitInput'
->
-
-export type SchedulerCardInputOf<T extends AnyScheduler> = SchemaInputOf<
+export type SchedulerCardOf<T extends HasSchema<'card'>> = SchemaOutputOf<
   T,
   'card'
 >
 
-export type SchedulerRevlogOf<T extends AnyScheduler> = SchemaOutputOf<
+export type SchedulerCardInitInputOf<T extends HasSchema<'cardInitInput'>> =
+  SchemaInputOf<T, 'cardInitInput'>
+
+export type SchedulerCardInputOf<T extends HasSchema<'card'>> = SchemaInputOf<
+  T,
+  'card'
+>
+
+export type SchedulerRevlogOf<T extends HasSchema<'revlog'>> = SchemaOutputOf<
   T,
   'revlog'
 >
 
-export type SchedulerRevlogInputOf<T extends AnyScheduler> = SchemaInputOf<
-  T,
-  'revlog'
->
+export type SchedulerRevlogInputOf<T extends HasSchema<'revlog'>> =
+  SchemaInputOf<T, 'revlog'>
 
-export type SchedulerTimeOf<T extends AnyScheduler> =
+export type SchedulerTimeOf<T extends HasSchema<'cardInitInput'>> =
   SchedulerCardInitInputOf<T> extends { readonly now?: infer Time }
     ? Exclude<Time, undefined>
     : never
 
-export type SchedulerStatusOf<T extends AnyScheduler> = SchemaOutputOf<
-  T,
-  'scheduleStatus'
->
+export type SchedulerStatusOf<T extends HasSchema<'scheduleStatus'>> =
+  SchemaOutputOf<T, 'scheduleStatus'>

--- a/packages/srs-kit/src/scheduler/scheduler.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.spec.ts
@@ -199,6 +199,7 @@ describe('defineScheduler', () => {
     expect(sourceScheduler).not.toBe(baseScheduler)
     expect(statsScheduler).not.toBe(baseScheduler)
     expect(statsScheduler).not.toBe(sourceScheduler)
+    expect(baseScheduler.use()).toBe(baseScheduler)
     expect(sourceSchema).not.toBe(baseSchema)
     expect(statsSchema).not.toBe(baseSchema)
     expect(sourceSchema).not.toBe(statsSchema)

--- a/packages/srs-kit/src/scheduler/scheduler.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.spec.ts
@@ -339,6 +339,24 @@ describe('defineScheduler', () => {
     )
   })
 
+  it('validates middleware card and revlog fields', () => {
+    const card = usedCore.newCard()
+    const review = usedCore.review({
+      card,
+      grade: Rating.Good,
+      now: 1,
+    })
+    const { source: _source, ...cardWithoutSource } = card
+    const { audit: _audit, ...revlogWithoutAudit } = review.revlog
+
+    expect(() => usedScheduler.schema.card.parse(cardWithoutSource)).toThrow(
+      'Expected source card field'
+    )
+    expect(() => usedScheduler.schema.revlog.parse(revlogWithoutAudit)).toThrow(
+      'Expected audit revlog field'
+    )
+  })
+
   it('validates composed chrono and model revlog fields', () => {
     const dateScheduler = defineScheduler({
       model: SM2Model,

--- a/packages/srs-kit/src/scheduler/scheduler.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.spec.ts
@@ -185,52 +185,74 @@ describe('defineScheduler', () => {
     ).toStrictEqual({ input: {}, now: 'raw-now' })
   })
 
-  it('uses middleware references from use() when schemas parse', () => {
-    const dynamicScheduler = createSM2NumericScheduler()
-    const schema = dynamicScheduler.schema
-    expect(schema.cardInitInput.parse({})).toStrictEqual({
-      input: {},
-      now: undefined,
+  it('keeps schema and default-value branches isolated after use()', () => {
+    const baseScheduler = createSM2NumericScheduler()
+    const baseSchema = baseScheduler.schema
+    const baseDefaultValue = baseScheduler.defaultValue
+    const sourceScheduler = baseScheduler.use(sourceMiddleware)
+    const statsScheduler = baseScheduler.use(schedulerStatsMiddleware)
+    const sourceSchema = sourceScheduler.schema
+    const statsSchema = statsScheduler.schema
+    const sourceDefaultValue = sourceScheduler.defaultValue
+    const statsDefaultValue = statsScheduler.defaultValue
+
+    expect(sourceScheduler).not.toBe(baseScheduler)
+    expect(statsScheduler).not.toBe(baseScheduler)
+    expect(statsScheduler).not.toBe(sourceScheduler)
+    expect(sourceSchema).not.toBe(baseSchema)
+    expect(statsSchema).not.toBe(baseSchema)
+    expect(sourceSchema).not.toBe(statsSchema)
+    expect(sourceDefaultValue).not.toBe(baseDefaultValue)
+    expect(statsDefaultValue).not.toBe(baseDefaultValue)
+    expect(sourceScheduler.schema).toBe(sourceSchema)
+    expect(statsScheduler.schema).toBe(statsSchema)
+    expect(sourceScheduler.defaultValue).toBe(sourceDefaultValue)
+    expect(statsScheduler.defaultValue).toBe(statsDefaultValue)
+
+    const baseCard = baseDefaultValue.newCard(
+      {
+        operation: 'newCard',
+        config: baseSchema.config.parse(config),
+        input: {},
+      },
+      0
+    )
+    const sourceCard = sourceDefaultValue.newCard(
+      {
+        operation: 'newCard',
+        config: sourceSchema.config.parse({
+          ...config,
+          source: 'source-branch',
+        }),
+        input: {},
+      },
+      0
+    )
+    const statsCard = statsDefaultValue.newCard(
+      {
+        operation: 'newCard',
+        config: statsSchema.config.parse(config),
+        input: {},
+      },
+      0
+    )
+
+    expect(baseScheduler.schema).toBe(baseSchema)
+    expect(baseScheduler.defaultValue).toBe(baseDefaultValue)
+    expect(baseCard).not.toHaveProperty('source')
+    expect(baseCard).not.toHaveProperty('reps')
+    expect(sourceCard).toHaveProperty('source', 'source-branch')
+    expect(sourceCard).not.toHaveProperty('reps')
+    expect(sourceSchema.card.parse(sourceCard)).toHaveProperty(
+      'source',
+      'source-branch'
+    )
+    expect(statsCard).toMatchObject({ reps: 0, lapses: 0 })
+    expect(statsCard).not.toHaveProperty('source')
+    expect(statsSchema.card.parse(statsCard)).toMatchObject({
+      reps: 0,
+      lapses: 0,
     })
-
-    const dynamicSchedulerWithMiddleware = dynamicScheduler.use(
-      sourceMiddleware,
-      schedulerStatsMiddleware
-    )
-    const usedSchema = dynamicSchedulerWithMiddleware.schema
-
-    expect(dynamicSchedulerWithMiddleware).toBe(dynamicScheduler)
-    expect(usedSchema).toBe(schema)
-    expect(() => usedSchema.card.parse(core.newCard())).toThrow(
-      'Expected source card field'
-    )
-    expect(() =>
-      usedSchema.revlog.parse({
-        ...core.newCard(),
-        rating: Rating.Good,
-      })
-    ).toThrow('Expected audit revlog field')
-
-    expect(
-      usedSchema.config.parse({
-        ...config,
-        source: 'schema-source',
-      }).source
-    ).toBe('schema-source')
-    expect(
-      usedSchema.cardInitInput.parse({ source: 'schema-source' }).input.source
-    ).toBe('schema-source')
-    expect(() => usedSchema.cardInitInput.parse({ source: 1 })).toThrow(
-      'Expected source card init input'
-    )
-    expect(usedSchema.card.parse(usedCore.newCard()).source).toBe('used-source')
-    expect(
-      usedSchema.revlog.parse({
-        ...usedCore.newCard(),
-        rating: Rating.Good,
-        audit: 'schema-source',
-      }).audit
-    ).toBe('schema-source')
   })
 
   it('validates scheduler config input before composing config fields', () => {

--- a/packages/srs-kit/src/scheduler/scheduler.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.ts
@@ -231,8 +231,8 @@ export type SchedulerCreate<
 >
 
 /**
- * Scheduler definition that can be extended with middleware before it is
- * materialized with create().
+ * Scheduler definition that can be extended into independent middleware
+ * branches and materialized with create().
  */
 export interface ComposableScheduler<
   Name extends string | symbol = string | symbol,
@@ -248,10 +248,8 @@ export interface ComposableScheduler<
   readonly create: SchedulerCreate<Env, M, C>
 
   /**
-   * Adds middleware to this scheduler instance.
-   *
-   * Must be called before the first create() call. Once create() has been
-   * called, the scheduler is locked and use() throws.
+   * Returns a new scheduler definition extended with the supplied middleware.
+   * The current scheduler and any cores created from it remain unchanged.
    */
   readonly use: SchedulerUseFn<Name, Env, M, C>
 }


### PR DESCRIPTION
## Summary

This pull request makes the scheduler middleware composition immutable, improving type inference, runtime safety, and performance. The core change is that calling `.use()` now returns a new scheduler instance with the added middleware, instead of mutating the original. This allows for safe branching and isolation of scheduler configurations. The PR also updates tests and type definitions to reflect this new behavior, removes the scheduler locking error, and fixes a TypeScript 7 type inference issue.

**Scheduler Middleware Composition and Immutability**

* Refactored `defineScheduler` so that `.use()` returns a new scheduler instance with the added middleware, leaving the original scheduler and any previously created cores unchanged. Middleware composition is now represented as an immutable chain, allowing safe branching and concurrent usage. [[1]](diffhunk://#diff-0242bd85ceedbc63d47bdd8881d2d3f804787e807db0b57d1fb6517ee3bb7167L1-R42) [[2]](diffhunk://#diff-0242bd85ceedbc63d47bdd8881d2d3f804787e807db0b57d1fb6517ee3bb7167L31-R126) [[3]](diffhunk://#diff-0e7ef6281e130581b00a89e47b7db56287c74115fe34f04c54991193c62eec6eL234-R235) [[4]](diffhunk://#diff-0e7ef6281e130581b00a89e47b7db56287c74115fe34f04c54991193c62eec6eL251-R252)
* Removed the `SRSSchedulerError` and the runtime error that previously prevented adding middleware after calling `.create()`, as this is no longer necessary with immutable composition. [[1]](diffhunk://#diff-32560ff627e75b716f298309ca03609776d78b0ff8b957f6ddc70c66e8547f0eL1-L7) [[2]](diffhunk://#diff-99d2a2ce495c22b6de5d0917d06943023472a5aa9387afcca0275c4506f9ca3aL176-R223)

**Type System and Inference Improvements**

* Fixed TypeScript 7 TS2590 errors in scheduler type inference for better compatibility and developer experience. [[1]](diffhunk://#diff-d357d3b2bf16babf5c479c946e4e43931b2886fab9fde24426a2ca32c94ecc2eR1-R5) [[2]](diffhunk://#diff-5f92685c4eec6a2004cef4bee1e9fba6a58b5cdfc440ce912eba7c318cb05362R25) [[3]](diffhunk://#diff-5f92685c4eec6a2004cef4bee1e9fba6a58b5cdfc440ce912eba7c318cb05362L39-R42) [[4]](diffhunk://#diff-5f92685c4eec6a2004cef4bee1e9fba6a58b5cdfc440ce912eba7c318cb05362L262-R286)

**Tests and Benchmarks**

* Updated and expanded tests to verify that scheduler and core instances are properly isolated after branching with `.use()`, and that middleware composition does not leak between branches. [[1]](diffhunk://#diff-99d2a2ce495c22b6de5d0917d06943023472a5aa9387afcca0275c4506f9ca3aR70-R76) [[2]](diffhunk://#diff-e439099b72b1baf74770609758c93874dd631ce4c64ce6465079323666389af3L188-R255)
* Improved benchmarks to evaluate the performance of various scheduler composition and branching scenarios under the new immutable design. [[1]](diffhunk://#diff-8461217fa9f221d668f1fc3a4f2c85f1d8e90deb7847d2633bb8bd63c83afce6L10-L22) [[2]](diffhunk://#diff-8461217fa9f221d668f1fc3a4f2c85f1d8e90deb7847d2633bb8bd63c83afce6L65-R160)

**Documentation and Minor Code Cleanups**

* Updated comments and documentation to clarify the new immutable branching behavior of scheduler composition. [[1]](diffhunk://#diff-55ac1e9ffdc165d72734fbd016e6b4c131d8c1ec0a51f909684bf65410afc67aR1-R5) [[2]](diffhunk://#diff-0e7ef6281e130581b00a89e47b7db56287c74115fe34f04c54991193c62eec6eL234-R235) [[3]](diffhunk://#diff-0e7ef6281e130581b00a89e47b7db56287c74115fe34f04c54991193c62eec6eL251-R252)
* Minor code cleanups in test files for clarity and correctness. [[1]](diffhunk://#diff-99d2a2ce495c22b6de5d0917d06943023472a5aa9387afcca0275c4506f9ca3aL18) [[2]](diffhunk://#diff-99d2a2ce495c22b6de5d0917d06943023472a5aa9387afcca0275c4506f9ca3aL1509-R1544)

These changes make scheduler composition safer and more predictable, and pave the way for more advanced middleware usage patterns.

## Related Issues

- Closes #

## Changes

- 

## Changeset

- [x] Added a changeset with `pnpm changeset`
- [ ] Not needed because this change does not affect published package behavior or contents

