### PR TITLE
feat(fsrs): add desired retention middleware

### DIFF
--- a/.changeset/desired-retention-middleware.md
+++ b/.changeset/desired-retention-middleware.md
@@ -1,5 +1,5 @@
 ---
-"ts-fsrs": major
+"ts-fsrs": minor
 ---
 
 feat(fsrs): add desired retention middleware and remove the exported `CardId` type.

--- a/.changeset/desired-retention-middleware.md
+++ b/.changeset/desired-retention-middleware.md
@@ -1,0 +1,5 @@
+---
+"ts-fsrs": major
+---
+
+feat(fsrs): add desired retention middleware and remove the exported `CardId` type.

--- a/packages/fsrs/src/middlewares/desired-retention/index.ts
+++ b/packages/fsrs/src/middlewares/desired-retention/index.ts
@@ -1,0 +1,5 @@
+export { schedulerDesiredRetentionMiddleware } from './middleware.js'
+export {
+  type DesiredRetentionConfig,
+  desiredRetentionConfigSchema,
+} from './schema.js'

--- a/packages/fsrs/src/middlewares/desired-retention/middleware.spec.ts
+++ b/packages/fsrs/src/middlewares/desired-retention/middleware.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { schedulerDesiredRetentionMiddleware } from './middleware.js'
+import { desiredRetentionConfigSchema } from './schema.js'
+
+describe('schedulerDesiredRetentionMiddleware', () => {
+  it('injects desiredRetention before the remaining review chain', () => {
+    const ctx = {
+      config: { desiredRetention: 0.9 },
+      desiredRetention: 0,
+    }
+
+    schedulerDesiredRetentionMiddleware.handlers!.review!(ctx as never, () => {
+      expect(ctx.desiredRetention).toBe(0.9)
+    })
+  })
+
+  it.each([
+    0,
+    -0.1,
+    1.1,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+  ])('rejects desiredRetention %s outside (0, 1]', (desiredRetention) => {
+    expect(() =>
+      desiredRetentionConfigSchema.parse({ desiredRetention })
+    ).toThrow()
+  })
+
+  it.each([0.1, 0.9, 1])('accepts desiredRetention %s', (desiredRetention) => {
+    expect(desiredRetentionConfigSchema.parse({ desiredRetention })).toEqual({
+      desiredRetention,
+    })
+  })
+})

--- a/packages/fsrs/src/middlewares/desired-retention/middleware.ts
+++ b/packages/fsrs/src/middlewares/desired-retention/middleware.ts
@@ -1,0 +1,13 @@
+import { defineMiddleware } from '@open-spaced-repetition/srs-kit'
+import { desiredRetentionConfigSchema } from './schema.js'
+
+export const schedulerDesiredRetentionMiddleware = defineMiddleware({
+  name: Symbol('ts-fsrs.desired-retention'),
+  schema: { config: desiredRetentionConfigSchema },
+  handlers: {
+    review(ctx, next) {
+      ctx.desiredRetention = ctx.config.desiredRetention
+      next()
+    },
+  },
+})

--- a/packages/fsrs/src/middlewares/desired-retention/schema.ts
+++ b/packages/fsrs/src/middlewares/desired-retention/schema.ts
@@ -1,0 +1,20 @@
+import { defineSchema, isObject } from '@open-spaced-repetition/srs-kit'
+
+export type DesiredRetentionConfig = {
+  readonly desiredRetention: number
+}
+
+export const desiredRetentionConfigSchema =
+  defineSchema<DesiredRetentionConfig>((value) => {
+    if (
+      !isObject(value) ||
+      typeof value.desiredRetention !== 'number' ||
+      !Number.isFinite(value.desiredRetention) ||
+      value.desiredRetention <= 0 ||
+      value.desiredRetention > 1
+    ) {
+      return { issues: [{ message: 'Expected desiredRetention in (0, 1]' }] }
+    }
+
+    return { value: { desiredRetention: value.desiredRetention } }
+  })

--- a/packages/fsrs/src/middlewares/fuzzing/index.ts
+++ b/packages/fsrs/src/middlewares/fuzzing/index.ts
@@ -5,7 +5,6 @@ export {
   schedulerFuzzingMiddleware,
 } from './middleware.js'
 export type {
-  CardId,
   FuzzingCardFields,
   FuzzingCardInitInput,
   FuzzingConfig,

--- a/packages/fsrs/src/middlewares/fuzzing/schema.ts
+++ b/packages/fsrs/src/middlewares/fuzzing/schema.ts
@@ -1,26 +1,24 @@
 import { defineSchema, isObject } from '@open-spaced-repetition/srs-kit'
 
-export type CardId = string | number
-
 export type FuzzingConfig = {
   readonly enableFuzz: boolean
   readonly maximumInterval: number
 }
 
 export type FuzzingCardFields = {
-  readonly cardId: CardId
+  readonly cardId: string | number
   readonly reps: number
 }
 
 export type FuzzingRevlogFields = {
-  readonly cardId: CardId
+  readonly cardId: string | number
 }
 
 export type FuzzingCardInitInput = {
-  readonly cardId?: CardId
+  readonly cardId?: string | number
 }
 
-function parseCardId(value: unknown): CardId | undefined {
+function parseCardId(value: unknown): string | number | undefined {
   if (typeof value === 'string' && value.length > 0) return value
   if (typeof value === 'number' && Number.isFinite(value)) return value
   return undefined

--- a/packages/fsrs/src/middlewares/index.ts
+++ b/packages/fsrs/src/middlewares/index.ts
@@ -1,3 +1,4 @@
+export * from './desired-retention/index.js'
 export * from './fuzzing/index.js'
 export * from './learning-steps/index.js'
 export * from './leech/index.js'


### PR DESCRIPTION
## Summary

- add schedulerDesiredRetentionMiddleware to inject validated retention into review contexts
- validate desiredRetention within the interval (0, 1]
- export the middleware and schema from ts-fsrs/middlewares
- inline string | number card ID fields, remove the exported CardId alias, and add a minor changeset

## Root cause

Scheduler configuration could carry desired retention, but FSRS middleware compositions had no dedicated policy that copied the validated value into each review context. The public CardId alias also duplicated its primitive union without adding domain behavior.

## Testing

- pnpm --filter ts-fsrs test -- src/middlewares/desired-retention
- pnpm --filter ts-fsrs check
- pnpm exec changeset status --since=origin/styles/models