### PR TITLE
chore: increase timeout for type display tests to 60 seconds

### DIFF
--- a/packages/binding/.gitignore
+++ b/packages/binding/.gitignore
@@ -3,6 +3,7 @@
 browser.js
 fsrs-binding.wasi-browser.js
 fsrs-binding.wasi.cjs
+fsrs-binding.wasi.d.cts
 fsrs-binding.wasip1*
 fsrs-binding.wasm32-wasip1.*
 # Generated once by `napi create-npm-dirs`, never by a build; the threadless

--- a/packages/srs-kit/src/chrono/define-chrono.type-display.spec.ts
+++ b/packages/srs-kit/src/chrono/define-chrono.type-display.spec.ts
@@ -114,4 +114,4 @@ describe('defineChrono type display', () => {
       expect(quickInfoAt(service, SELF, marker)).toBe(expected)
     }
   })
-}, 20_000)
+}, 60_000)

--- a/packages/srs-kit/src/middleware/middleware.type-display.spec.ts
+++ b/packages/srs-kit/src/middleware/middleware.type-display.spec.ts
@@ -213,4 +213,4 @@ describe('middleware type display', () => {
       expect(quickInfoAt(service, SELF, marker)).toBe(expected)
     }
   })
-}, 20_000)
+}, 60_000)

--- a/packages/srs-kit/src/model/model.type-display.spec.ts
+++ b/packages/srs-kit/src/model/model.type-display.spec.ts
@@ -95,4 +95,4 @@ describe('defineModel type display', () => {
       expect(quickInfoAt(service, SELF, marker)).toBe(expected)
     }
   })
-}, 20_000)
+}, 60_000)

--- a/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
@@ -674,4 +674,4 @@ describe('defineScheduler type display', () => {
       expect(quickInfoAt(service, SELF, marker)).toBe(expected)
     }
   })
-}, 20_000)
+}, 60_000)


### PR DESCRIPTION
## Summary

This pull request makes minor updates to test configuration and `.gitignore` settings. The most notable changes are increasing test timeouts for type display tests to improve reliability and adding a new generated file to `.gitignore`.

Test reliability improvements:

* Increased the timeout for type display tests in `model.type-display.spec.ts`, `define-chrono.type-display.spec.ts`, `middleware.type-display.spec.ts`, and `scheduler.type-display.spec.ts` from 20 seconds to 60 seconds to reduce flaky test failures. [[1]](diffhunk://#diff-78ef7cc6376f4588bc41a83becd3c73cee69e66549b923a574ad788bb03568f5L98-R98) [[2]](diffhunk://#diff-754ec23fa8908ab2942e8f901b9a09fc18f13608b9e07a82b885ae4908f224c0L117-R117) [[3]](diffhunk://#diff-5e8d8f68b6fa4d60df1223aeaed9529d2f0f7651486cf186f21a510d7f23c93bL216-R216) [[4]](diffhunk://#diff-3f311bb9d99aac458987d43de1f2b6932c8cb3883426eb091345d7c62b44b1d3L677-R677)

Build artifact management:

* Added `fsrs-binding.wasi.d.cts` to the `.gitignore` file to prevent generated type definition files from being committed.

## Related Issues

- Closes #

## Changes

- 

## Changeset

- [ ] Added a changeset with `pnpm changeset`
- [ ] Not needed because this change does not affect published package behavior or contents

