### PR TITLE
pref: optimize middleware interval hot paths

### DIFF
--- a/.changeset/optimize-middleware-interval-hot-paths.md
+++ b/.changeset/optimize-middleware-interval-hot-paths.md
@@ -1,0 +1,5 @@
+---
+"ts-fsrs": patch
+---
+
+perf(middleware): avoid redundant model interval and schedule array calculations.

--- a/packages/fsrs/src/middlewares/learning-steps/middleware.spec.ts
+++ b/packages/fsrs/src/middlewares/learning-steps/middleware.spec.ts
@@ -1,6 +1,6 @@
 import { defineScheduler, Rating, State } from '@open-spaced-repetition/srs-kit'
 import { dateChrono } from '@open-spaced-repetition/srs-kit/chrono/date'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { FSRS6_DEFAULT_WEIGHTS, FSRS6Model } from '@/models/fsrs-6/index.js'
 import { schedulerLearningStepsMiddleware } from './middleware.js'
 import type { StepUnit } from './types.js'
@@ -69,6 +69,19 @@ describe('schedulerLearningStepsMiddleware integration', () => {
     expect(easy.card.state).toBe(State.Review)
     expect(easy.card.scheduleStatus).toBe('review')
     expect(easy.card.learningStep).toBe(0)
+  })
+
+  it('uses the model interval only when no positive learning step exists', () => {
+    const core = createCore({ learningSteps: ['1m'] })
+    const now = new Date(2022, 11, 29, 12, 30)
+    const card = core.newCard({ now })
+    const nextInterval = vi.spyOn(core.model, 'nextInterval')
+
+    core.review({ card, grade: Rating.Again, now })
+    expect(nextInterval).not.toHaveBeenCalled()
+
+    core.review({ card, grade: Rating.Easy, now })
+    expect(nextInterval).toHaveBeenCalledOnce()
   })
 
   it('graduates after the final learning step', () => {

--- a/packages/fsrs/src/middlewares/learning-steps/middleware.ts
+++ b/packages/fsrs/src/middlewares/learning-steps/middleware.ts
@@ -55,8 +55,13 @@ export const schedulerLearningStepsMiddleware = defineMiddleware({
         ? Math.round(Math.max(0, step.scheduledMinutes))
         : undefined
 
+      // Set before BaseScheduler.finalizeReview() falls back to model.nextInterval().
+      if (scheduledMinutes !== undefined && scheduledMinutes > 0) {
+        ctx.scheduledDays = scheduledMinutes / MINUTES_PER_DAY
+      }
       next()
 
+      // Restore after schedulerMonotonicIntervalMiddleware normalizes the interval.
       if (scheduledMinutes !== undefined && scheduledMinutes > 0) {
         ctx.scheduledDays = scheduledMinutes / MINUTES_PER_DAY
       }

--- a/packages/fsrs/src/middlewares/monotonic-interval/core.spec.ts
+++ b/packages/fsrs/src/middlewares/monotonic-interval/core.spec.ts
@@ -45,5 +45,8 @@ describe('calculateScheduleDays', () => {
     expect(calculateScheduleDay([4, 2], 100)).toBe(5)
     expect(calculateScheduleDay([4, 2, 8], 100)).toBe(8)
     expect(calculateScheduleDay([4, 2, 8, 7], 100)).toBe(9)
+    expect(calculateScheduleDay([0, 0, 2, 3], 100)).toBe(3)
+    expect(calculateScheduleDay([98, 99, 100, 101], 100)).toBe(100)
+    expect(calculateScheduleDay([102], 100)).toBe(100)
   })
 })

--- a/packages/fsrs/src/middlewares/monotonic-interval/core.ts
+++ b/packages/fsrs/src/middlewares/monotonic-interval/core.ts
@@ -54,6 +54,12 @@ export function calculateScheduleDay(
   candidates: IntervalCandidates,
   maximumInterval: number
 ): number {
-  const scheduledDays = calculateScheduleDays(candidates, maximumInterval)
-  return scheduledDays[scheduledDays.length - 1]
+  let scheduledDay = Math.min(candidates[0], maximumInterval)
+  for (let index = 1; index < candidates.length; index++) {
+    scheduledDay = Math.min(
+      Math.max(candidates[index], scheduledDay === 0 ? 0 : scheduledDay + 1),
+      maximumInterval
+    )
+  }
+  return scheduledDay
 }


### PR DESCRIPTION
## Summary

- avoid calculating a model interval when a positive learning step already resolves the schedule
- preserve learning-step ownership after inner monotonic interval normalization
- compute the current monotonic interval without allocating a temporary schedule array
- add regression coverage and a patch changeset for `ts-fsrs`

## Why

Positive learning steps already determine the next interval, so the model fallback was calculated and then discarded. The monotonic middleware also needs only the current rating's final interval, not the complete normalized tuple.

Graduation and other cases without a positive learning step continue to use the model interval. Existing short-term due-date behavior is preserved.

## Testing

- `pnpm --filter @open-spaced-repetition/srs-kit build`
- `pnpm --filter ts-fsrs test` (444 passed, 2 skipped)
- `pnpm --filter ts-fsrs typecheck`
- `pnpm --filter ts-fsrs check`
- targeted monotonic interval tests (7 tests)
