### PR TITLE
feat(model): expose algorithm instance on ModelCore

### DIFF
--- a/packages/fsrs/src/kit/types.ts
+++ b/packages/fsrs/src/kit/types.ts
@@ -1,7 +1,9 @@
 import type { ModelCore } from '@open-spaced-repetition/srs-kit/model'
 import type { FSRSState } from '../models'
+import type { FSRS6Algorithm } from '../models/fsrs-6/algorithm.js'
 
 /** @internal */
 export type IFSRSModel = ModelCore<{
   readonly memoryState: FSRSState
+  readonly algorithm: FSRS6Algorithm
 }>

--- a/packages/fsrs/src/models/fsrs-3/index.ts
+++ b/packages/fsrs/src/models/fsrs-3/index.ts
@@ -7,6 +7,7 @@ export {
   FSRS3_MODEL_BOUNDS,
   FSRS3ParameterBounds,
 } from './constants.js'
+export type { FSRS3ModelCore } from './model.js'
 export { FSRS3Model } from './model.js'
 export type { FSRS3Config } from './parameters.js'
 export {

--- a/packages/fsrs/src/models/fsrs-3/model.spec.ts
+++ b/packages/fsrs/src/models/fsrs-3/model.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { type Grade, Rating } from '../../models.js'
+import { FSRS3Algorithm } from './algorithm.js'
 import { FSRS3_DEFAULT_WEIGHTS } from './constants.js'
 import { FSRS3Model } from './model.js'
 import { migrateFSRS3Parameters } from './parameters.js'
@@ -41,6 +42,16 @@ describe('FSRS3Model', () => {
       { difficulty: 4.8527, stability: 4.4073 },
       { difficulty: 4.8527, stability: 7.4609786 },
     ])
+  })
+
+  it('exposes the underlying algorithm instance', () => {
+    const model = FSRS3Model.create({
+      config: {
+        weights: FSRS3_DEFAULT_WEIGHTS,
+      },
+    })
+
+    expect(model.algorithm).toBeInstanceOf(FSRS3Algorithm)
   })
 
   it('validates config with schema before creating model runtime', () => {

--- a/packages/fsrs/src/models/fsrs-3/model.ts
+++ b/packages/fsrs/src/models/fsrs-3/model.ts
@@ -15,12 +15,13 @@ import {
   migrateFSRS3Parameters,
 } from './parameters.js'
 
-const createFSRS3Model = (
-  config: FSRS3Config
-): ModelCore<{
+export type FSRS3ModelCore = ModelCore<{
   readonly config: FSRS3Config
   readonly memoryState: FSRSState
-}> => {
+  readonly algorithm: FSRS3Algorithm
+}>
+
+const createFSRS3Model = (config: FSRS3Config): FSRS3ModelCore => {
   const bounds = FSRS3_MODEL_BOUNDS
   const algo = new FSRS3Algorithm(config.weights, bounds)
 
@@ -67,6 +68,7 @@ const createFSRS3Model = (
   return {
     config,
     bounds,
+    algorithm: algo,
     step,
     nextInterval,
     forgettingCurve,

--- a/packages/fsrs/src/models/fsrs-4/index.ts
+++ b/packages/fsrs/src/models/fsrs-4/index.ts
@@ -6,6 +6,7 @@ export {
   FSRS4_DEFAULT_WEIGHTS,
   FSRS4_MODEL_BOUNDS,
 } from './constants.js'
+export type { FSRS4ModelCore } from './model.js'
 export { FSRS4Model } from './model.js'
 export type { FSRS4Config } from './parameters.js'
 export {

--- a/packages/fsrs/src/models/fsrs-4/model.spec.ts
+++ b/packages/fsrs/src/models/fsrs-4/model.spec.ts
@@ -4,6 +4,7 @@ import type {
   ModelMemoryOf,
 } from '@open-spaced-repetition/srs-kit/model'
 import { describe, expect, it } from 'vitest'
+import { FSRS4Algorithm } from './algorithm.js'
 import { FSRS4_DEFAULT_WEIGHTS, FSRS4Model, forgettingCurve } from './index.js'
 
 type FSRSState = ModelMemoryOf<typeof FSRS4Model>
@@ -81,6 +82,16 @@ describe('FSRS-4 model', () => {
     expect(Number.isFinite(model.nextInterval(initialState, 0.9))).toBe(true)
     expect(Number.isFinite(model.forgettingCurve(initialState, 14))).toBe(true)
     expect(states).toHaveLength(2)
+  })
+
+  it('exposes the underlying algorithm instance', () => {
+    const model = FSRS4Model.create({
+      config: {
+        weights,
+      },
+    })
+
+    expect(model.algorithm).toBeInstanceOf(FSRS4Algorithm)
   })
 
   it('uses FSRS-4 default weights', () => {

--- a/packages/fsrs/src/models/fsrs-4/model.ts
+++ b/packages/fsrs/src/models/fsrs-4/model.ts
@@ -15,12 +15,13 @@ import {
   migrateFSRS4Parameters,
 } from './parameters.js'
 
-const createFSRS4Model = (
-  config: FSRS4Config
-): ModelCore<{
+export type FSRS4ModelCore = ModelCore<{
   readonly config: FSRS4Config
   readonly memoryState: FSRSState
-}> => {
+  readonly algorithm: FSRS4Algorithm
+}>
+
+const createFSRS4Model = (config: FSRS4Config): FSRS4ModelCore => {
   const bounds = FSRS4_MODEL_BOUNDS
 
   const algo = new FSRS4Algorithm(config.weights, FSRS4_MODEL_BOUNDS)
@@ -68,6 +69,7 @@ const createFSRS4Model = (
   return {
     config,
     bounds,
+    algorithm: algo,
     step,
     nextInterval,
     forgettingCurve,

--- a/packages/fsrs/src/models/fsrs-4dot5/index.ts
+++ b/packages/fsrs/src/models/fsrs-4dot5/index.ts
@@ -8,6 +8,7 @@ export {
   FSRS4Dot5_FACTOR,
   FSRS4Dot5_MODEL_BOUNDS,
 } from './constants.js'
+export type { FSRS4Dot5ModelCore } from './model.js'
 export { FSRS4Dot5Model } from './model.js'
 export type { FSRS4Dot5Config } from './parameters.js'
 export {

--- a/packages/fsrs/src/models/fsrs-4dot5/model.spec.ts
+++ b/packages/fsrs/src/models/fsrs-4dot5/model.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { Rating } from '../../models.js'
+import { FSRS4Dot5Algorithm } from './algorithm.js'
 import { FSRS4Dot5_DEFAULT_WEIGHTS, FSRS4Dot5Model } from './index.js'
 
 describe('FSRS-4.5 model', () => {
@@ -54,6 +55,16 @@ describe('FSRS-4.5 model', () => {
         } as never,
       }).config
     ).toEqual(model.config)
+  })
+
+  it('exposes the underlying algorithm instance', () => {
+    const model = FSRS4Dot5Model.create({
+      config: {
+        weights,
+      },
+    })
+
+    expect(model.algorithm).toBeInstanceOf(FSRS4Dot5Algorithm)
   })
 
   it('exposes the FSRS-4.5 model runtime methods', () => {

--- a/packages/fsrs/src/models/fsrs-4dot5/model.ts
+++ b/packages/fsrs/src/models/fsrs-4dot5/model.ts
@@ -15,12 +15,13 @@ import {
   migrateFSRS4Dot5Parameters,
 } from './parameters.js'
 
-const createFSRS4Dot5Model = (
-  config: FSRS4Dot5Config
-): ModelCore<{
+export type FSRS4Dot5ModelCore = ModelCore<{
   readonly config: FSRS4Dot5Config
   readonly memoryState: FSRSState
-}> => {
+  readonly algorithm: FSRS4Dot5Algorithm
+}>
+
+const createFSRS4Dot5Model = (config: FSRS4Dot5Config): FSRS4Dot5ModelCore => {
   const bounds = FSRS4Dot5_MODEL_BOUNDS
 
   const algo = new FSRS4Dot5Algorithm(config.weights, FSRS4Dot5_MODEL_BOUNDS)
@@ -68,6 +69,7 @@ const createFSRS4Dot5Model = (
   return {
     config,
     bounds,
+    algorithm: algo,
     step,
     nextInterval,
     forgettingCurve,

--- a/packages/fsrs/src/models/fsrs-5/index.ts
+++ b/packages/fsrs/src/models/fsrs-5/index.ts
@@ -9,6 +9,7 @@ export {
   FSRS5_MODEL_BOUNDS,
   FSRS5_W17_W18_CEILING,
 } from './constants.js'
+export type { FSRS5ModelCore } from './model.js'
 export { FSRS5Model } from './model.js'
 export type { FSRS5Config } from './parameters.js'
 export {

--- a/packages/fsrs/src/models/fsrs-5/model.spec.ts
+++ b/packages/fsrs/src/models/fsrs-5/model.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { type Grade, Rating } from '../../models.js'
+import { FSRS5Algorithm } from './algorithm.js'
 import { FSRS5_DEFAULT_WEIGHTS } from './constants.js'
 import { FSRS5Model } from './model.js'
 import { migrateFSRS5Parameters } from './parameters.js'
@@ -55,6 +56,17 @@ describe('FSRS5Model', () => {
         elapsedDays: 1,
       })
     )
+  })
+
+  it('exposes the underlying algorithm instance', () => {
+    const model = FSRS5Model.create({
+      config: {
+        weights: FSRS5_DEFAULT_WEIGHTS,
+        enableShortTerm: true,
+      },
+    })
+
+    expect(model.algorithm).toBeInstanceOf(FSRS5Algorithm)
   })
 
   it('validates config with schema before creating model runtime', () => {

--- a/packages/fsrs/src/models/fsrs-5/model.ts
+++ b/packages/fsrs/src/models/fsrs-5/model.ts
@@ -15,12 +15,13 @@ import {
   migrateFSRS5Parameters,
 } from './parameters.js'
 
-const createFSRS5Model = (
-  config: FSRS5Config
-): ModelCore<{
+export type FSRS5ModelCore = ModelCore<{
   readonly config: FSRS5Config
   readonly memoryState: FSRSState
-}> => {
+  readonly algorithm: FSRS5Algorithm
+}>
+
+const createFSRS5Model = (config: FSRS5Config): FSRS5ModelCore => {
   const bounds = FSRS5_MODEL_BOUNDS
 
   const algo = new FSRS5Algorithm(
@@ -72,6 +73,7 @@ const createFSRS5Model = (
   return {
     config,
     bounds,
+    algorithm: algo,
     step,
     nextInterval,
     forgettingCurve,

--- a/packages/fsrs/src/models/fsrs-6/constants.ts
+++ b/packages/fsrs/src/models/fsrs-6/constants.ts
@@ -34,7 +34,7 @@ export const FSRS6_DEFAULT_WEIGHTS = Object.freeze([
   0.0912,
   0.0658,
   FSRS6_DECAY,
-])
+]) as number[]
 
 export const FSRS6ParameterBounds = (
   w17W18Ceiling: number,

--- a/packages/fsrs/src/models/fsrs-6/index.ts
+++ b/packages/fsrs/src/models/fsrs-6/index.ts
@@ -9,6 +9,7 @@ export {
   FSRS6_MODEL_BOUNDS,
   FSRS6_W17_W18_CEILING,
 } from './constants.js'
+export type { FSRS6ModelCore } from './model.js'
 export { FSRS6Model } from './model.js'
 export type { FSRS6Config } from './parameters.js'
 export {

--- a/packages/fsrs/src/models/fsrs-6/model.spec.ts
+++ b/packages/fsrs/src/models/fsrs-6/model.spec.ts
@@ -1,10 +1,23 @@
 import { describe, expect, it } from 'vitest'
 import { FSRS5_DEFAULT_WEIGHTS } from '../fsrs-5/constants.js'
+import { FSRS6Algorithm } from './algorithm.js'
 import { FSRS6_DEFAULT_WEIGHTS } from './constants.js'
 import { FSRS6Model } from './model.js'
 import { migrateFSRS6Parameters } from './parameters.js'
 
 describe('FSRS6Model', () => {
+  it('exposes the underlying algorithm instance', () => {
+    const model = FSRS6Model.create({
+      config: {
+        weights: FSRS6_DEFAULT_WEIGHTS,
+        enableShortTerm: true,
+        numRelearningSteps: 0,
+      },
+    })
+
+    expect(model.algorithm).toBeInstanceOf(FSRS6Algorithm)
+  })
+
   it('validates config with schema before creating model runtime', () => {
     expect(() =>
       FSRS6Model.create({

--- a/packages/fsrs/src/models/fsrs-6/model.ts
+++ b/packages/fsrs/src/models/fsrs-6/model.ts
@@ -15,12 +15,13 @@ import {
   migrateFSRS6Parameters,
 } from './parameters.js'
 
-const createFSRS6Model = (
-  config: FSRS6Config
-): ModelCore<{
+export type FSRS6ModelCore = ModelCore<{
   readonly config: FSRS6Config
   readonly memoryState: FSRSState
-}> => {
+  readonly algorithm: FSRS6Algorithm
+}>
+
+const createFSRS6Model = (config: FSRS6Config): FSRS6ModelCore => {
   const bounds = FSRS6_MODEL_BOUNDS
 
   const algo = new FSRS6Algorithm(
@@ -72,6 +73,7 @@ const createFSRS6Model = (
   return {
     config,
     bounds,
+    algorithm: algo,
     step,
     nextInterval,
     forgettingCurve,

--- a/packages/srs-kit/src/model/model.ts
+++ b/packages/srs-kit/src/model/model.ts
@@ -44,6 +44,7 @@ export type ModelBounds<MemoryState extends object> = Prettify<
 export type BlankModelCoreEnv = {
   readonly config?: unknown
   readonly memoryState: object
+  readonly algorithm: unknown
 }
 
 type ModelCoreConfig<Env extends BlankModelCoreEnv> = Env extends {
@@ -55,6 +56,7 @@ type ModelCoreConfig<Env extends BlankModelCoreEnv> = Env extends {
 export interface ModelCore<Env extends BlankModelCoreEnv = BlankModelCoreEnv> {
   readonly config: ModelCoreConfig<Env>
   readonly bounds: ModelBounds<Env['memoryState']>
+  readonly algorithm: Env['algorithm']
   readonly step: (
     input: ModelStepInput<Env['memoryState']>
   ) => Env['memoryState']
@@ -89,7 +91,10 @@ export interface ModelSchema<
   readonly memoryState: Schema['memoryState']
 }
 
-export type ModelCreate<Schema extends BlankModelSchema> = (ctx: {
+export type ModelCreate<
+  Schema extends BlankModelSchema,
+  Algorithm = unknown,
+> = (ctx: {
   readonly config:
     | SchemaInput<Schema['config']>
     | SchemaOutput<Schema['config']>
@@ -104,12 +109,14 @@ export type ModelCreate<Schema extends BlankModelSchema> = (ctx: {
 }) => ModelCore<{
   readonly config: SchemaOutput<Schema['config']>
   readonly memoryState: SchemaOutput<Schema['memoryState']>
+  readonly algorithm: Algorithm
 }>
 
 export type BlankModelEnv = {
   readonly name: string | symbol
   readonly config: AnySchema
   readonly memoryState: AnyObjectSchema
+  readonly algorithm: unknown
 }
 
 export interface Model<Env extends BlankModelEnv = BlankModelEnv> {
@@ -120,7 +127,7 @@ export interface Model<Env extends BlankModelEnv = BlankModelEnv> {
       readonly config: SchemaOutput<Env['config']>
     }) => SchemaInput<Env['memoryState']>
   }
-  readonly create: ModelCreate<Env>
+  readonly create: ModelCreate<Env, Env['algorithm']>
 }
 
 export type AnyModel = Model<any>
@@ -129,16 +136,29 @@ export function defineModel<
   const Name extends string | symbol,
   const ConfigSchema extends AnySchema,
   const MemoryStateSchema extends AnyObjectSchema,
+  const Algorithm,
 >(
-  definition: Model<{
+  definition: {
+    readonly name: Name
+    readonly schema: ModelSchema<{
+      readonly config: ConfigSchema
+      readonly memoryState: MemoryStateSchema
+    }>
+    readonly defaultValue: {
+      readonly memoryState: (ctx: {
+        readonly config: SchemaOutput<ConfigSchema>
+      }) => SchemaInput<MemoryStateSchema>
+    }
+    readonly create: ModelCreate<
+      { readonly config: ConfigSchema; readonly memoryState: MemoryStateSchema },
+      Algorithm
+    >
+  }
+) {
+  return definition as Model<{
     readonly name: Name
     readonly config: ConfigSchema
     readonly memoryState: MemoryStateSchema
+    readonly algorithm: Algorithm
   }>
-): Model<{
-  readonly name: Name
-  readonly config: ConfigSchema
-  readonly memoryState: MemoryStateSchema
-}> {
-  return definition
 }

--- a/packages/srs-kit/src/model/model.ts
+++ b/packages/srs-kit/src/model/model.ts
@@ -137,24 +137,22 @@ export function defineModel<
   const ConfigSchema extends AnySchema,
   const MemoryStateSchema extends AnyObjectSchema,
   const Algorithm,
->(
-  definition: {
-    readonly name: Name
-    readonly schema: ModelSchema<{
-      readonly config: ConfigSchema
-      readonly memoryState: MemoryStateSchema
-    }>
-    readonly defaultValue: {
-      readonly memoryState: (ctx: {
-        readonly config: SchemaOutput<ConfigSchema>
-      }) => SchemaInput<MemoryStateSchema>
-    }
-    readonly create: ModelCreate<
-      { readonly config: ConfigSchema; readonly memoryState: MemoryStateSchema },
-      Algorithm
-    >
+>(definition: {
+  readonly name: Name
+  readonly schema: ModelSchema<{
+    readonly config: ConfigSchema
+    readonly memoryState: MemoryStateSchema
+  }>
+  readonly defaultValue: {
+    readonly memoryState: (ctx: {
+      readonly config: SchemaOutput<ConfigSchema>
+    }) => SchemaInput<MemoryStateSchema>
   }
-) {
+  readonly create: ModelCreate<
+    { readonly config: ConfigSchema; readonly memoryState: MemoryStateSchema },
+    Algorithm
+  >
+}) {
   return definition as Model<{
     readonly name: Name
     readonly config: ConfigSchema

--- a/packages/srs-kit/src/model/model.type-display.spec.ts
+++ b/packages/srs-kit/src/model/model.type-display.spec.ts
@@ -37,6 +37,7 @@ describe('defineModel type display', () => {
             readonly reviewStep: number;
         };
     }>;
+    readonly algorithm: null;
 }>`,
   }
 
@@ -73,6 +74,7 @@ describe('defineModel type display', () => {
         readonly easeFactor: number;
         readonly reviewStep: number;
     };
+    readonly algorithm: null;
 }>`,
   }
 

--- a/packages/srs-kit/src/model/sm2.test.ts
+++ b/packages/srs-kit/src/model/sm2.test.ts
@@ -88,9 +88,11 @@ function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max)
 }
 
-function createSM2Core(
-  config: SM2Config
-): ModelCore<{ readonly config: SM2Config; readonly memoryState: SM2State }> {
+function createSM2Core(config: SM2Config): ModelCore<{
+  readonly config: SM2Config
+  readonly memoryState: SM2State
+  readonly algorithm: null
+}> {
   const w = config.weights
   const bounds = SM2_MODEL_BOUNDS
 
@@ -165,6 +167,7 @@ function createSM2Core(
   return {
     config,
     bounds,
+    algorithm: null,
     step,
     nextInterval,
     forgettingCurve,

--- a/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
@@ -173,6 +173,7 @@ describe('defineScheduler type display', () => {
             readonly reviewStep: number;
         };
     }>;
+    readonly algorithm: null;
 }>, Chrono<{
     readonly time: SRSSchema<{
         input: {};
@@ -255,6 +256,7 @@ describe('defineScheduler type display', () => {
             readonly reviewStep: number;
         };
     }>;
+    readonly algorithm: null;
 }>, Chrono<{
     readonly time: SRSSchema<{
         input: {};
@@ -341,6 +343,7 @@ describe('defineScheduler type display', () => {
             readonly reviewStep: number;
         };
     }>;
+    readonly algorithm: null;
 }>, Chrono<{
     readonly time: SRSSchema<{
         input: {};
@@ -413,6 +416,7 @@ describe('defineScheduler type display', () => {
         readonly easeFactor: number;
         readonly reviewStep: number;
     };
+    readonly algorithm: null;
 }>, ChronoCore<number>>`,
     sm2NumericCore: `const sm2NumericCore: SchedulerCore<{
     readonly config: {
@@ -472,6 +476,7 @@ describe('defineScheduler type display', () => {
         readonly easeFactor: number;
         readonly reviewStep: number;
     };
+    readonly algorithm: null;
 }>, ChronoCore<number>>`,
   }
 
@@ -558,6 +563,7 @@ describe('defineScheduler type display', () => {
             readonly reviewStep: number;
         };
     }>;
+    readonly algorithm: null;
 }>, Chrono<{
     readonly time: SRSSchema<{
         input: {};
@@ -618,6 +624,7 @@ describe('defineScheduler type display', () => {
         readonly easeFactor: number;
         readonly reviewStep: number;
     };
+    readonly algorithm: null;
 }>, ChronoCore<number>>`,
   }
 


### PR DESCRIPTION
## Summary

- Add `algorithm` property to `ModelCore` interface, exposing the underlying algorithm instance (e.g., `FSRS5Algorithm`) to consumers
- Export named `ModelCore` type aliases (`FSRS3ModelCore`, `FSRS4ModelCore`, etc.) from each model version's barrel
- Inline `defineModel` parameter type to fix TypeScript generic inference — `Omit<Model<...>, 'create'>` prevented TypeScript from inferring `Algorithm` through invariant `ModelCore<Env>`

## Test plan

- [x] Runtime tests for `model.algorithm` instanceof check on all 5 FSRS versions (3, 4, 4.5, 5, 6)
- [x] Type-display specs (`model.type-display.spec.ts`, `scheduler.type-display.spec.ts`) pass with `algorithm: null` for SM2 fixture
- [x] Full srs-kit test suite (201 tests) and fsrs test suite (418 tests) pass
- [x] `tsc --noEmit` clean