### PR TITLE
chore: improve DTS build and VS Code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,9 @@
 {
-  "typescript.preferences.importModuleSpecifier": "non-relative",
-  "typescript.preferences.quoteStyle": "single",
-  "typescript.preferences.importModuleSpecifierEnding": "js",
-  // "typescript.preferGoToSourceDefinition": true,
-  "typescript.tsdk": "./node_modules/typescript/lib",
+  "js/ts.preferences.importModuleSpecifier": "non-relative",
+  "js/ts.preferences.quoteStyle": "single",
+  "js/ts.preferences.importModuleSpecifierEnding": "js",
+  "js/ts.preferGoToSourceDefinition": true,
+  "js/ts.tsdk.path": "./node_modules/typescript/lib",
   "editor.defaultFormatter": "biomejs.biome",
   "editor.codeActionsOnSave": {
     "source.fixAll.biome": "explicit",

--- a/packages/fsrs/tsdown.config.ts
+++ b/packages/fsrs/tsdown.config.ts
@@ -13,7 +13,7 @@ export default defineConfig([
     },
     format: ['esm', 'cjs'],
     outDir: 'dist',
-    dts: true
+    dts: true,
     clean: true,
     sourcemap: false,
     minify: false,

--- a/packages/fsrs/tsdown.config.ts
+++ b/packages/fsrs/tsdown.config.ts
@@ -13,7 +13,7 @@ export default defineConfig([
     },
     format: ['esm', 'cjs'],
     outDir: 'dist',
-    dts: { cjsReexport: true },
+    dts: true
     clean: true,
     sourcemap: false,
     minify: false,

--- a/packages/fsrs/tsdown.config.ts
+++ b/packages/fsrs/tsdown.config.ts
@@ -13,7 +13,7 @@ export default defineConfig([
     },
     format: ['esm', 'cjs'],
     outDir: 'dist',
-    dts: true,
+    dts: { cjsReexport: true },
     clean: true,
     sourcemap: false,
     minify: false,

--- a/packages/srs-kit/package.json
+++ b/packages/srs-kit/package.json
@@ -139,7 +139,8 @@
   "author": "ishiko",
   "license": "BSD-3-Clause",
   "files": [
-    "dist"
+    "dist",
+    "!dist/**/*.d.ts.map"
   ],
   "repository": {
     "type": "git",

--- a/packages/srs-kit/tsdown.config.ts
+++ b/packages/srs-kit/tsdown.config.ts
@@ -20,7 +20,7 @@ const shared = {
       'src/chrono/presets/temporal-instant/index.ts',
     'scheduler/index': 'src/scheduler/index.ts',
   },
-  dts: true,
+  dts: { sourcemap: true },
   clean: true,
   sourcemap: true,
   minify: false,


### PR DESCRIPTION
## Summary
- **fsrs**: Enable `dts.cjsReexport` in tsdown config to eliminate duplicate `.d.cts` declaration files, reducing dist file count
- **srs-kit**: Enable `dts.sourcemap` to generate `.d.ts.map` files for proper "Go to Definition" navigation in monorepo; exclude `.d.ts.map` from npm publish via `files` negation pattern
- **VS Code**: Migrate deprecated `typescript.*` settings to `js/ts.*` namespace and enable `preferGoToSourceDefinition`

## Test plan
- [x] `pnpm --filter ts-fsrs build` succeeds
- [x] `pnpm --filter @open-spaced-repetition/srs-kit build` succeeds
- [x] `pnpm --filter ts-fsrs typecheck` passes
- [x] `.d.ts.map` files excluded from `npm pack --dry-run`
- [x] Verify "Go to Definition" on `ModelCore` jumps to `srs-kit/src/model/model.ts`