### PR TITLE
fix: infer scheduler card input

### DIFF
--- a/.changeset/fix-scheduler-card-init-input.md
+++ b/.changeset/fix-scheduler-card-init-input.md
@@ -1,0 +1,5 @@
+---
+"@open-spaced-repetition/srs-kit": patch
+---
+
+fix: infer middleware card initialization fields for `newCard`.

--- a/packages/srs-kit/src/scheduler/infer.ts
+++ b/packages/srs-kit/src/scheduler/infer.ts
@@ -220,7 +220,11 @@ export type SchedulerEnvFor<
     input: Prettify<SchedulerConfigInput<M, C, MWs>>
     output: Prettify<SchedulerConfigOutput<M, C, MWs>>
   }>
-  readonly cardInitInput: SchedulerCardInitSchema<ChronoTimeOf<C>>
+  readonly cardInitInput: SchedulerCardInitSchema<
+    ChronoTimeOf<C>,
+    MiddlewareCardInitInputFields<MWs, 'input'>,
+    MiddlewareCardInitInputFields<MWs, 'output'>
+  >
   readonly card: SRSSchema<{
     input: Prettify<Readonly<SchedulerObjectFields<M, C, MWs, 'card', 'input'>>>
     output: Prettify<SchedulerCardFields<M, C, MWs>>

--- a/packages/srs-kit/src/scheduler/infer.ts
+++ b/packages/srs-kit/src/scheduler/infer.ts
@@ -220,11 +220,16 @@ export type SchedulerEnvFor<
     input: Prettify<SchedulerConfigInput<M, C, MWs>>
     output: Prettify<SchedulerConfigOutput<M, C, MWs>>
   }>
-  readonly cardInitInput: SchedulerCardInitSchema<
-    ChronoTimeOf<C>,
-    MiddlewareCardInitInputFields<MWs, 'input'>,
-    MiddlewareCardInitInputFields<MWs, 'output'>
-  >
+  readonly cardInitInput: [
+    | keyof MiddlewareCardInitInputFields<MWs, 'input'>
+    | keyof MiddlewareCardInitInputFields<MWs, 'output'>,
+  ] extends [never]
+    ? SchedulerCardInitSchema<ChronoTimeOf<C>>
+    : SchedulerCardInitSchema<
+        ChronoTimeOf<C>,
+        MiddlewareCardInitInputFields<MWs, 'input'>,
+        MiddlewareCardInitInputFields<MWs, 'output'>
+      >
   readonly card: SRSSchema<{
     input: Prettify<Readonly<SchedulerObjectFields<M, C, MWs, 'card', 'input'>>>
     output: Prettify<SchedulerCardFields<M, C, MWs>>

--- a/packages/srs-kit/src/scheduler/scheduler.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.spec.ts
@@ -12,11 +12,13 @@ import type {
   SchedulerCardInputOf,
   SchedulerCardOf,
   SchedulerConfigOf,
+  SchedulerEnvFor,
   SchedulerRevlogInputOf,
   SchedulerRevlogOf,
   SchedulerStatusOf,
   SchedulerTimeOf,
 } from './infer.js'
+import type { SchedulerCoreEnv, SchedulerNewCardOptions } from './scheduler.js'
 import {
   config,
   createSM2NumericScheduler,
@@ -85,6 +87,21 @@ describe('defineScheduler', () => {
     }
 
     expectTypeOf(invalidNewCard).toBeFunction()
+  })
+
+  it('includes middleware new-card input in SchedulerEnvFor', () => {
+    type Env = SchedulerEnvFor<
+      typeof SM2Model,
+      typeof dateChrono,
+      readonly [typeof sourceMiddleware]
+    >
+
+    expectTypeOf<
+      SchedulerNewCardOptions<SchedulerCoreEnv<Env>>
+    >().toEqualTypeOf<{
+      readonly now?: Date
+      readonly source?: string
+    }>()
   })
 
   it('requires new-card input when middleware declares required fields', () => {


### PR DESCRIPTION
## Summary

- include middleware card initialization fields in SchedulerEnvFor
- preserve optional and required middleware fields in newCard input inference
- keep the no-middleware input shape compact when no additional fields exist
- add type-level regression coverage and a patch changeset

## Root cause

SchedulerEnvFor always built cardInitInput from chrono fields alone. Middleware-provided initialization fields were therefore dropped from the inferred newCard API even though the runtime schema accepted them.

## Testing

- pnpm --filter @open-spaced-repetition/srs-kit test (25 files passed; 214 passed)
- pnpm --filter @open-spaced-repetition/srs-kit check
- pnpm --filter @open-spaced-repetition/srs-kit build