### PR TITLE
fix: pin npm version to 11 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
       # Ensure npm 11.5.1 or later is installed
       # https://docs.npmjs.com/trusted-publishers#step-2-configure-your-cicd-workflow
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
       - name: Enter beta prerelease mode (preview only)
         if: github.ref == 'refs/heads/preview'
         run: '[ -f .changeset/pre.json ] || pnpm exec changeset pre enter beta'


### PR DESCRIPTION
## Summary

- 

## Related Issues

- Closes #

## Changes

- 

## Changeset

- [ ] Added a changeset with `pnpm changeset`
- [ ] Not needed because this change does not affect published package behavior or contents

