### PR TITLE
feat(fsrs): expose middleware APIs

### DIFF
--- a/.changeset/expose-middlewares.md
+++ b/.changeset/expose-middlewares.md
@@ -1,0 +1,5 @@
+---
+"ts-fsrs": minor
+---
+
+feat(fsrs): expose `defineMiddleware` and built-in middlewares.

--- a/packages/fsrs/package.json
+++ b/packages/fsrs/package.json
@@ -30,6 +30,17 @@
       },
       "default": "./dist/reschedule.mjs"
     },
+    "./middlewares": {
+      "require": {
+        "types": "./dist/middlewares/index.d.cts",
+        "default": "./dist/middlewares/index.cjs"
+      },
+      "import": {
+        "types": "./dist/middlewares/index.d.mts",
+        "default": "./dist/middlewares/index.mjs"
+      },
+      "default": "./dist/middlewares/index.mjs"
+    },
     "./models/fsrs-3": {
       "require": {
         "types": "./dist/models/fsrs-3.d.cts",

--- a/packages/fsrs/src/index.ts
+++ b/packages/fsrs/src/index.ts
@@ -1,5 +1,6 @@
 export {
   defineChrono,
+  defineMiddleware,
   defineScheduler,
 } from '@open-spaced-repetition/srs-kit'
 export { dateChrono } from '@open-spaced-repetition/srs-kit/chrono/date'
@@ -14,15 +15,7 @@ export * from './legacy/fsrs.js'
 export * from './legacy/impl/basic_scheduler.js'
 export * from './legacy/impl/long_term_scheduler.js'
 export * from './legacy/strategies/index.js'
-export * from './middlewares/fuzzing/core.js'
-export {
-  defaultLearningSteps,
-  defaultRelearningSteps,
-} from './middlewares/learning-steps/schema.js'
-export type {
-  StepUnit,
-  TimeUnit,
-} from './middlewares/learning-steps/types.js'
+export * from './middlewares/index.js'
 export type {
   Card,
   CardInput,

--- a/packages/fsrs/tsdown.config.ts
+++ b/packages/fsrs/tsdown.config.ts
@@ -9,6 +9,7 @@ export default defineConfig([
     entry: {
       index: 'src/index.ts',
       error: 'src/error.ts',
+      'middlewares/index': 'src/middlewares/index.ts',
       'models/fsrs-3': 'src/models/fsrs-3/index.ts',
       'models/fsrs-4': 'src/models/fsrs-4/index.ts',
       'models/fsrs-4dot5': 'src/models/fsrs-4dot5/index.ts',


### PR DESCRIPTION
## Summary

- export `defineMiddleware` and built-in middleware APIs from the root package
- add the `ts-fsrs/middlewares` ESM/CJS subpath and build entry
- include built-in middleware exports in the existing UMD bundle
- add a minor changeset

## Testing

- `pnpm --filter @open-spaced-repetition/srs-kit build`
- `pnpm --filter ts-fsrs check`
- `pnpm --filter ts-fsrs test`
- `pnpm --filter ts-fsrs typecheck`
- `pnpm --filter ts-fsrs build`
- ESM, CommonJS, and UMD export smoke checks