### PR TITLE
feat(binding): support progress callbacks in threadless WASM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,7 +137,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 [[package]]
 name = "fsrs"
 version = "6.6.2"
-source = "git+https://github.com/ishiko732/fsrs-rs?branch=wasm32-wasip1#f859784ddf105faf35446369a637d5f225da3ba3"
+source = "git+https://github.com/ishiko732/fsrs-rs?branch=wasm32-wasip1#48b2ff3251a040dbc339fd8095262a1cd0f6b380"
 dependencies = [
  "itertools 0.15.0",
  "log",

--- a/packages/binding-test/src/threadless.spec.ts
+++ b/packages/binding-test/src/threadless.spec.ts
@@ -55,11 +55,33 @@ describeThreadless('threadless WASI binding', () => {
           )
 
           ;(async () => {
+            const updates = []
+            let completed = false
+            let lateProgress = false
             const parameters = await computeParameters(items, {
               enableShortTerm: true,
+              timeout: 10,
+              progress: (current, total) => {
+                if (completed) lateProgress = true
+                updates.push([current, total])
+              },
             })
+            completed = true
+            const updatesAtCompletion = updates.length
+            await new Promise((resolve) => setTimeout(resolve, 50))
+
             if (parameters.length !== 21) {
               throw new Error('CommonJS computeParameters returned invalid parameters')
+            }
+            if (updates.length < 2) {
+              throw new Error('CommonJS computeParameters reported insufficient progress')
+            }
+            const [current, total] = updates.at(-1)
+            if (current !== total) {
+              throw new Error('CommonJS computeParameters did not report completion')
+            }
+            if (lateProgress || updates.length !== updatesAtCompletion) {
+              throw new Error('CommonJS computeParameters reported progress after completion')
             }
 
             const metrics = await evaluateWithTimeSeriesSplits(items, {

--- a/packages/binding-test/src/threadless.spec.ts
+++ b/packages/binding-test/src/threadless.spec.ts
@@ -11,14 +11,20 @@ import {
 
 const describeThreadless =
   process.env.NAPI_RS_WASI_FLAVOR === 'wasm32-wasip1' ? describe : describe.skip
-const progressError =
-  'Progress callbacks are not supported by the threadless wasm32-wasip1 target'
 
 function createItem() {
   return new FSRSBindingItem([
     new FSRSBindingReview(3, 0),
     new FSRSBindingReview(4, 1),
   ])
+}
+
+function createTrainingItems() {
+  return convertCsvToFsrsItems(
+    fs.readFileSync(new URL('./revlog.csv', import.meta.url)),
+    4,
+    'Asia/Shanghai'
+  )
 }
 
 describeThreadless('threadless WASI binding', () => {
@@ -72,41 +78,71 @@ describeThreadless('threadless WASI binding', () => {
     )
   })
 
-  test('computes parameters without progress', async () => {
-    const parameters = await computeParameters([createItem()], {
+  test('computes parameters without progress', () => {
+    const parameters = computeParameters([createItem()], {
       enableShortTerm: true,
     })
 
     expect(parameters).toHaveLength(21)
   })
 
-  test('evaluates time-series splits without progress', async () => {
-    const items = convertCsvToFsrsItems(
-      fs.readFileSync(new URL('./revlog.csv', import.meta.url)),
-      4,
-      'Asia/Shanghai'
-    )
-    const metrics = await evaluateWithTimeSeriesSplits(items, {
+  test('evaluates time-series splits without progress', () => {
+    const metrics = evaluateWithTimeSeriesSplits(createTrainingItems(), {
       enableShortTerm: true,
     })
 
-    expect(Number.isFinite(metrics.logLoss)).toBe(true)
-    expect(Number.isFinite(metrics.rmseBins)).toBe(true)
+    expect(metrics).toEqual(
+      expect.objectContaining({
+        logLoss: expect.any(Number),
+        rmseBins: expect.any(Number),
+      })
+    )
   })
 
-  test.each([
-    ['computeParameters', computeParameters],
-    ['evaluateWithTimeSeriesSplits', evaluateWithTimeSeriesSplits],
-  ])('rejects progress before running %s', async (_name, run) => {
-    let called = false
-    const result = run([createItem()], {
+  test('reports training progress', () => {
+    const updates: Array<[number, number]> = []
+    const parameters = computeParameters(createTrainingItems(), {
       enableShortTerm: true,
-      progress: () => {
-        called = true
+      progress: (current, total) => {
+        updates.push([current, total])
       },
     })
 
-    await expect(result).rejects.toThrow(progressError)
-    expect(called).toBe(false)
+    expect(parameters).toHaveLength(21)
+    expect(updates.length).toBeGreaterThan(1)
+    expect(updates.at(-1)?.[0]).toBe(updates.at(-1)?.[1])
+  })
+
+  test('reports each time-series split', () => {
+    const updates: Array<[number, number]> = []
+    const metrics = evaluateWithTimeSeriesSplits(createTrainingItems(), {
+      enableShortTerm: true,
+      progress: (current, total) => {
+        updates.push([current, total])
+      },
+    })
+
+    expect(metrics).toEqual(
+      expect.objectContaining({
+        logLoss: expect.any(Number),
+        rmseBins: expect.any(Number),
+      })
+    )
+    expect(updates).toEqual([
+      [1, 5],
+      [2, 5],
+      [3, 5],
+      [4, 5],
+      [5, 5],
+    ])
+  })
+
+  test('progress can stop training', () => {
+    expect(() =>
+      computeParameters(createTrainingItems(), {
+        enableShortTerm: true,
+        progress: () => false,
+      })
+    ).toThrow('compute_parameters failed')
   })
 })

--- a/packages/binding-test/src/threadless.spec.ts
+++ b/packages/binding-test/src/threadless.spec.ts
@@ -78,19 +78,23 @@ describeThreadless('threadless WASI binding', () => {
     )
   })
 
-  test('computes parameters without progress', () => {
-    const parameters = computeParameters([createItem()], {
+  test('computes parameters without progress', async () => {
+    const result = computeParameters([createItem()], {
       enableShortTerm: true,
     })
+    expect(result).toBeInstanceOf(Promise)
 
+    const parameters = await result
     expect(parameters).toHaveLength(21)
   })
 
-  test('evaluates time-series splits without progress', () => {
-    const metrics = evaluateWithTimeSeriesSplits(createTrainingItems(), {
+  test('evaluates time-series splits without progress', async () => {
+    const result = evaluateWithTimeSeriesSplits(createTrainingItems(), {
       enableShortTerm: true,
     })
+    expect(result).toBeInstanceOf(Promise)
 
+    const metrics = await result
     expect(metrics).toEqual(
       expect.objectContaining({
         logLoss: expect.any(Number),
@@ -99,9 +103,9 @@ describeThreadless('threadless WASI binding', () => {
     )
   })
 
-  test('reports training progress', () => {
+  test('reports training progress', async () => {
     const updates: Array<[number, number]> = []
-    const parameters = computeParameters(createTrainingItems(), {
+    const parameters = await computeParameters(createTrainingItems(), {
       enableShortTerm: true,
       progress: (current, total) => {
         updates.push([current, total])
@@ -113,9 +117,9 @@ describeThreadless('threadless WASI binding', () => {
     expect(updates.at(-1)?.[0]).toBe(updates.at(-1)?.[1])
   })
 
-  test('reports each time-series split', () => {
+  test('reports each time-series split', async () => {
     const updates: Array<[number, number]> = []
-    const metrics = evaluateWithTimeSeriesSplits(createTrainingItems(), {
+    const metrics = await evaluateWithTimeSeriesSplits(createTrainingItems(), {
       enableShortTerm: true,
       progress: (current, total) => {
         updates.push([current, total])
@@ -137,12 +141,12 @@ describeThreadless('threadless WASI binding', () => {
     ])
   })
 
-  test('progress can stop training', () => {
-    expect(() =>
+  test('progress can stop training', async () => {
+    await expect(
       computeParameters(createTrainingItems(), {
         enableShortTerm: true,
         progress: () => false,
       })
-    ).toThrow('compute_parameters failed')
+    ).rejects.toThrow('compute_parameters failed')
   })
 })

--- a/packages/binding-test/src/train.spec.ts
+++ b/packages/binding-test/src/train.spec.ts
@@ -70,21 +70,23 @@ describe('FSRS compute_parameters', () => {
     console.log('Minimal data parameters:', parameters)
   })
 
-  test('compute_parameters passes external training config', async () => {
+  test('compute_parameters rejects invalid external training config', async () => {
     const item = createMinimalTestItem()
 
     await expect(
-      computeParameters([item], {
-        enableShortTerm: true,
-        trainingConfig: {
-          numEpochs: 5,
-          batchSize: 0,
-          seed: 2023,
-          maxSeqLen: 256,
-          learningRate: 0.04,
-          gamma: 0.0001,
-        },
-      })
+      Promise.resolve().then(() =>
+        computeParameters([item], {
+          enableShortTerm: true,
+          trainingConfig: {
+            numEpochs: 5,
+            batchSize: 0,
+            seed: 2023,
+            maxSeqLen: 256,
+            learningRate: 0.04,
+            gamma: 0.0001,
+          },
+        })
+      )
     ).rejects.toThrow('compute_parameters failed')
   })
 

--- a/packages/binding-test/src/train.spec.ts
+++ b/packages/binding-test/src/train.spec.ts
@@ -70,23 +70,21 @@ describe('FSRS compute_parameters', () => {
     console.log('Minimal data parameters:', parameters)
   })
 
-  test('compute_parameters rejects invalid external training config', async () => {
+  test('compute_parameters passes external training config', async () => {
     const item = createMinimalTestItem()
 
     await expect(
-      Promise.resolve().then(() =>
-        computeParameters([item], {
-          enableShortTerm: true,
-          trainingConfig: {
-            numEpochs: 5,
-            batchSize: 0,
-            seed: 2023,
-            maxSeqLen: 256,
-            learningRate: 0.04,
-            gamma: 0.0001,
-          },
-        })
-      )
+      computeParameters([item], {
+        enableShortTerm: true,
+        trainingConfig: {
+          numEpochs: 5,
+          batchSize: 0,
+          seed: 2023,
+          maxSeqLen: 256,
+          learningRate: 0.04,
+          gamma: 0.0001,
+        },
+      })
     ).rejects.toThrow('compute_parameters failed')
   })
 

--- a/packages/binding/check-threadless-package.mjs
+++ b/packages/binding/check-threadless-package.mjs
@@ -184,6 +184,23 @@ function nextStatesSnapshot(label, FSRSBinding) {
 
 function smokeTestThreadlessEntry() {
   const binding = require('@open-spaced-repetition/binding-wasm32-wasip1')
+  for (const name of ['computeParameters', 'evaluateWithTimeSeriesSplits']) {
+    assert.equal(
+      typeof binding[name],
+      'function',
+      `Threadless default entry is missing ${name}`
+    )
+  }
+  for (const name of [
+    'computeParametersSync',
+    'evaluateWithTimeSeriesSplitsSync',
+  ]) {
+    assert.equal(
+      binding[name],
+      undefined,
+      `Threadless default entry still exposes ${name}`
+    )
+  }
   return nextStatesSnapshot('Threadless default entry', binding.FSRSBinding)
 }
 

--- a/packages/binding/src/evaluate.rs
+++ b/packages/binding/src/evaluate.rs
@@ -1,6 +1,8 @@
-use napi::bindgen_prelude::Result;
+#[cfg(threadless_wasm)]
+use napi::bindgen_prelude::PromiseRaw;
 #[cfg(not(threadless_wasm))]
-use napi::bindgen_prelude::{AsyncTask, Env, Task};
+use napi::bindgen_prelude::{AsyncTask, Task};
+use napi::bindgen_prelude::{Env, Result};
 use napi_derive::napi;
 #[cfg(not(threadless_wasm))]
 use std::sync::{Arc, Mutex};
@@ -19,13 +21,14 @@ pub fn evaluate_with_time_series_splits(
   AsyncTask::new(EvaluateParametersTask::new(train_set, options.as_ref()))
 }
 
-/// Evaluate parameters synchronously inside a threadless WASM worker.
+/// Evaluate parameters on the current thread inside a threadless WASM worker.
 #[cfg(threadless_wasm)]
-#[napi(catch_unwind)]
-pub fn evaluate_with_time_series_splits(
+#[napi(ts_return_type = "Promise<ModelEvaluation>", catch_unwind)]
+pub fn evaluate_with_time_series_splits<'env>(
+  env: &'env Env,
   train_set: Vec<&FSRSItem>,
   #[napi(ts_arg_type = "ComputeParametersOptions")] options: Option<ComputeParametersOptions>,
-) -> Result<ModelEvaluation> {
+) -> Result<PromiseRaw<'env, ModelEvaluation>> {
   let resolved = ComputeParametersOptions::resolve(options.as_ref());
   let callback = options
     .as_ref()
@@ -60,9 +63,12 @@ pub fn evaluate_with_time_series_splits(
   });
 
   if let Some(error) = callback_error {
-    return Err(error);
+    return PromiseRaw::reject(env, error);
   }
-  result
+  match result {
+    Ok(metrics) => PromiseRaw::resolve(env, metrics),
+    Err(error) => PromiseRaw::reject(env, error),
+  }
 }
 
 #[cfg(not(threadless_wasm))]

--- a/packages/binding/src/evaluate.rs
+++ b/packages/binding/src/evaluate.rs
@@ -1,4 +1,6 @@
-use napi::bindgen_prelude::{AsyncTask, Env, Result, Task};
+use napi::bindgen_prelude::Result;
+#[cfg(not(threadless_wasm))]
+use napi::bindgen_prelude::{AsyncTask, Env, Task};
 use napi_derive::napi;
 #[cfg(not(threadless_wasm))]
 use std::sync::{Arc, Mutex};
@@ -8,6 +10,7 @@ use crate::progress;
 use crate::{ComputeParametersOptions, FSRSItem, ModelEvaluation, prepare_items};
 
 /// Evaluate parameters using time-series splits.
+#[cfg(not(threadless_wasm))]
 #[napi(ts_return_type = "Promise<ModelEvaluation>", catch_unwind)]
 pub fn evaluate_with_time_series_splits(
   train_set: Vec<&FSRSItem>,
@@ -16,6 +19,53 @@ pub fn evaluate_with_time_series_splits(
   AsyncTask::new(EvaluateParametersTask::new(train_set, options.as_ref()))
 }
 
+/// Evaluate parameters synchronously inside a threadless WASM worker.
+#[cfg(threadless_wasm)]
+#[napi(catch_unwind)]
+pub fn evaluate_with_time_series_splits(
+  train_set: Vec<&FSRSItem>,
+  #[napi(ts_arg_type = "ComputeParametersOptions")] options: Option<ComputeParametersOptions>,
+) -> Result<ModelEvaluation> {
+  let resolved = ComputeParametersOptions::resolve(options.as_ref());
+  let callback = options
+    .as_ref()
+    .and_then(|options| options.progress.as_ref());
+  let mut callback_error = None;
+  let result = fsrs::evaluate_with_time_series_splits(
+    fsrs::ComputeParametersInput {
+      card_ids: None,
+      train_set: prepare_items(train_set),
+      progress: None,
+      enable_short_term: resolved.enable_short_term,
+      num_relearning_steps: resolved.num_relearning_steps,
+      training_config: resolved.training_config,
+    },
+    |progress| match callback {
+      Some(callback) => {
+        match callback.call((progress.current as u32, progress.total as u32).into()) {
+          Ok(Some(false)) => false,
+          Ok(_) => true,
+          Err(error) => {
+            callback_error = Some(error);
+            false
+          }
+        }
+      }
+      None => true,
+    },
+  )
+  .map(ModelEvaluation::from)
+  .map_err(|error| {
+    napi::Error::from_reason(format!("evaluate_with_time_series_splits failed: {error}"))
+  });
+
+  if let Some(error) = callback_error {
+    return Err(error);
+  }
+  result
+}
+
+#[cfg(not(threadless_wasm))]
 impl Task for EvaluateParametersTask {
   type Output = fsrs::ModelEvaluation;
   type JsValue = ModelEvaluation;
@@ -119,53 +169,5 @@ impl EvaluateParametersTask {
     }
 
     result
-  }
-}
-
-// ============================================================================
-// Threadless wasm: evaluation runs serially without progress reporting
-// ============================================================================
-
-#[cfg(threadless_wasm)]
-pub struct EvaluateParametersTask {
-  pub(crate) train: Vec<fsrs::FSRSItem>,
-  pub(crate) enable_short_term: bool,
-  pub(crate) num_relearning_steps: Option<usize>,
-  pub(crate) training_config: Option<fsrs::TrainingConfig>,
-  pub(crate) progress_error: Option<&'static str>,
-}
-
-#[cfg(threadless_wasm)]
-impl EvaluateParametersTask {
-  fn new(train_set: Vec<&FSRSItem>, options: Option<&ComputeParametersOptions>) -> Self {
-    let resolved = ComputeParametersOptions::resolve(options);
-    Self {
-      train: prepare_items(train_set),
-      enable_short_term: resolved.enable_short_term,
-      num_relearning_steps: resolved.num_relearning_steps,
-      training_config: resolved.training_config,
-      progress_error: resolved
-        .progress_requested
-        .then_some(crate::threadless::PROGRESS_ERROR),
-    }
-  }
-
-  fn evaluate(&mut self) -> Result<fsrs::ModelEvaluation> {
-    if let Some(reason) = self.progress_error {
-      return Err(napi::Error::from_reason(reason));
-    }
-
-    fsrs::evaluate_with_time_series_splits(
-      fsrs::ComputeParametersInput {
-        card_ids: None,
-        train_set: std::mem::take(&mut self.train),
-        progress: None,
-        enable_short_term: self.enable_short_term,
-        num_relearning_steps: self.num_relearning_steps,
-        training_config: self.training_config,
-      },
-      |_| true,
-    )
-    .map_err(|e| napi::Error::from_reason(format!("evaluate_with_time_series_splits failed: {e}")))
   }
 }

--- a/packages/binding/src/lib.rs
+++ b/packages/binding/src/lib.rs
@@ -8,8 +8,6 @@ mod model;
 #[cfg(not(threadless_wasm))]
 mod progress;
 mod steps;
-#[cfg(threadless_wasm)]
-mod threadless;
 mod timezone;
 mod train;
 pub use convert::*;

--- a/packages/binding/src/model.rs
+++ b/packages/binding/src/model.rs
@@ -315,9 +315,6 @@ pub(crate) struct ResolvedOptions {
   /// Progress poll interval; only meaningful where a poller can run.
   #[cfg(not(threadless_wasm))]
   pub(crate) timeout_ms: u32,
-  /// Whether the caller asked for progress reports, which the threadless target rejects.
-  #[cfg(threadless_wasm)]
-  pub(crate) progress_requested: bool,
 }
 
 impl ComputeParametersOptions<'_> {
@@ -338,8 +335,6 @@ impl ComputeParametersOptions<'_> {
       timeout_ms: options
         .and_then(|x| x.timeout)
         .unwrap_or(Self::DEFAULT_TIMEOUT_MS),
-      #[cfg(threadless_wasm)]
-      progress_requested: options.and_then(|x| x.progress.as_ref()).is_some(),
     }
   }
 }

--- a/packages/binding/src/threadless.rs
+++ b/packages/binding/src/threadless.rs
@@ -1,7 +1,0 @@
-//! Error messages for the threadless `wasm32-wasip1` target.
-//!
-//! This target has no threads, so the progress poller (`crate::progress`) is not
-//! compiled in and the APIs relying on it reject the call instead.
-
-pub const PROGRESS_ERROR: &str =
-  "Progress callbacks are not supported by the threadless wasm32-wasip1 target";

--- a/packages/binding/src/train.rs
+++ b/packages/binding/src/train.rs
@@ -1,11 +1,15 @@
-use napi::bindgen_prelude::{AsyncTask, Env, Result, Task};
+use napi::bindgen_prelude::Result;
+#[cfg(not(threadless_wasm))]
+use napi::bindgen_prelude::{AsyncTask, Env, Task};
 use napi_derive::napi;
+#[cfg(not(threadless_wasm))]
 use std::sync::{Arc, Mutex};
 
 #[cfg(not(threadless_wasm))]
 use crate::progress;
 use crate::{ComputeParametersOptions, FSRSItem};
 
+#[cfg(not(threadless_wasm))]
 pub struct ComputeParametersTask {
   pub(crate) train: Vec<fsrs::FSRSItem>,
   pub(crate) state: Arc<Mutex<fsrs::CombinedProgressState>>,
@@ -18,11 +22,9 @@ pub struct ComputeParametersTask {
   pub(crate) progress_cb: Option<progress::ProgressCallback>,
   #[cfg(threaded_wasm)]
   pub(crate) progress_thread: Option<std::thread::JoinHandle<()>>,
-  /// Set when the caller passed a progress callback this target cannot honour.
-  #[cfg(threadless_wasm)]
-  pub(crate) progress_error: Option<&'static str>,
 }
 
+#[cfg(not(threadless_wasm))]
 impl ComputeParametersTask {
   fn new(train_set: Vec<&FSRSItem>, options: Option<&ComputeParametersOptions>) -> Self {
     let resolved = ComputeParametersOptions::resolve(options);
@@ -52,24 +54,16 @@ impl ComputeParametersTask {
       progress_cb: progress::build_callback(options),
       #[cfg(threaded_wasm)]
       progress_thread,
-      #[cfg(threadless_wasm)]
-      progress_error: resolved
-        .progress_requested
-        .then_some(crate::threadless::PROGRESS_ERROR),
     }
   }
 }
 
+#[cfg(not(threadless_wasm))]
 impl Task for ComputeParametersTask {
   type Output = Vec<f32>;
   type JsValue = Vec<f64>;
 
   fn compute(&mut self) -> Result<Self::Output> {
-    #[cfg(threadless_wasm)]
-    if let Some(reason) = self.progress_error {
-      return Err(napi::Error::from_reason(reason));
-    }
-
     #[cfg(not(target_arch = "wasm32"))]
     let progress_thread = progress::spawn_progress_poller(
       Arc::clone(&self.state),
@@ -105,10 +99,57 @@ impl Task for ComputeParametersTask {
 }
 
 /// Calculate appropriate parameters for the provided review history.
+#[cfg(not(threadless_wasm))]
 #[napi(ts_return_type = "Promise<number[]>", catch_unwind)]
 pub fn compute_parameters(
   train_set: Vec<&FSRSItem>,
   #[napi(ts_arg_type = "ComputeParametersOptions")] options: Option<ComputeParametersOptions>,
 ) -> AsyncTask<ComputeParametersTask> {
   AsyncTask::new(ComputeParametersTask::new(train_set, options.as_ref()))
+}
+
+/// Calculate appropriate parameters synchronously inside a threadless WASM worker.
+#[cfg(threadless_wasm)]
+#[napi(catch_unwind)]
+pub fn compute_parameters(
+  train_set: Vec<&FSRSItem>,
+  #[napi(ts_arg_type = "ComputeParametersOptions")] options: Option<ComputeParametersOptions>,
+) -> Result<Vec<f64>> {
+  let resolved = ComputeParametersOptions::resolve(options.as_ref());
+  let callback = options
+    .as_ref()
+    .and_then(|options| options.progress.as_ref());
+  let mut callback_error = None;
+  let result = fsrs::compute_parameters_with_progress(
+    fsrs::ComputeParametersInput {
+      card_ids: None,
+      train_set: train_set
+        .into_iter()
+        .map(|item| item.inner.clone())
+        .collect(),
+      progress: None,
+      enable_short_term: resolved.enable_short_term,
+      num_relearning_steps: resolved.num_relearning_steps,
+      training_config: resolved.training_config,
+    },
+    |progress| match callback {
+      Some(callback) => {
+        match callback.call((progress.current as u32, progress.total as u32).into()) {
+          Ok(Some(false)) => false,
+          Ok(_) => true,
+          Err(error) => {
+            callback_error = Some(error);
+            false
+          }
+        }
+      }
+      None => true,
+    },
+  )
+  .map_err(|error| napi::Error::from_reason(format!("compute_parameters failed: {error}")));
+
+  if let Some(error) = callback_error {
+    return Err(error);
+  }
+  result.map(|parameters| parameters.into_iter().map(f64::from).collect())
 }

--- a/packages/binding/src/train.rs
+++ b/packages/binding/src/train.rs
@@ -1,6 +1,8 @@
-use napi::bindgen_prelude::Result;
+#[cfg(threadless_wasm)]
+use napi::bindgen_prelude::PromiseRaw;
 #[cfg(not(threadless_wasm))]
-use napi::bindgen_prelude::{AsyncTask, Env, Task};
+use napi::bindgen_prelude::{AsyncTask, Task};
+use napi::bindgen_prelude::{Env, Result};
 use napi_derive::napi;
 #[cfg(not(threadless_wasm))]
 use std::sync::{Arc, Mutex};
@@ -108,13 +110,14 @@ pub fn compute_parameters(
   AsyncTask::new(ComputeParametersTask::new(train_set, options.as_ref()))
 }
 
-/// Calculate appropriate parameters synchronously inside a threadless WASM worker.
+/// Calculate appropriate parameters on the current thread inside a threadless WASM worker.
 #[cfg(threadless_wasm)]
-#[napi(catch_unwind)]
-pub fn compute_parameters(
+#[napi(ts_return_type = "Promise<number[]>", catch_unwind)]
+pub fn compute_parameters<'env>(
+  env: &'env Env,
   train_set: Vec<&FSRSItem>,
   #[napi(ts_arg_type = "ComputeParametersOptions")] options: Option<ComputeParametersOptions>,
-) -> Result<Vec<f64>> {
+) -> Result<PromiseRaw<'env, Vec<f64>>> {
   let resolved = ComputeParametersOptions::resolve(options.as_ref());
   let callback = options
     .as_ref()
@@ -149,7 +152,13 @@ pub fn compute_parameters(
   .map_err(|error| napi::Error::from_reason(format!("compute_parameters failed: {error}")));
 
   if let Some(error) = callback_error {
-    return Err(error);
+    return PromiseRaw::reject(env, error);
   }
-  result.map(|parameters| parameters.into_iter().map(f64::from).collect())
+  match result {
+    Ok(parameters) => PromiseRaw::resolve(
+      env,
+      parameters.into_iter().map(f64::from).collect::<Vec<_>>(),
+    ),
+    Err(error) => PromiseRaw::reject(env, error),
+  }
 }


### PR DESCRIPTION
## Summary

- keep `computeParameters` and `evaluateWithTimeSeriesSplits` Promise-based on every target: `AsyncTask` on native/threaded targets and `PromiseRaw` around serial current-thread execution on threadless WASM
- forward progress callbacks directly from serial FSRS execution, including cancellation and callback error propagation
- keep the same JavaScript API names across targets, update threadless coverage and package checks, and pin the FSRS revision with threadless progress support

## Why

Threadless WASM cannot use the worker threads required by `AsyncTask`. Running FSRS serially inside a Dedicated Worker and settling a real JavaScript Promise preserves the public API without spawning threads.

## Testing

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `pnpm --filter @open-spaced-repetition/binding build:wasm:threadless`
- full threadless binding tests on Node.js 24 and 26