### PR TITLE
test(fsrs): reach 100% coverage

### DIFF
--- a/packages/fsrs/src/kit/schema.spec.ts
+++ b/packages/fsrs/src/kit/schema.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { FSRSMemoryStateSchema } from './schema.js'
+import { isNumberArray } from './schema-utils.js'
+
+describe('FSRS schemas', () => {
+  it('rejects an invalid memory state', () => {
+    expect(() =>
+      FSRSMemoryStateSchema.parse({ stability: '1', difficulty: 2 })
+    ).toThrow('Expected FSRS memory state')
+  })
+
+  it('rejects non-number and non-finite array items', () => {
+    expect(isNumberArray(['1'])).toBe(false)
+    expect(isNumberArray([Number.NaN])).toBe(false)
+  })
+})

--- a/packages/fsrs/src/legacy/__tests__/FSRS-5.test.ts
+++ b/packages/fsrs/src/legacy/__tests__/FSRS-5.test.ts
@@ -134,7 +134,7 @@ describe('FSRS-5', () => {
 })
 
 describe('get retrievability', () => {
-  const fsrs = new FSRS({})
+  const fsrs = new FSRS()
   test('return 0 for new cards', () => {
     const card = createEmptyCard()
     const now = new Date()

--- a/packages/fsrs/src/legacy/__tests__/middlewares/learning-steps/legacy.spec.ts
+++ b/packages/fsrs/src/legacy/__tests__/middlewares/learning-steps/legacy.spec.ts
@@ -82,6 +82,14 @@ describe('legacy FSRS learning-steps integration', () => {
       // biome-ignore lint/complexity/useLiteralKeys: verify legacy cleanup
       scheduler['strategyHandler'].get(StrategyMode.LEARNING_STEPS)
     ).toBeUndefined()
+
+    scheduler
+      .useStrategy(StrategyMode.LEARNING_STEPS, learningSteps)
+      .clearStrategy(StrategyMode.LEARNING_STEPS)
+    expect(
+      // biome-ignore lint/complexity/useLiteralKeys: verify legacy cleanup
+      scheduler['strategyHandler'].get(StrategyMode.LEARNING_STEPS)
+    ).toBeUndefined()
   })
 
   it('keeps minute precision while exposing whole scheduled days', () => {

--- a/packages/fsrs/src/middlewares/fuzzing/core.spec.ts
+++ b/packages/fsrs/src/middlewares/fuzzing/core.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { fnv1aMulberry32Rng, getFuzzRange, withFuzzing } from './core.js'
 
 const config = {
@@ -30,6 +30,13 @@ describe('fuzzing core', () => {
     expect(second).toBe(first)
     expect(first).toBeGreaterThanOrEqual(range.minInterval)
     expect(first).toBeLessThanOrEqual(range.maxInterval)
+  })
+
+  it('uses the current time when no seed is supplied', () => {
+    const dateNow = vi.spyOn(Date, 'now').mockReturnValue(42)
+
+    expect(withFuzzing(10, 5, config)).toBe(withFuzzing(10, 5, config, '42'))
+    dateNow.mockRestore()
   })
 
   it('creates interval ranges from custom fuzz ranges', () => {

--- a/packages/fsrs/src/middlewares/scheduled-days/middleware.spec.ts
+++ b/packages/fsrs/src/middlewares/scheduled-days/middleware.spec.ts
@@ -50,6 +50,22 @@ describe('schedulerScheduledDaysMiddleware', () => {
     expect(result.revlog.scheduledDays).toBe(7.5)
   })
 
+  it('defaults a missing scheduled interval to zero', () => {
+    const ctx = {
+      input: { card: { scheduledDays: 7 } },
+      result: {
+        card: { scheduledDays: -1 },
+        revlog: { scheduledDays: -1 },
+      },
+      scheduledDays: undefined,
+    }
+
+    schedulerScheduledDaysMiddleware.handlers!.review!(ctx as never, () => {})
+
+    expect(ctx.result.card.scheduledDays).toBe(0)
+    expect(ctx.result.revlog.scheduledDays).toBe(7)
+  })
+
   it('stores an interval selected by a later middleware during unwind', () => {
     const intervalMiddleware = defineMiddleware({
       name: 'test.scheduled-days.post-interval',

--- a/packages/fsrs/src/models/fsrs-5/algorithm.spec.ts
+++ b/packages/fsrs/src/models/fsrs-5/algorithm.spec.ts
@@ -21,6 +21,12 @@ describe('FSRS5Algorithm', () => {
     expect(forgetting_curve(8, 8.2956)).toBe(0.90306221)
   })
 
+  it('rejects an invalid weight count', () => {
+    expect(() => new FSRS5Algorithm([], true, FSRS5_MODEL_BOUNDS)).toThrow(
+      'FSRS5Algorithm requires exactly 19 weights'
+    )
+  })
+
   it('calculates intervals through the FSRS-5 interval modifier', () => {
     expect(algorithm.next_interval(15.69105, 0.9)).toBe(16)
     expect(algorithm.next_interval(15.69105, 0.8)).toBe(38)
@@ -40,6 +46,42 @@ describe('FSRS5Algorithm', () => {
     expect(states.map((state) => state.difficulty)).toEqual([
       7.1949, 6.48830527, 5.28243442, 3.22450159,
     ])
+  })
+
+  it('validates state inputs and handles every review rating', () => {
+    const state = { difficulty: 5, stability: 10 }
+
+    expect(() => algorithm.next_state(state, -1, Rating.Good)).toThrow(
+      'Invalid delta_t "-1"'
+    )
+    expect(() => algorithm.next_state(state, 1, -1 as Grade)).toThrow(
+      'Invalid grade "-1"'
+    )
+    expect(() => algorithm.next_state(state, 1, 5 as Grade)).toThrow(
+      'Invalid grade "5"'
+    )
+    expect(algorithm.next_state(state, 1, Rating.Manual as Grade)).toEqual(
+      state
+    )
+    expect(() =>
+      algorithm.next_state({ difficulty: 0.5, stability: 10 }, 1, Rating.Good)
+    ).toThrow('Invalid memory state')
+
+    for (const rating of [Rating.Hard, Rating.Easy] as const) {
+      const next = algorithm.next_state(state, 1, rating, 0.9)
+      expect(next.difficulty).toBeGreaterThanOrEqual(FSRS5_MODEL_BOUNDS.dMin)
+      expect(next.stability).toBeGreaterThanOrEqual(FSRS5_MODEL_BOUNDS.sMin)
+    }
+
+    const withoutShortTerm = new FSRS5Algorithm(
+      FSRS5_DEFAULT_WEIGHTS,
+      false,
+      FSRS5_MODEL_BOUNDS
+    )
+    for (const candidate of [algorithm, withoutShortTerm]) {
+      const next = candidate.next_state(state, 1, Rating.Again, 0.9)
+      expect(next.stability).toBeGreaterThanOrEqual(FSRS5_MODEL_BOUNDS.sMin)
+    }
   })
 
   it.each([

--- a/packages/fsrs/src/models/fsrs-6/algorithm.spec.ts
+++ b/packages/fsrs/src/models/fsrs-6/algorithm.spec.ts
@@ -1,0 +1,23 @@
+import { expect, it } from 'vitest'
+import { Rating } from '@/models.js'
+import { FSRS6Algorithm } from './algorithm.js'
+import { FSRS6_DEFAULT_WEIGHTS, FSRS6_MODEL_BOUNDS } from './constants.js'
+
+it('rejects an invalid FSRS-6 weight count', () => {
+  expect(() => new FSRS6Algorithm([], true, FSRS6_MODEL_BOUNDS)).toThrow(
+    'FSRS6Algorithm requires exactly 21 weights'
+  )
+})
+
+it('keeps the memory state for a manual rating', () => {
+  const algorithm = new FSRS6Algorithm(
+    Array.from(FSRS6_DEFAULT_WEIGHTS),
+    true,
+    FSRS6_MODEL_BOUNDS
+  )
+  const memoryState = { difficulty: 5, stability: 10 }
+
+  expect(algorithm.next_state(memoryState, 1, Rating.Manual)).toEqual(
+    memoryState
+  )
+})


### PR DESCRIPTION
## Summary

- add focused tests for legacy constructor and strategy behavior, schema failures, fuzzing without a seed, scheduled-day defaults, and FSRS-5/6 boundaries
- cover the FSRS-6 manual-rating identity path explicitly
- raise `packages/fsrs` statements, branches, functions, and lines to exactly 100%

## Why

The package now exercises every reported production branch without ignore comments, production-file exclusions, or reduced thresholds.

## Validation

- `pnpm --dir packages/fsrs check`
- `pnpm --dir packages/fsrs typecheck`
- `pnpm --dir packages/fsrs test` — 53 files passed, 444 tests passed, 1 skipped
- `pnpm --dir packages/fsrs build`
- `pnpm --dir packages/fsrs test:coverage`
  - statements: 100% (`1362/1362`)
  - branches: 100% (`795/795`)
  - functions: 100% (`264/264`)
  - lines: 100% (`1335/1335`)
- `git diff --check`

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
