### PR TITLE
pref: optimize srs-kit scheduler schema composition

### DIFF
--- a/.changeset/optimize-scheduler-schema.md
+++ b/.changeset/optimize-scheduler-schema.md
@@ -1,0 +1,5 @@
+---
+"@open-spaced-repetition/srs-kit": patch
+---
+
+perf(kit): cache middleware schemas used by scheduler validation.

--- a/packages/srs-kit/src/scheduler/compose-schema.ts
+++ b/packages/srs-kit/src/scheduler/compose-schema.ts
@@ -8,6 +8,7 @@ import { stateSchema } from '@/primitives/state.js'
 import { scheduleStatuses } from '@/primitives/status.js'
 import { rememberAttachedValue } from '@/schema/attached-value.js'
 import {
+  type AnySchema,
   assignObjectFields,
   defineSchema,
   isObject,
@@ -33,6 +34,20 @@ export function composeSchema(ctx: {
   const chronoConfigSchema = chronoSchema.config
   const chronoCardSchema = chronoSchema.card
   const chronoRevlogSchema = chronoSchema.revlog
+  const middlewareConfigSchemas: AnySchema[] = []
+  const middlewareCardInitInputSchemas: AnySchema[] = []
+  const middlewareCardSchemas: AnySchema[] = []
+  const middlewareRevlogSchemas: AnySchema[] = []
+  for (const middleware of middlewares) {
+    const schema = middleware.schema
+    if (!schema) continue
+    if (schema.config) middlewareConfigSchemas.push(schema.config)
+    if (schema.cardInitInput) {
+      middlewareCardInitInputSchemas.push(schema.cardInitInput)
+    }
+    if (schema.card) middlewareCardSchemas.push(schema.card)
+    if (schema.revlog) middlewareRevlogSchemas.push(schema.revlog)
+  }
 
   const scheduleStatusSchema = defineSchema<string>((value) => {
     if (typeof value !== 'string') {
@@ -103,11 +118,7 @@ export function composeSchema(ctx: {
     const result: Record<PropertyKey, unknown> = { chrono: chronoValue }
     assignObjectFields(result, modelResult.value)
 
-    for (const middleware of middlewares) {
-      const schema = middleware.schema?.config
-      if (!schema) {
-        continue
-      }
+    for (const schema of middlewareConfigSchemas) {
       const middlewareResult = schema['~standard'].validate(value)
       if (middlewareResult.issues) {
         return middlewareResult
@@ -139,9 +150,7 @@ export function composeSchema(ctx: {
 
     let firstMiddlewareFields: Record<string, unknown> | undefined
     let combinedFields: Record<string, unknown> | undefined
-    for (const middleware of middlewares) {
-      const schema = middleware.schema?.cardInitInput
-      if (!schema) continue
+    for (const schema of middlewareCardInitInputSchemas) {
       const middlewareResult = schema['~standard'].validate(middlewareValue)
       if (middlewareResult.issues) return middlewareResult
       const fields = middlewareResult.value as Record<string, unknown>
@@ -181,9 +190,7 @@ export function composeSchema(ctx: {
     card.state = coreFields.value.state
     card.scheduleStatus = coreFields.value.scheduleStatus
 
-    for (const middleware of middlewares) {
-      const schema = middleware.schema?.card
-      if (!schema) continue
+    for (const schema of middlewareCardSchemas) {
       const middlewareCard = schema['~standard'].validate(value)
       if (middlewareCard.issues) return middlewareCard
       Object.assign(card, middlewareCard.value)
@@ -224,9 +231,7 @@ export function composeSchema(ctx: {
     result.rating = coreFields.value.rating
     result.state = coreFields.value.state
 
-    for (const middleware of middlewares) {
-      const schema = middleware.schema?.revlog
-      if (!schema) continue
+    for (const schema of middlewareRevlogSchemas) {
       const middlewareRevlog = schema['~standard'].validate(value)
       if (middlewareRevlog.issues) return middlewareRevlog
       Object.assign(result, middlewareRevlog.value)


### PR DESCRIPTION
## Summary

- collect middleware schemas once during scheduler schema composition
- reuse the collected schemas across config, card input, card, and revlog validation
- add a patch changeset for `@open-spaced-repetition/srs-kit`

## Why

The composed validators previously rescanned every middleware descriptor whenever they selected schemas for a validation category. Collecting all four categories in one initialization loop preserves validation order while reducing repeated property traversal.

## Performance

The local `compose schema` benchmark improved from approximately 2.69M to 5.55M operations per second, about a 2.1x increase.

## Testing

- `pnpm --filter @open-spaced-repetition/srs-kit test` (210 tests)
- `pnpm --filter @open-spaced-repetition/srs-kit check`
- `pnpm --filter @open-spaced-repetition/srs-kit build`
- `pnpm --filter @open-spaced-repetition/srs-kit exec vitest bench --run --config=vitest.config.ts bench/compose-schema.bench.ts`
