### PR TITLE
feat(binding): support CSV conversion from Web ReadableStreams

### DIFF
--- a/.changeset/binding-csv-web-stream.md
+++ b/.changeset/binding-csv-web-stream.md
@@ -1,0 +1,5 @@
+---
+"@open-spaced-repetition/binding": minor
+---
+
+feat(binding): support `ReadableStream<Uint8Array>` input in `convertCsvToFsrsItems`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,10 +414,13 @@ dependencies = [
  "bitflags",
  "ctor",
  "futures",
+ "futures-core",
  "napi-build",
  "napi-sys",
  "nohash-hasher",
  "rustc-hash",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -769,6 +772,26 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "tokio"
+version = "1.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
+dependencies = [
+ "pin-project-lite",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "unicode-ident"

--- a/packages/binding-test/package.json
+++ b/packages/binding-test/package.json
@@ -10,8 +10,8 @@
     "dev": "vitest"
   },
   "devDependencies": {
-    "@emnapi/core": "2.0.0-alpha.3",
-    "@emnapi/runtime": "2.0.0-alpha.3",
+    "@emnapi/core": "2.0.0-alpha.4",
+    "@emnapi/runtime": "2.0.0-alpha.4",
     "@napi-rs/wasm-runtime": "^1.2.0",
     "@types/papaparse": "^5.5.2",
     "papaparse": "^5.5.3",

--- a/packages/binding-test/src/csv-parser.spec.ts
+++ b/packages/binding-test/src/csv-parser.spec.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs'
 import * as path from 'node:path'
+import { Readable } from 'node:stream'
 import { fileURLToPath } from 'node:url'
 import { convertCsvToFsrsItems } from '@open-spaced-repetition/binding'
 import { getTimezoneOffset, parseCSVToFSRSItems } from './helpers/csv-parser.js'
@@ -66,6 +67,72 @@ describe('CSV Parser', () => {
     expect(offsetItems).toEqual(timezoneItems)
   })
 
+  test('should match Uint8Array input for a chunked Web ReadableStream', async () => {
+    const data = fs.readFileSync(testDataPath)
+    const stream = Readable.toWeb(
+      fs.createReadStream(testDataPath)
+    ) as ReadableStream<Uint8Array>
+    const expected = convertCsvToFsrsItems(data, nextDayStartsAt, timezone)
+
+    await expect(
+      convertCsvToFsrsItems(stream, nextDayStartsAt, timezone)
+    ).resolves.toEqual(expected)
+    expect(stream.locked).toBe(false)
+  })
+
+  test('should propagate Web ReadableStream errors', async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.error(new Error('stream failed'))
+      },
+    })
+
+    await expect(
+      convertCsvToFsrsItems(stream, nextDayStartsAt, 0)
+    ).rejects.toThrow('stream failed')
+    expect(stream.locked).toBe(false)
+  })
+
+  test('should convert an empty Web ReadableStream', async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.close()
+      },
+    })
+
+    await expect(
+      convertCsvToFsrsItems(stream, nextDayStartsAt, 0)
+    ).resolves.toEqual([])
+    expect(stream.locked).toBe(false)
+  })
+
+  test('should reject non-Uint8Array chunks and release the lock', async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue('invalid' as unknown as Uint8Array)
+        controller.close()
+      },
+    })
+
+    await expect(
+      convertCsvToFsrsItems(stream, nextDayStartsAt, 0)
+    ).rejects.toThrow()
+    expect(stream.locked).toBe(false)
+  })
+
+  test('should reject a locked Web ReadableStream asynchronously', async () => {
+    const stream = new ReadableStream<Uint8Array>()
+    const reader = stream.getReader()
+
+    try {
+      const result = convertCsvToFsrsItems(stream, nextDayStartsAt, 0)
+      expect(result).toBeInstanceOf(Promise)
+      await expect(result).rejects.toThrow(/locked/i)
+    } finally {
+      reader.releaseLock()
+    }
+  })
+
   test('should throw for unsupported timezone', () => {
     const csvBuffer = Buffer.from(
       [
@@ -78,6 +145,40 @@ describe('CSV Parser', () => {
     expect(() =>
       convertCsvToFsrsItems(csvBuffer, nextDayStartsAt, 'Mars/Base')
     ).toThrow('Unsupported timezone')
+  })
+
+  test('should reject unsupported timezone asynchronously for a Web ReadableStream', async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.close()
+      },
+    })
+
+    const result = convertCsvToFsrsItems(stream, nextDayStartsAt, 'Mars/Base')
+    expect(result).toBeInstanceOf(Promise)
+    await expect(result).rejects.toThrow('Unsupported timezone')
+    expect(stream.locked).toBe(false)
+  })
+
+  test('should release the stream lock when attaching the finalizer fails', async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.close()
+      },
+    })
+    const promiseFinally = Promise.prototype.finally
+    const result = (() => {
+      Reflect.set(Promise.prototype, 'finally', undefined)
+      try {
+        return convertCsvToFsrsItems(stream, nextDayStartsAt, 0)
+      } finally {
+        Reflect.set(Promise.prototype, 'finally', promiseFinally)
+      }
+    })()
+
+    expect(result).toBeInstanceOf(Promise)
+    await expect(result).rejects.toThrow()
+    expect(stream.locked).toBe(false)
   })
 
   describe('getTimezoneOffset', () => {

--- a/packages/binding-test/src/csv-parser.spec.ts
+++ b/packages/binding-test/src/csv-parser.spec.ts
@@ -71,7 +71,7 @@ describe('CSV Parser', () => {
     const data = fs.readFileSync(testDataPath)
     const stream = Readable.toWeb(
       fs.createReadStream(testDataPath)
-    ) as ReadableStream<Uint8Array>
+    )
     const expected = convertCsvToFsrsItems(data, nextDayStartsAt, timezone)
 
     await expect(

--- a/packages/binding/Cargo.toml
+++ b/packages/binding/Cargo.toml
@@ -8,7 +8,10 @@ version = "0.0.2"
 crate-type = ["cdylib"]
 
 [dependencies]
-napi = { version = "3.12.0", default-features = true }
+napi = { version = "3.12.0", default-features = true, features = [
+  "napi5",
+  "web_stream",
+] }
 napi-derive = "3.6.1"
 csv = "1.3.0"
 jiff = { version = "=0.2.28", default-features = false, features = [

--- a/packages/binding/npm/wasm32-wasi/package.json
+++ b/packages/binding/npm/wasm32-wasi/package.json
@@ -52,7 +52,7 @@
   "type": "module",
   "dependencies": {
     "@napi-rs/wasm-runtime": "^1.2.0",
-    "@emnapi/core": "2.0.0-alpha.3",
-    "@emnapi/runtime": "2.0.0-alpha.3"
+    "@emnapi/core": "2.0.0-alpha.4",
+    "@emnapi/runtime": "2.0.0-alpha.4"
   }
 }

--- a/packages/binding/npm/wasm32-wasip1/package.json
+++ b/packages/binding/npm/wasm32-wasip1/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@napi-rs/wasm-runtime": "^1.2.0",
-    "@emnapi/core": "2.0.0-alpha.3",
-    "@emnapi/runtime": "2.0.0-alpha.3"
+    "@emnapi/core": "2.0.0-alpha.4",
+    "@emnapi/runtime": "2.0.0-alpha.4"
   }
 }

--- a/packages/binding/package.json
+++ b/packages/binding/package.json
@@ -51,14 +51,14 @@
     "check:rs": "cargo fmt && cargo clippy"
   },
   "devDependencies": {
-    "@emnapi/core": "2.0.0-alpha.3",
-    "@emnapi/runtime": "2.0.0-alpha.3",
+    "@emnapi/core": "2.0.0-alpha.4",
+    "@emnapi/runtime": "2.0.0-alpha.4",
     "@napi-rs/cli": "3.8.0",
     "@napi-rs/wasm-runtime": "^1.2.0",
     "@taplo/cli": "^0.7.0",
     "@types/papaparse": "^5.5.2",
     "chalk": "^5.4.1",
-    "emnapi": "2.0.0-alpha.3",
+    "emnapi": "2.0.0-alpha.4",
     "npm-run-all2": "^8.0.4",
     "papaparse": "^5.5.3",
     "tinybench": "^6.0.1"

--- a/packages/binding/src/convert.rs
+++ b/packages/binding/src/convert.rs
@@ -3,12 +3,13 @@ use fsrs::filter_outlier;
 use itertools::Itertools;
 use napi_derive::napi;
 
-use napi::bindgen_prelude::Result;
+use napi::bindgen_prelude::{Either, Env, Object, PromiseRaw, ReadableStream, Result, Uint8Array};
 use serde::{Deserialize, Serialize};
 use time::{Date, Duration, OffsetDateTime};
 
 use crate::{
   FSRSItem as FSRSBindingItem,
+  convert_stream::convert_csv_stream,
   timezone::{TimezoneOffset, TimezoneOrOffset, resolve_timezone_offset},
 };
 
@@ -103,29 +104,17 @@ fn convert_to_fsrs_items_internal(
   )
 }
 
-/// Convert CSV review logs to FSRS training items.
-///
-/// @param timezoneOrOffset Pass an IANA timezone name, such as `Asia/Shanghai`,
-/// when daylight saving rules should be resolved for each review timestamp.
-/// Pass a number when the source data should use one fixed UTC offset in
-/// minutes, such as `480` for UTC+08:00 or `-300` for UTC-05:00.
-#[napi]
-pub fn convert_csv_to_fsrs_items(
+pub(crate) fn convert_csv_bytes(
   data: &[u8],
   next_day_starts_at: i64,
-  // Accepts an IANA timezone name or a fixed UTC offset in minutes.
-  // IANA names resolve DST per review timestamp; numeric offsets stay fixed.
-  timezone_or_offset: TimezoneOrOffset,
+  timezone_offset: &TimezoneOffset,
 ) -> Result<Vec<FSRSBindingItem>> {
-  let timezone_offset = resolve_timezone_offset(timezone_or_offset)?;
-
   let mut rdr = ReaderBuilder::new().has_headers(true).from_reader(data);
 
-  let mut revlogs: Vec<RevlogEntry> = rdr
+  let mut revlogs = rdr
     .deserialize::<RevlogEntry>()
     .collect::<std::result::Result<Vec<RevlogEntry>, _>>()
     .map_err(|e| napi::Error::from_reason(format!("CSV deserialization error: {}", e)))?;
-
   // Sort by review_time first to ensure ordering
   revlogs.sort_by_cached_key(|r| (r.card_id.clone(), r.review_time));
 
@@ -135,7 +124,7 @@ pub fn convert_csv_to_fsrs_items(
     .chunk_by(|r| r.card_id.clone())
     .into_iter()
     .map(|(_card_id, entries)| {
-      convert_to_fsrs_items_internal(entries.collect(), next_day_starts_at, &timezone_offset)
+      convert_to_fsrs_items_internal(entries.collect(), next_day_starts_at, timezone_offset)
     })
     .collect::<Result<Vec<_>>>()?
     .into_iter()
@@ -146,6 +135,43 @@ pub fn convert_csv_to_fsrs_items(
   revlogs.sort_by_cached_key(|(_, _, review_time)| *review_time);
 
   Ok(revlogs.into_iter().map(|(_, item, _)| item).collect())
+}
+
+/// Convert CSV review logs to FSRS training items.
+///
+/// @param timezoneOrOffset Pass an IANA timezone name, such as `Asia/Shanghai`,
+/// when daylight saving rules should be resolved for each review timestamp.
+/// Pass a number when the source data should use one fixed UTC offset in
+/// minutes, such as `480` for UTC+08:00 or `-300` for UTC-05:00.
+#[napi(
+  ts_generic_types = "T extends Uint8Array | ReadableStream<Uint8Array>",
+  ts_args_type = "data: T, nextDayStartsAt: number, timezoneOrOffset: TimezoneOrOffset",
+  ts_return_type = "T extends ReadableStream<Uint8Array> ? Promise<Array<FSRSBindingItem>> : Array<FSRSBindingItem>"
+)]
+pub fn convert_csv_to_fsrs_items<'env>(
+  env: &'env Env,
+  data: Either<&[u8], ReadableStream<'env, Uint8Array>>,
+  next_day_starts_at: i64,
+  // Accepts an IANA timezone name or a fixed UTC offset in minutes.
+  // IANA names resolve DST per review timestamp; numeric offsets stay fixed.
+  timezone_or_offset: TimezoneOrOffset,
+) -> Result<Either<Vec<FSRSBindingItem>, PromiseRaw<'env, Object<'env>>>> {
+  let timezone_offset = resolve_timezone_offset(timezone_or_offset);
+
+  match data {
+    Either::A(data) => {
+      let timezone_offset = timezone_offset?;
+      Ok(Either::A(convert_csv_bytes(
+        data,
+        next_day_starts_at,
+        &timezone_offset,
+      )?))
+    }
+    Either::B(stream) => Ok(Either::B(match timezone_offset {
+      Ok(timezone_offset) => convert_csv_stream(env, stream, next_day_starts_at, timezone_offset)?,
+      Err(error) => PromiseRaw::reject(env, error)?,
+    })),
+  }
 }
 
 pub(crate) fn prepare_items(train_set: Vec<&FSRSBindingItem>) -> Vec<fsrs::FSRSItem> {

--- a/packages/binding/src/convert_stream.rs
+++ b/packages/binding/src/convert_stream.rs
@@ -1,0 +1,91 @@
+use std::rc::Rc;
+
+use napi::bindgen_prelude::{
+  Either, Env, Function, FunctionRef, JsObjectValue, JsValue, Object, PromiseRaw, ReadableStream,
+  Result, Uint8Array,
+};
+
+use crate::{convert::convert_csv_bytes, timezone::TimezoneOffset};
+
+type ReadFunction<'env> = FunctionRef<(), PromiseRaw<'env, Object<'env>>>;
+type ReleaseLockFunction = FunctionRef<(), ()>;
+
+fn bind_stream_reader<'env>(
+  stream: &ReadableStream<'env, Uint8Array>,
+) -> Result<(ReadFunction<'env>, ReleaseLockFunction)> {
+  let get_reader: Function<(), Object<'env>> = stream.get_named_property_unchecked("getReader")?;
+  let reader = get_reader.apply(stream.to_unknown(), ())?;
+  let read: Function<(), PromiseRaw<'env, Object<'env>>> =
+    reader.get_named_property_unchecked("read")?;
+  let release_lock: Function<(), ()> = reader.get_named_property_unchecked("releaseLock")?;
+  Ok((
+    read.bind(reader)?.create_ref()?,
+    release_lock.bind(reader)?.create_ref()?,
+  ))
+}
+
+fn read_csv_stream<'env>(
+  env: &Env,
+  read: ReadFunction<'env>,
+  mut data: Vec<u8>,
+  next_day_starts_at: i64,
+  timezone_offset: TimezoneOffset,
+) -> Result<PromiseRaw<'env, Object<'env>>> {
+  let chained = read.borrow_back(env)?.call(())?.then(move |context| {
+    if context.value.get_named_property("done")? {
+      return Ok(Either::A(convert_csv_bytes(
+        &data,
+        next_day_starts_at,
+        &timezone_offset,
+      )?));
+    }
+
+    let chunk: Uint8Array = context.value.get_named_property("value")?;
+    data.extend_from_slice(chunk.as_ref());
+
+    Ok(Either::B(read_csv_stream(
+      &context.env,
+      read,
+      data,
+      next_day_starts_at,
+      timezone_offset,
+    )?))
+  })?;
+
+  // Returning the next read Promise lets JavaScript flatten the chain until the final array.
+  Ok(PromiseRaw::new(env.raw(), chained.raw()))
+}
+
+pub(crate) fn convert_csv_stream<'env>(
+  env: &'env Env,
+  stream: ReadableStream<'env, Uint8Array>,
+  next_day_starts_at: i64,
+  timezone_offset: TimezoneOffset,
+) -> Result<PromiseRaw<'env, Object<'env>>> {
+  if stream.locked()? {
+    return PromiseRaw::reject(env, napi::Error::from_reason("ReadableStream is locked"));
+  }
+  let (read, release_lock) = match bind_stream_reader(&stream) {
+    Ok(reader) => reader,
+    Err(error) => return PromiseRaw::reject(env, error),
+  };
+  let release_lock = Rc::new(release_lock);
+  // ponytail: buffers in Rust because conversion must sort every revlog; add an async CSV parser
+  // only if this extra raw buffer becomes a measured memory bottleneck.
+  let mut promise =
+    match read_csv_stream(env, read, Vec::new(), next_day_starts_at, timezone_offset) {
+      Ok(promise) => promise,
+      Err(error) => {
+        release_lock.borrow_back(env)?.call(())?;
+        return PromiseRaw::reject(env, error);
+      }
+    };
+  let release_lock_on_settle = Rc::clone(&release_lock);
+  match promise.finally(move |env| release_lock_on_settle.borrow_back(&env)?.call(())) {
+    Ok(promise) => Ok(promise),
+    Err(error) => {
+      release_lock.borrow_back(env)?.call(())?;
+      PromiseRaw::reject(env, error)
+    }
+  }
+}

--- a/packages/binding/src/lib.rs
+++ b/packages/binding/src/lib.rs
@@ -3,6 +3,7 @@
 use napi::bindgen_prelude::Result;
 use napi_derive::napi;
 mod convert;
+mod convert_stream;
 mod evaluate;
 mod model;
 #[cfg(not(threadless_wasm))]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   is-core-module: npm:@nolyfill/is-core-module@^1
   minimatch: '>=10.2.3'
+  '@napi-rs/cli@3.8.0>emnapi': 2.0.0-alpha.4
   '@rolldown/binding-wasm32-wasi>@napi-rs/wasm-runtime': 1.1.4
 
 importers:
@@ -50,17 +51,17 @@ importers:
   packages/binding:
     devDependencies:
       '@emnapi/core':
-        specifier: 2.0.0-alpha.3
-        version: 2.0.0-alpha.3
+        specifier: 2.0.0-alpha.4
+        version: 2.0.0-alpha.4
       '@emnapi/runtime':
-        specifier: 2.0.0-alpha.3
-        version: 2.0.0-alpha.3
+        specifier: 2.0.0-alpha.4
+        version: 2.0.0-alpha.4
       '@napi-rs/cli':
         specifier: 3.8.0
-        version: 3.8.0(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@25.6.2)
+        version: 3.8.0(@emnapi/core@2.0.0-alpha.4)(@emnapi/runtime@2.0.0-alpha.4)(@types/node@25.6.2)
       '@napi-rs/wasm-runtime':
         specifier: ^1.2.0
-        version: 1.2.0(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
+        version: 1.2.0(@emnapi/core@2.0.0-alpha.4)(@emnapi/runtime@2.0.0-alpha.4)
       '@taplo/cli':
         specifier: ^0.7.0
         version: 0.7.0
@@ -71,8 +72,8 @@ importers:
         specifier: ^5.4.1
         version: 5.6.2
       emnapi:
-        specifier: 2.0.0-alpha.3
-        version: 2.0.0-alpha.3
+        specifier: 2.0.0-alpha.4
+        version: 2.0.0-alpha.4
       npm-run-all2:
         specifier: ^8.0.4
         version: 8.0.4
@@ -124,14 +125,14 @@ importers:
         version: link:../binding
     devDependencies:
       '@emnapi/core':
-        specifier: 2.0.0-alpha.3
-        version: 2.0.0-alpha.3
+        specifier: 2.0.0-alpha.4
+        version: 2.0.0-alpha.4
       '@emnapi/runtime':
-        specifier: 2.0.0-alpha.3
-        version: 2.0.0-alpha.3
+        specifier: 2.0.0-alpha.4
+        version: 2.0.0-alpha.4
       '@napi-rs/wasm-runtime':
         specifier: ^1.2.0
-        version: 1.2.0(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
+        version: 1.2.0(@emnapi/core@2.0.0-alpha.4)(@emnapi/runtime@2.0.0-alpha.4)
       '@types/papaparse':
         specifier: ^5.5.2
         version: 5.5.2
@@ -165,26 +166,26 @@ importers:
   packages/binding/npm/wasm32-wasi:
     dependencies:
       '@emnapi/core':
-        specifier: 2.0.0-alpha.3
-        version: 2.0.0-alpha.3
+        specifier: 2.0.0-alpha.4
+        version: 2.0.0-alpha.4
       '@emnapi/runtime':
-        specifier: 2.0.0-alpha.3
-        version: 2.0.0-alpha.3
+        specifier: 2.0.0-alpha.4
+        version: 2.0.0-alpha.4
       '@napi-rs/wasm-runtime':
         specifier: ^1.2.0
-        version: 1.2.0(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
+        version: 1.2.0(@emnapi/core@2.0.0-alpha.4)(@emnapi/runtime@2.0.0-alpha.4)
 
   packages/binding/npm/wasm32-wasip1:
     dependencies:
       '@emnapi/core':
-        specifier: 2.0.0-alpha.3
-        version: 2.0.0-alpha.3
+        specifier: 2.0.0-alpha.4
+        version: 2.0.0-alpha.4
       '@emnapi/runtime':
-        specifier: 2.0.0-alpha.3
-        version: 2.0.0-alpha.3
+        specifier: 2.0.0-alpha.4
+        version: 2.0.0-alpha.4
       '@napi-rs/wasm-runtime':
         specifier: ^1.2.0
-        version: 1.2.0(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
+        version: 1.2.0(@emnapi/core@2.0.0-alpha.4)(@emnapi/runtime@2.0.0-alpha.4)
 
   packages/binding/npm/win32-arm64-msvc: {}
 
@@ -424,8 +425,8 @@ packages:
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
-  '@emnapi/core@2.0.0-alpha.3':
-    resolution: {integrity: sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==}
+  '@emnapi/core@2.0.0-alpha.4':
+    resolution: {integrity: sha512-KjoUR6mNvjT+z5bKMy+a5QDI+kTNTiMZi6uPKzWuWjwZGNa0UPwIVduTfeBRdf6v8Ws5fmHDh7Usf15w/ANfkg==}
 
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
@@ -433,8 +434,8 @@ packages:
   '@emnapi/runtime@1.11.1':
     resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
 
-  '@emnapi/runtime@2.0.0-alpha.3':
-    resolution: {integrity: sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==}
+  '@emnapi/runtime@2.0.0-alpha.4':
+    resolution: {integrity: sha512-Wy1TQ99obRP3Ah7cf/OOtK1zD9t3pYTWz+G/SpAwTFMhG5hoMdlvfzBpYoHUigS/izu3q+VhYMKhJd7Ii/trpg==}
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
@@ -2008,8 +2009,8 @@ packages:
   electron-to-chromium@1.5.349:
     resolution: {integrity: sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==}
 
-  emnapi@2.0.0-alpha.3:
-    resolution: {integrity: sha512-K9bc9Xx4OwSfhJpdSOpcfIKzn7/6emuubaIorf6I5e7WBAM79665rf6iHr9y50NL4qYMUP/AheTpD1Z4yU1EBw==}
+  emnapi@2.0.0-alpha.4:
+    resolution: {integrity: sha512-nunHTwW00/hM8v0QGdToZGQ+OoI1yD09vDPbhPdO+bzQrih/m8NokPVj26J02dDimaF6cE87l5H4xZdSX7RiIw==}
     peerDependencies:
       node-addon-api: '>= 6.1.0'
     peerDependenciesMeta:
@@ -3227,7 +3228,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/core@2.0.0-alpha.3':
+  '@emnapi/core@2.0.0-alpha.4':
     dependencies:
       '@emnapi/wasi-threads': 2.0.1
       tslib: 2.8.1
@@ -3242,7 +3243,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@2.0.0-alpha.3':
+  '@emnapi/runtime@2.0.0-alpha.4':
     dependencies:
       tslib: 2.8.1
 
@@ -3511,15 +3512,15 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@napi-rs/cli@3.8.0(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@25.6.2)':
+  '@napi-rs/cli@3.8.0(@emnapi/core@2.0.0-alpha.4)(@emnapi/runtime@2.0.0-alpha.4)(@types/node@25.6.2)':
     dependencies:
       '@inquirer/prompts': 8.5.2(@types/node@25.6.2)
-      '@napi-rs/cross-toolchain': 1.0.3(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
-      '@napi-rs/wasm-tools': 1.0.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
+      '@napi-rs/cross-toolchain': 1.0.3(@emnapi/core@2.0.0-alpha.4)(@emnapi/runtime@2.0.0-alpha.4)
+      '@napi-rs/wasm-tools': 1.0.1(@emnapi/core@2.0.0-alpha.4)(@emnapi/runtime@2.0.0-alpha.4)
       '@octokit/rest': 22.0.1
       clipanion: 4.0.0-rc.4(typanion@3.14.0)
       colorette: 2.0.20
-      emnapi: 2.0.0-alpha.3
+      emnapi: 2.0.0-alpha.4
       es-toolkit: 1.50.0
       js-yaml: 4.3.0
       obug: 2.1.3
@@ -3527,7 +3528,7 @@ snapshots:
       typanion: 3.14.0
       typescript: 6.0.3
     optionalDependencies:
-      '@emnapi/runtime': 2.0.0-alpha.3
+      '@emnapi/runtime': 2.0.0-alpha.4
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@napi-rs/cross-toolchain-arm64-target-aarch64'
@@ -3544,10 +3545,10 @@ snapshots:
       - node-addon-api
       - supports-color
 
-  '@napi-rs/cross-toolchain@1.0.3(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)':
+  '@napi-rs/cross-toolchain@1.0.3(@emnapi/core@2.0.0-alpha.4)(@emnapi/runtime@2.0.0-alpha.4)':
     dependencies:
-      '@napi-rs/lzma': 1.4.5(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
-      '@napi-rs/tar': 1.1.0(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
+      '@napi-rs/lzma': 1.4.5(@emnapi/core@2.0.0-alpha.4)(@emnapi/runtime@2.0.0-alpha.4)
+      '@napi-rs/tar': 1.1.0(@emnapi/core@2.0.0-alpha.4)(@emnapi/runtime@2.0.0-alpha.4)
       debug: 4.4.3
     transitivePeerDependencies:
       - '@emnapi/core'
@@ -3593,9 +3594,9 @@ snapshots:
   '@napi-rs/lzma-linux-x64-musl@1.4.5':
     optional: true
 
-  '@napi-rs/lzma-wasm32-wasi@1.4.5(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)':
+  '@napi-rs/lzma-wasm32-wasi@1.4.5(@emnapi/core@2.0.0-alpha.4)(@emnapi/runtime@2.0.0-alpha.4)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.2.0(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
+      '@napi-rs/wasm-runtime': 1.2.0(@emnapi/core@2.0.0-alpha.4)(@emnapi/runtime@2.0.0-alpha.4)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -3610,7 +3611,7 @@ snapshots:
   '@napi-rs/lzma-win32-x64-msvc@1.4.5':
     optional: true
 
-  '@napi-rs/lzma@1.4.5(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)':
+  '@napi-rs/lzma@1.4.5(@emnapi/core@2.0.0-alpha.4)(@emnapi/runtime@2.0.0-alpha.4)':
     optionalDependencies:
       '@napi-rs/lzma-android-arm-eabi': 1.4.5
       '@napi-rs/lzma-android-arm64': 1.4.5
@@ -3625,7 +3626,7 @@ snapshots:
       '@napi-rs/lzma-linux-s390x-gnu': 1.4.5
       '@napi-rs/lzma-linux-x64-gnu': 1.4.5
       '@napi-rs/lzma-linux-x64-musl': 1.4.5
-      '@napi-rs/lzma-wasm32-wasi': 1.4.5(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
+      '@napi-rs/lzma-wasm32-wasi': 1.4.5(@emnapi/core@2.0.0-alpha.4)(@emnapi/runtime@2.0.0-alpha.4)
       '@napi-rs/lzma-win32-arm64-msvc': 1.4.5
       '@napi-rs/lzma-win32-ia32-msvc': 1.4.5
       '@napi-rs/lzma-win32-x64-msvc': 1.4.5
@@ -3669,9 +3670,9 @@ snapshots:
   '@napi-rs/tar-linux-x64-musl@1.1.0':
     optional: true
 
-  '@napi-rs/tar-wasm32-wasi@1.1.0(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)':
+  '@napi-rs/tar-wasm32-wasi@1.1.0(@emnapi/core@2.0.0-alpha.4)(@emnapi/runtime@2.0.0-alpha.4)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.2.0(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
+      '@napi-rs/wasm-runtime': 1.2.0(@emnapi/core@2.0.0-alpha.4)(@emnapi/runtime@2.0.0-alpha.4)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -3686,7 +3687,7 @@ snapshots:
   '@napi-rs/tar-win32-x64-msvc@1.1.0':
     optional: true
 
-  '@napi-rs/tar@1.1.0(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)':
+  '@napi-rs/tar@1.1.0(@emnapi/core@2.0.0-alpha.4)(@emnapi/runtime@2.0.0-alpha.4)':
     optionalDependencies:
       '@napi-rs/tar-android-arm-eabi': 1.1.0
       '@napi-rs/tar-android-arm64': 1.1.0
@@ -3700,7 +3701,7 @@ snapshots:
       '@napi-rs/tar-linux-s390x-gnu': 1.1.0
       '@napi-rs/tar-linux-x64-gnu': 1.1.0
       '@napi-rs/tar-linux-x64-musl': 1.1.0
-      '@napi-rs/tar-wasm32-wasi': 1.1.0(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
+      '@napi-rs/tar-wasm32-wasi': 1.1.0(@emnapi/core@2.0.0-alpha.4)(@emnapi/runtime@2.0.0-alpha.4)
       '@napi-rs/tar-win32-arm64-msvc': 1.1.0
       '@napi-rs/tar-win32-ia32-msvc': 1.1.0
       '@napi-rs/tar-win32-x64-msvc': 1.1.0
@@ -3722,10 +3723,10 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@napi-rs/wasm-runtime@1.2.0(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)':
+  '@napi-rs/wasm-runtime@1.2.0(@emnapi/core@2.0.0-alpha.4)(@emnapi/runtime@2.0.0-alpha.4)':
     dependencies:
-      '@emnapi/core': 2.0.0-alpha.3
-      '@emnapi/runtime': 2.0.0-alpha.3
+      '@emnapi/core': 2.0.0-alpha.4
+      '@emnapi/runtime': 2.0.0-alpha.4
       '@tybys/wasm-util': 0.10.3
 
   '@napi-rs/wasm-tools-android-arm-eabi@1.0.1':
@@ -3755,9 +3756,9 @@ snapshots:
   '@napi-rs/wasm-tools-linux-x64-musl@1.0.1':
     optional: true
 
-  '@napi-rs/wasm-tools-wasm32-wasi@1.0.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)':
+  '@napi-rs/wasm-tools-wasm32-wasi@1.0.1(@emnapi/core@2.0.0-alpha.4)(@emnapi/runtime@2.0.0-alpha.4)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.2.0(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
+      '@napi-rs/wasm-runtime': 1.2.0(@emnapi/core@2.0.0-alpha.4)(@emnapi/runtime@2.0.0-alpha.4)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -3772,7 +3773,7 @@ snapshots:
   '@napi-rs/wasm-tools-win32-x64-msvc@1.0.1':
     optional: true
 
-  '@napi-rs/wasm-tools@1.0.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)':
+  '@napi-rs/wasm-tools@1.0.1(@emnapi/core@2.0.0-alpha.4)(@emnapi/runtime@2.0.0-alpha.4)':
     optionalDependencies:
       '@napi-rs/wasm-tools-android-arm-eabi': 1.0.1
       '@napi-rs/wasm-tools-android-arm64': 1.0.1
@@ -3783,7 +3784,7 @@ snapshots:
       '@napi-rs/wasm-tools-linux-arm64-musl': 1.0.1
       '@napi-rs/wasm-tools-linux-x64-gnu': 1.0.1
       '@napi-rs/wasm-tools-linux-x64-musl': 1.0.1
-      '@napi-rs/wasm-tools-wasm32-wasi': 1.0.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
+      '@napi-rs/wasm-tools-wasm32-wasi': 1.0.1(@emnapi/core@2.0.0-alpha.4)(@emnapi/runtime@2.0.0-alpha.4)
       '@napi-rs/wasm-tools-win32-arm64-msvc': 1.0.1
       '@napi-rs/wasm-tools-win32-ia32-msvc': 1.0.1
       '@napi-rs/wasm-tools-win32-x64-msvc': 1.0.1
@@ -4381,7 +4382,7 @@ snapshots:
 
   electron-to-chromium@1.5.349: {}
 
-  emnapi@2.0.0-alpha.3: {}
+  emnapi@2.0.0-alpha.4: {}
 
   empathic@2.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,7 @@ packages:
 overrides:
   is-core-module: npm:@nolyfill/is-core-module@^1
   minimatch: '>=10.2.3'
+  '@napi-rs/cli@3.8.0>emnapi': 2.0.0-alpha.4
   '@rolldown/binding-wasm32-wasi>@napi-rs/wasm-runtime': 1.1.4
 
 allowBuilds:
@@ -18,3 +19,6 @@ supportedArchitectures:
 minimumReleaseAgeExclude:
   - '@napi-rs/cli@3.8.0'
   - '@napi-rs/wasm-runtime@1.2.0'
+  - '@emnapi/core@2.0.0-alpha.4'
+  - '@emnapi/runtime@2.0.0-alpha.4'
+  - emnapi@2.0.0-alpha.4


### PR DESCRIPTION
## Summary

- accept `ReadableStream<Uint8Array>` in `convertCsvToFsrsItems` while preserving synchronous `Uint8Array` calls
- collect stream chunks in Rust and reuse the existing CSV conversion
- release the reader lock on success and failure across native, threaded WASI, and threadless WASI

## Why

Callers can pass a Web stream directly instead of buffering the entire CSV in JavaScript first.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p fsrs-binding`
- `cargo clippy -p fsrs-binding --all-targets -- -D warnings`
- native CSV parser tests: 17 passed
- wasm32-wasip1-threads CSV parser tests: 17 passed
- wasm32-wasip1 CSV parser tests: 17 passed
- `changeset status`
