### PR TITLE
fix: format FSRS model imports

### DIFF
--- a/packages/fsrs/src/models/fsrs-3/model.ts
+++ b/packages/fsrs/src/models/fsrs-3/model.ts
@@ -1,9 +1,9 @@
+import { defineModel } from '@open-spaced-repetition/srs-kit'
 import type {
   ModelCore,
   ModelForwardInput,
   ModelStepInput,
 } from '@open-spaced-repetition/srs-kit/model'
-import { defineModel } from '@open-spaced-repetition/srs-kit/model'
 import { FSRSMemoryStateSchema } from '@/kit/index.js'
 import type { FSRSState } from '@/models.js'
 import { FSRS3Algorithm } from './algorithm.js'

--- a/packages/fsrs/src/models/fsrs-4/model.ts
+++ b/packages/fsrs/src/models/fsrs-4/model.ts
@@ -1,9 +1,9 @@
+import { defineModel } from '@open-spaced-repetition/srs-kit'
 import type {
   ModelCore,
   ModelForwardInput,
   ModelStepInput,
 } from '@open-spaced-repetition/srs-kit/model'
-import { defineModel } from '@open-spaced-repetition/srs-kit/model'
 import { FSRSMemoryStateSchema } from '@/kit/index.js'
 import type { FSRSState } from '@/models.js'
 import { FSRS4Algorithm } from './algorithm.js'

--- a/packages/fsrs/src/models/fsrs-4dot5/model.ts
+++ b/packages/fsrs/src/models/fsrs-4dot5/model.ts
@@ -1,9 +1,9 @@
+import { defineModel } from '@open-spaced-repetition/srs-kit'
 import type {
   ModelCore,
   ModelForwardInput,
   ModelStepInput,
 } from '@open-spaced-repetition/srs-kit/model'
-import { defineModel } from '@open-spaced-repetition/srs-kit/model'
 import { FSRSMemoryStateSchema } from '@/kit/index.js'
 import type { FSRSState } from '@/models.js'
 import { FSRS4Dot5Algorithm } from './algorithm.js'

--- a/packages/fsrs/src/models/fsrs-5/model.ts
+++ b/packages/fsrs/src/models/fsrs-5/model.ts
@@ -1,9 +1,9 @@
+import { defineModel } from '@open-spaced-repetition/srs-kit'
 import type {
   ModelCore,
   ModelForwardInput,
   ModelStepInput,
 } from '@open-spaced-repetition/srs-kit/model'
-import { defineModel } from '@open-spaced-repetition/srs-kit/model'
 import { FSRSMemoryStateSchema } from '@/kit/index.js'
 import type { FSRSState } from '@/models.js'
 import { FSRS5Algorithm } from './algorithm.js'


### PR DESCRIPTION
## Summary

- import defineModel from the public srs-kit entry in the FSRS-3, FSRS-4, FSRS-4.5, and FSRS-5 models
- keep model-only types on the model subpath
- align runtime import layout across the supported model implementations

## Root cause

The four older model modules used a different defineModel import path from the current package convention. This created avoidable import inconsistency across otherwise parallel model implementations.

## Testing

- pnpm --filter ts-fsrs check
- pnpm --filter ts-fsrs typecheck
- pnpm --filter ts-fsrs build