### PR TITLE
feat: add default scheduler

### DIFF
--- a/.changeset/add-default-scheduler.md
+++ b/.changeset/add-default-scheduler.md
@@ -1,0 +1,5 @@
+---
+"ts-fsrs": major
+---
+
+feat: add the srs-kit-backed `DefaultScheduler` API.

--- a/packages/fsrs/src/index.ts
+++ b/packages/fsrs/src/index.ts
@@ -35,4 +35,5 @@ export type {
   Steps,
 } from './models.js'
 export { Rating, State } from './models.js'
+export * from './scheduler/index.js'
 export type * from './types.js'

--- a/packages/fsrs/src/scheduler/default-scheduler.legacy-parity.spec.ts
+++ b/packages/fsrs/src/scheduler/default-scheduler.legacy-parity.spec.ts
@@ -1,0 +1,370 @@
+import { grades, states } from '@open-spaced-repetition/srs-kit'
+import {
+  DefaultScheduler,
+  type DefaultSchedulerOptions,
+  type Grade,
+  Rating,
+  State,
+} from 'ts-fsrs'
+import {
+  expectFullParity,
+  expectRevlogParity,
+  expectRollbackParity,
+  expectSequenceParity,
+  legacyNext,
+  legacyReview,
+  legacyRollback,
+} from './default-scheduler.legacy-test-utils.js'
+import {
+  createStateCard,
+  DAY,
+  NOW,
+  scheduleStatusByState,
+} from './default-scheduler.test-utils.js'
+
+const cardKeys = [
+  'cardId',
+  'difficulty',
+  'dueAt',
+  'lapses',
+  'lastReviewAt',
+  'learningStep',
+  'reps',
+  'scheduleStatus',
+  'scheduledDays',
+  'stability',
+  'state',
+] as const
+const revlogKeys = [
+  'cardId',
+  'difficulty',
+  'dueAt',
+  'learningStep',
+  'rating',
+  'reviewTime',
+  'scheduleStatus',
+  'scheduledDays',
+  'stability',
+  'state',
+] as const
+
+describe('DefaultScheduler legacy parity', () => {
+  describe.each([
+    true,
+    false,
+  ])('field parity with enableShortTerm=%s', (enableShortTerm) => {
+    const options = { enableShortTerm } satisfies DefaultSchedulerOptions
+
+    it.each(
+      grades
+    )('matches every card and revlog field for rating %s', async (grade) => {
+      const scheduler = await DefaultScheduler(options)
+      const card = createStateCard(State.Review)
+      const actual = scheduler.review({ card, grade, now: NOW })
+      const legacy = legacyNext(options, card, NOW, grade)
+
+      expect(Object.keys(actual.card).sort()).toEqual(cardKeys)
+      expect(actual.card.cardId).toBe(card.cardId)
+      expect(actual.card.dueAt).toEqual(legacy.card.due)
+      expect(actual.card.stability).toBe(legacy.card.stability)
+      expect(actual.card.difficulty).toBe(legacy.card.difficulty)
+      expect(actual.card.scheduledDays).toBe(legacy.card.scheduled_days)
+      expect(actual.card.learningStep).toBe(legacy.card.learning_steps)
+      expect(actual.card.reps).toBe(legacy.card.reps)
+      expect(actual.card.lapses).toBe(legacy.card.lapses)
+      expect(actual.card.state).toBe(legacy.card.state)
+      expect(actual.card.scheduleStatus).toBe(
+        scheduleStatusByState[legacy.card.state]
+      )
+      expect(actual.card.lastReviewAt).toEqual(legacy.card.last_review ?? null)
+
+      expect(Object.keys(actual.revlog).sort()).toEqual(revlogKeys)
+      expect(actual.revlog.cardId).toBe(card.cardId)
+      expect(actual.revlog.dueAt).toEqual(legacy.log.due)
+      expect(actual.revlog.stability).toBe(legacy.log.stability)
+      expect(actual.revlog.difficulty).toBe(legacy.log.difficulty)
+      expect(actual.revlog.scheduledDays).toBe(legacy.log.scheduled_days)
+      expect(actual.revlog.learningStep).toBe(legacy.log.learning_steps)
+      expect(actual.revlog.rating).toBe(legacy.log.rating)
+      expect(actual.revlog.state).toBe(legacy.log.state)
+      expect(actual.revlog.scheduleStatus).toBe(
+        scheduleStatusByState[legacy.log.state]
+      )
+      expect(actual.revlog.reviewTime).toEqual(legacy.log.review)
+    })
+  })
+
+  describe.each([
+    { name: 'short-term', enableShortTerm: true },
+    { name: 'long-term', enableShortTerm: false },
+  ])('$name legacy parity', ({ enableShortTerm }) => {
+    const options = { enableShortTerm } satisfies DefaultSchedulerOptions
+
+    it.each(states)('matches every rating from state %s', async (state) => {
+      const card = createStateCard(state)
+      const actual = Array.from(
+        (await DefaultScheduler(options)).preview({ card, now: NOW })
+      )
+
+      expect(actual.map((item) => item.grade)).toEqual(grades)
+      for (const [index, grade] of grades.entries()) {
+        const expected = legacyReview(options, card, NOW, grade)
+        if (
+          !enableShortTerm &&
+          (state === State.Learning || state === State.Relearning)
+        ) {
+          expect(actual[index].card).toEqual({
+            ...expected.card,
+            dueAt: actual[index].card.dueAt,
+            lapses: card.lapses,
+            scheduledDays: actual[index].card.scheduledDays,
+          })
+          expect(actual[index].card.scheduledDays).toBeLessThanOrEqual(
+            expected.card.scheduledDays
+          )
+          expectRevlogParity(actual[index].revlog, expected.revlog)
+        } else {
+          expectFullParity(actual[index], expected)
+        }
+      }
+
+      if (state === State.New) {
+        expect(actual.every((item) => +item.revlog.dueAt === +NOW)).toBe(true)
+        expect(+card.dueAt).not.toBe(+NOW)
+      }
+    })
+
+    it('matches a multi-round review sequence', async () => {
+      const scheduler = await DefaultScheduler(options)
+      const ratings = [
+        Rating.Again,
+        Rating.Hard,
+        Rating.Good,
+        Rating.Again,
+        Rating.Easy,
+        Rating.Good,
+        Rating.Hard,
+        Rating.Easy,
+      ] as const satisfies readonly Grade[]
+      let card = scheduler.newCard({
+        now: NOW,
+        cardId: `multi-${enableShortTerm}`,
+      })
+      let now = NOW
+
+      for (const [index, grade] of ratings.entries()) {
+        const expected = legacyReview(options, card, now, grade)
+        const actual = scheduler.review({ card, grade, now })
+        expectSequenceParity(actual, expected, card, enableShortTerm)
+        card = actual.card
+        now = new Date(card.dueAt.getTime() + (index % 2 === 0 ? 0 : DAY))
+      }
+    })
+
+    it('matches 200 fixed-seed randomized review rounds', async () => {
+      const scheduler = await DefaultScheduler(options)
+      let seed = enableShortTerm ? 0x6f6e : 0x6f66
+      let card = scheduler.newCard({
+        now: NOW,
+        cardId: `random-${enableShortTerm}`,
+      })
+      let now = NOW
+
+      const random = () => {
+        seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0
+        return seed / 0x1_0000_0000
+      }
+
+      for (let round = 0; round < 200; round += 1) {
+        const grade = grades[Math.floor(random() * grades.length)]
+        const expected = legacyReview(options, card, now, grade)
+        const actual = scheduler.review({ card, grade, now })
+
+        expectSequenceParity(actual, expected, card, enableShortTerm)
+        expectRollbackParity(
+          scheduler.rollback(actual),
+          legacyRollback(options, expected),
+          actual.revlog
+        )
+
+        card = actual.card
+        const delay = Math.floor(random() * 15) * DAY
+        const hourOffset = Math.floor(random() * 24) * (DAY / 24)
+        now = new Date(card.dueAt.getTime() + delay + hourOffset)
+      }
+    })
+
+    it.each(
+      states
+    )('rolls state %s back to the legacy input', async (state) => {
+      const scheduler = await DefaultScheduler(options)
+      const card = createStateCard(state)
+
+      for (const grade of grades) {
+        const reviewed = scheduler.review({ card, grade, now: NOW })
+        expectRollbackParity(
+          scheduler.rollback(reviewed),
+          card,
+          reviewed.revlog
+        )
+      }
+    })
+  })
+
+  describe.each([
+    {
+      name: 'short-term without learning steps',
+      options: {
+        enableShortTerm: true,
+        learningSteps: [],
+        relearningSteps: [],
+      },
+    },
+    {
+      name: 'short-term with day-scale learning steps',
+      options: {
+        enableShortTerm: true,
+        learningSteps: ['1.5d'],
+        relearningSteps: ['2d'],
+      },
+    },
+    {
+      name: 'short-term with zero-minute learning steps',
+      options: {
+        enableShortTerm: true,
+        learningSteps: ['0m'],
+        relearningSteps: ['0m'],
+      },
+    },
+    {
+      name: 'short-term with a small maximum interval',
+      options: {
+        enableShortTerm: true,
+        maximumInterval: 2,
+      },
+    },
+    {
+      name: 'long-term with a small maximum interval',
+      options: {
+        enableShortTerm: false,
+        maximumInterval: 2,
+      },
+    },
+    {
+      name: 'long-term with high requested retention',
+      options: {
+        enableShortTerm: false,
+        desiredRetention: 0.99,
+      },
+    },
+  ] as const)('parameter edge parity: $name', ({ options }) => {
+    it.each(states)('matches every rating from state %s', async (state) => {
+      const card = createStateCard(state)
+      const scheduler = await DefaultScheduler(options)
+
+      for (const grade of grades) {
+        const expected = legacyReview(options, card, NOW, grade)
+        const actual = scheduler.review({ card, grade, now: NOW })
+
+        if (
+          options.enableShortTerm &&
+          options.maximumInterval === 2 &&
+          expected.card.scheduledDays > options.maximumInterval
+        ) {
+          expect(actual.card).toEqual({
+            ...expected.card,
+            dueAt: new Date(NOW.getTime() + 2 * DAY),
+            scheduledDays: options.maximumInterval,
+          })
+          expectRevlogParity(actual.revlog, expected.revlog)
+          continue
+        }
+        if (
+          !options.enableShortTerm &&
+          (state === State.Learning || state === State.Relearning)
+        ) {
+          expect(actual.card).toEqual({
+            ...expected.card,
+            dueAt: actual.card.dueAt,
+            lapses: card.lapses,
+            scheduledDays: actual.card.scheduledDays,
+          })
+          expect(actual.card.scheduledDays).toBeLessThanOrEqual(
+            expected.card.scheduledDays
+          )
+          expectRevlogParity(actual.revlog, expected.revlog)
+          continue
+        }
+        if (options.enableShortTerm && state === State.New) {
+          expect(actual.card).toEqual({
+            ...expected.card,
+            dueAt: actual.card.dueAt,
+            scheduledDays: actual.card.scheduledDays,
+          })
+          expect(actual.card.scheduledDays).toBeGreaterThanOrEqual(
+            expected.card.scheduledDays
+          )
+          expectRevlogParity(actual.revlog, expected.revlog)
+          continue
+        }
+        expectFullParity(actual, expected)
+      }
+    })
+  })
+
+  describe('legacy card compatibility', () => {
+    it.each([
+      2.5, -1,
+    ])('consumes legacy scheduledDays=%s without losing rollback parity', async (scheduledDays) => {
+      const options = { enableShortTerm: true }
+      const scheduler = await DefaultScheduler(options)
+      const card = {
+        ...createStateCard(State.Review),
+        cardId: `legacy-scheduled-${scheduledDays}`,
+        scheduledDays,
+      }
+      const expected = legacyReview(options, card, NOW, Rating.Good)
+      const actual = scheduler.review({
+        card,
+        grade: Rating.Good,
+        now: NOW,
+      })
+
+      expectFullParity(actual, expected)
+      expectRollbackParity(
+        scheduler.rollback(actual),
+        legacyRollback(options, expected),
+        actual.revlog
+      )
+      expect(scheduler.rollback(actual).scheduledDays).toBe(scheduledDays)
+    })
+
+    it('keeps scheduledDays aligned with the rounded learning-step due', async () => {
+      const options = {
+        enableShortTerm: true,
+        learningSteps: ['23.999h'],
+        relearningSteps: ['47.999h'],
+      } satisfies DefaultSchedulerOptions
+      const scheduler = await DefaultScheduler(options)
+
+      for (const [state, expectedDays] of [
+        [State.New, 1],
+        [State.Review, 2],
+      ] as const) {
+        const card = createStateCard(state)
+        const actual = scheduler.review({
+          card,
+          grade: Rating.Again,
+          now: NOW,
+        })
+        const legacy = legacyReview(options, card, NOW, Rating.Again)
+
+        expect(actual.card.dueAt.getTime() - NOW.getTime()).toBe(
+          expectedDays * DAY
+        )
+        expect(actual.card.scheduledDays).toBe(expectedDays)
+        expect(legacy.card.scheduledDays).toBe(expectedDays - 1)
+      }
+    })
+  })
+})

--- a/packages/fsrs/src/scheduler/default-scheduler.legacy-test-utils.ts
+++ b/packages/fsrs/src/scheduler/default-scheduler.legacy-test-utils.ts
@@ -1,0 +1,194 @@
+import {
+  type Card,
+  type DefaultScheduler,
+  type DefaultSchedulerCard,
+  type DefaultSchedulerOptions,
+  FSRS,
+  type FSRSParameters,
+  type Grade,
+  generatorParameters,
+  type ReviewLog,
+  State,
+} from 'ts-fsrs'
+import { scheduleStatusByState } from './default-scheduler.test-utils.js'
+
+type ReviewResult = ReturnType<DefaultScheduler['review']>
+const legacyDefaults = generatorParameters()
+
+function toLegacyParameters(options: DefaultSchedulerOptions): FSRSParameters {
+  return generatorParameters({
+    w: Array.from(options.weights ?? legacyDefaults.w),
+    enable_short_term:
+      options.enableShortTerm ?? legacyDefaults.enable_short_term,
+    request_retention:
+      options.desiredRetention ?? legacyDefaults.request_retention,
+    learning_steps: Array.from(
+      options.learningSteps ?? legacyDefaults.learning_steps
+    ),
+    relearning_steps: Array.from(
+      options.relearningSteps ?? legacyDefaults.relearning_steps
+    ),
+    enable_fuzz: options.enableFuzz ?? legacyDefaults.enable_fuzz,
+    maximum_interval:
+      options.maximumInterval ?? legacyDefaults.maximum_interval,
+  })
+}
+
+function toLegacyCard(card: DefaultSchedulerCard): Card {
+  return {
+    due: card.dueAt,
+    stability: card.stability,
+    difficulty: card.difficulty,
+    scheduled_days: card.scheduledDays,
+    learning_steps: card.learningStep,
+    reps: card.reps,
+    lapses: card.lapses,
+    state: card.state,
+    last_review: card.lastReviewAt ?? undefined,
+  }
+}
+
+function fromLegacyCard(
+  card: Card,
+  cardId: DefaultSchedulerCard['cardId']
+): DefaultSchedulerCard {
+  return {
+    cardId,
+    dueAt: card.due,
+    stability: card.stability,
+    difficulty: card.difficulty,
+    scheduledDays: card.scheduled_days,
+    learningStep: card.learning_steps,
+    reps: card.reps,
+    lapses: card.lapses,
+    state: card.state,
+    scheduleStatus: scheduleStatusByState[card.state],
+    lastReviewAt: card.last_review ?? null,
+  }
+}
+
+function fromLegacyRevlog(
+  revlog: ReviewLog,
+  cardId: DefaultSchedulerCard['cardId']
+): ReviewResult['revlog'] {
+  return {
+    cardId,
+    dueAt: revlog.due,
+    stability: revlog.stability,
+    difficulty: revlog.difficulty,
+    scheduledDays: revlog.scheduled_days,
+    learningStep: revlog.learning_steps,
+    rating: revlog.rating as Grade,
+    state: revlog.state,
+    scheduleStatus: scheduleStatusByState[revlog.state],
+    reviewTime: revlog.review,
+  }
+}
+
+function toLegacyRevlog(revlog: ReviewResult['revlog']): ReviewLog {
+  return {
+    rating: revlog.rating,
+    state: revlog.state,
+    due: revlog.dueAt,
+    stability: revlog.stability,
+    difficulty: revlog.difficulty,
+    scheduled_days: revlog.scheduledDays,
+    learning_steps: revlog.learningStep,
+    review: revlog.reviewTime,
+  }
+}
+
+export function legacyReview(
+  options: DefaultSchedulerOptions,
+  card: DefaultSchedulerCard,
+  now: Date,
+  grade: Grade
+): ReviewResult {
+  const result = legacyNext(options, card, now, grade)
+  return {
+    card: fromLegacyCard(result.card, card.cardId),
+    revlog: fromLegacyRevlog(result.log, card.cardId),
+  }
+}
+
+export function legacyNext(
+  options: DefaultSchedulerOptions,
+  card: DefaultSchedulerCard,
+  now: Date,
+  grade: Grade
+) {
+  return new FSRS(toLegacyParameters(options)).next(
+    toLegacyCard(card),
+    now,
+    grade
+  )
+}
+
+export function legacyRollback(
+  options: DefaultSchedulerOptions,
+  result: ReviewResult
+): Card {
+  return new FSRS(toLegacyParameters(options)).rollback(
+    toLegacyCard(result.card),
+    toLegacyRevlog(result.revlog)
+  )
+}
+
+export function expectRollbackParity(
+  actual: DefaultSchedulerCard,
+  expected: Card | DefaultSchedulerCard,
+  revlog?: ReviewResult['revlog']
+): void {
+  const expectedCard =
+    'cardId' in expected ? expected : fromLegacyCard(expected, actual.cardId)
+  expect(actual).toEqual({
+    ...expectedCard,
+    dueAt: revlog?.state === State.New ? revlog.reviewTime : expectedCard.dueAt,
+    lastReviewAt:
+      revlog?.state === State.New ? revlog.dueAt : expectedCard.lastReviewAt,
+  })
+}
+
+export function expectRevlogParity(
+  actual: ReviewResult['revlog'],
+  expected: ReviewResult['revlog']
+): void {
+  expect(actual).toEqual({
+    ...expected,
+    dueAt: expected.state === State.New ? actual.dueAt : expected.dueAt,
+  })
+}
+
+export function expectFullParity(
+  actual: ReviewResult,
+  expected: ReviewResult
+): void {
+  expect(actual.card).toEqual(expected.card)
+  expectRevlogParity(actual.revlog, expected.revlog)
+}
+
+export function expectSequenceParity(
+  actual: ReviewResult,
+  expected: ReviewResult,
+  previousCard: DefaultSchedulerCard,
+  enableShortTerm: boolean
+): void {
+  if (
+    enableShortTerm &&
+    (previousCard.state === State.Learning ||
+      previousCard.state === State.Relearning)
+  ) {
+    expect(actual.card).toEqual({
+      ...expected.card,
+      dueAt: actual.card.dueAt,
+      scheduledDays: actual.card.scheduledDays,
+    })
+    expect(actual.card.scheduledDays).toBeGreaterThanOrEqual(
+      expected.card.scheduledDays
+    )
+    expectRevlogParity(actual.revlog, expected.revlog)
+    return
+  }
+
+  expectFullParity(actual, expected)
+}

--- a/packages/fsrs/src/scheduler/default-scheduler.spec.ts
+++ b/packages/fsrs/src/scheduler/default-scheduler.spec.ts
@@ -1,0 +1,281 @@
+import {
+  DefaultScheduler,
+  type DefaultSchedulerCard,
+  type DefaultSchedulerOptions,
+  type Grade,
+  Rating,
+  State,
+} from 'ts-fsrs'
+import { FSRS3_DEFAULT_WEIGHTS } from 'ts-fsrs/models/fsrs-3'
+import { FSRS4_DEFAULT_WEIGHTS } from 'ts-fsrs/models/fsrs-4'
+import { FSRS4Dot5_DEFAULT_WEIGHTS } from 'ts-fsrs/models/fsrs-4dot5'
+import { FSRS5_DEFAULT_WEIGHTS } from 'ts-fsrs/models/fsrs-5'
+import { FSRS6_DEFAULT_WEIGHTS } from 'ts-fsrs/models/fsrs-6'
+import {
+  expectFullParity,
+  legacyReview,
+} from './default-scheduler.legacy-test-utils.js'
+import { createStateCard, DAY, NOW } from './default-scheduler.test-utils.js'
+
+describe('DefaultScheduler', () => {
+  describe('validation', () => {
+    it('delegates review input validation to the scheduler core', async () => {
+      const scheduler = await DefaultScheduler()
+      const card = createStateCard(State.Review)
+
+      expect(() =>
+        scheduler.review({
+          card: {
+            ...card,
+            dueAt: '2025-02-20' as never,
+          },
+          grade: Rating.Good,
+          now: NOW,
+        })
+      ).toThrow('Expected valid Date fields')
+      expect(() =>
+        scheduler.review({
+          card,
+          grade: Rating.Good,
+          now: '2025-02-21' as never,
+        })
+      ).toThrow('Expected valid Date')
+    })
+
+    it.each([
+      Rating.Manual,
+      5,
+      1.5,
+    ])('rejects review grade %s', async (grade) => {
+      const scheduler = await DefaultScheduler()
+      const card = scheduler.newCard({ now: NOW, cardId: 'invalid-grade' })
+
+      expect(() =>
+        scheduler.review({ card, grade: grade as Grade, now: NOW })
+      ).toThrow('Expected grade')
+    })
+
+    it('rejects Manual revlogs during rollback', async () => {
+      const scheduler = await DefaultScheduler()
+      const reviewed = scheduler.review({
+        card: scheduler.newCard({ now: NOW, cardId: 'manual' }),
+        grade: Rating.Good,
+        now: NOW,
+      })
+
+      expect(() =>
+        scheduler.rollback({
+          card: reviewed.card,
+          revlog: { ...reviewed.revlog, rating: Rating.Manual as never },
+        })
+      ).toThrow('Expected grade')
+    })
+  })
+
+  describe('version presets', () => {
+    it.each([
+      ['FSRS-4', FSRS4_DEFAULT_WEIGHTS],
+      ['FSRS-5', FSRS5_DEFAULT_WEIGHTS],
+      ['FSRS-6', FSRS6_DEFAULT_WEIGHTS],
+    ] as const)('migrates %s weights before scheduling', async (_name, weights) => {
+      const options = {
+        weights,
+        enableShortTerm: true,
+      } satisfies DefaultSchedulerOptions
+      const scheduler = await DefaultScheduler(options)
+      const card = scheduler.newCard({
+        now: NOW,
+        cardId: `migrate-${weights.length}`,
+      })
+      const actual = scheduler.review({
+        card,
+        grade: Rating.Good,
+        now: NOW,
+      })
+
+      expectFullParity(actual, legacyReview(options, card, NOW, Rating.Good))
+    })
+
+    it.each([
+      ['FSRS-3', FSRS3_DEFAULT_WEIGHTS],
+      ['FSRS-4', FSRS4_DEFAULT_WEIGHTS],
+      ['FSRS-4.5', FSRS4Dot5_DEFAULT_WEIGHTS],
+      ['FSRS-5', FSRS5_DEFAULT_WEIGHTS],
+      ['FSRS-6', FSRS6_DEFAULT_WEIGHTS],
+    ] as const)('uses the %s model and parameter migrator', async (version, weights) => {
+      const scheduler = await DefaultScheduler({ version })
+      const card = scheduler.newCard({ now: NOW, cardId: version })
+      const result = scheduler.review({
+        card,
+        grade: Rating.Again,
+        now: NOW,
+      })
+
+      expect(result.card.stability).toBe(weights[Rating.Again - 1])
+    })
+
+    it('defaults to FSRS-6', async () => {
+      const defaultScheduler = await DefaultScheduler()
+      const card = defaultScheduler.newCard({ now: NOW, cardId: 'fsrs-6' })
+      const review = (scheduler: DefaultScheduler) =>
+        scheduler.review({ card, grade: Rating.Good, now: NOW })
+      const defaultResult = review(defaultScheduler)
+
+      expect(defaultResult.card.stability).toBe(
+        FSRS6_DEFAULT_WEIGHTS[Rating.Good - 1]
+      )
+      expect(defaultResult).toEqual(
+        review(await DefaultScheduler({ version: 'FSRS-6' }))
+      )
+    })
+
+    it('rejects unsupported FSRS versions clearly', async () => {
+      await expect(
+        DefaultScheduler({ version: 'FSRS-7' as never })
+      ).rejects.toThrow('Unsupported FSRS version "FSRS-7"')
+    })
+  })
+
+  describe('public API', () => {
+    it('creates a card with a caller-provided cardId without config', async () => {
+      const card = (await DefaultScheduler()).newCard({
+        now: NOW,
+        cardId: 'test-card-id',
+      })
+
+      expect(card.cardId).toBe('test-card-id')
+      expect(card.dueAt).toEqual(NOW)
+    })
+
+    it('preserves cardId through review, rollback, and forget', async () => {
+      const scheduler = await DefaultScheduler()
+      const card = scheduler.newCard({ now: NOW, cardId: 42 })
+      const reviewed = scheduler.review({
+        card,
+        grade: Rating.Easy,
+        now: NOW,
+      })
+      const rolledBack = scheduler.rollback(reviewed)
+      const forgotten = scheduler.forget({
+        card: reviewed.card,
+        now: new Date(NOW.getTime() + DAY),
+      })
+
+      expect(reviewed.card.cardId).toBe(42)
+      expect(rolledBack.cardId).toBe(42)
+      expect(forgotten.cardId).toBe(42)
+    })
+
+    it.each([
+      true,
+      false,
+    ])('returns the core forget card with clearStatsOnForget=%s', async (clearStatsOnForget) => {
+      const scheduler = await DefaultScheduler({ clearStatsOnForget })
+      const card: DefaultSchedulerCard = {
+        cardId: 'forget-card',
+        dueAt: new Date(NOW.getTime() + 2 * DAY),
+        stability: 9.5,
+        difficulty: 4.5,
+        scheduledDays: 9,
+        learningStep: 1,
+        reps: 12,
+        lapses: 3,
+        state: State.Relearning,
+        scheduleStatus: 'learning',
+        lastReviewAt: new Date(NOW.getTime() - 7 * DAY),
+      }
+
+      const actual = scheduler.forget({
+        card,
+        now: NOW,
+      })
+
+      expect(actual).toEqual({
+        cardId: card.cardId,
+        dueAt: NOW,
+        stability: 0,
+        difficulty: 0,
+        scheduledDays: 0,
+        learningStep: 0,
+        reps: clearStatsOnForget ? 0 : card.reps,
+        lapses: clearStatsOnForget ? 0 : card.lapses,
+        state: State.New,
+        scheduleStatus: 'new',
+        lastReviewAt: null,
+      })
+    })
+  })
+
+  describe('options', () => {
+    it('honors desiredRetention and remains equal to the legacy scheduler', async () => {
+      const card = {
+        ...createStateCard(State.Review),
+        stability: 35,
+        cardId: 'retention',
+      }
+      const lowRetention = { desiredRetention: 0.8 }
+      const highRetention = { desiredRetention: 0.95 }
+      const low = (await DefaultScheduler(lowRetention)).review({
+        card,
+        grade: Rating.Good,
+        now: NOW,
+      })
+      const high = (await DefaultScheduler(highRetention)).review({
+        card,
+        grade: Rating.Good,
+        now: NOW,
+      })
+
+      expectFullParity(low, legacyReview(lowRetention, card, NOW, Rating.Good))
+      expectFullParity(
+        high,
+        legacyReview(highRetention, card, NOW, Rating.Good)
+      )
+      expect(low.card.scheduledDays).toBeGreaterThan(high.card.scheduledDays)
+    })
+
+    it('snapshots mutable learning-step parameters before lazy preview iteration', async () => {
+      const learningSteps: Array<'1m' | '1d'> = ['1m']
+      const relearningSteps: Array<'10m' | '1d'> = ['10m']
+      const options = { learningSteps, relearningSteps }
+      const scheduler = await DefaultScheduler(options)
+      const card = scheduler.newCard({
+        now: NOW,
+        cardId: 'mutable-step-parameters',
+      })
+      const expected = structuredClone(
+        legacyReview(options, card, NOW, Rating.Again)
+      )
+      const preview = scheduler.preview({
+        card,
+        now: NOW,
+      })
+
+      learningSteps[0] = '1d'
+      relearningSteps[0] = '1d'
+
+      expectFullParity(Array.from(preview)[0], expected)
+    })
+  })
+
+  describe('middleware composition', () => {
+    it('wires cardId-based fuzzing', async () => {
+      const scheduler = await DefaultScheduler({ enableFuzz: true })
+      const firstCard = {
+        ...createStateCard(State.Review),
+        cardId: 'fuzz-card-a',
+        stability: 80,
+      }
+      const secondCard = { ...firstCard, cardId: 'fuzz-card-b' }
+      const scheduledDays = (card: DefaultSchedulerCard) =>
+        Array.from(
+          scheduler.preview({ card, now: NOW }),
+          (item) => item.card.scheduledDays
+        )
+      const first = scheduledDays(firstCard)
+
+      expect(first).toEqual(scheduledDays(firstCard))
+      expect(first).not.toEqual(scheduledDays(secondCard))
+    })
+  })
+})

--- a/packages/fsrs/src/scheduler/default-scheduler.test-utils.ts
+++ b/packages/fsrs/src/scheduler/default-scheduler.test-utils.ts
@@ -1,0 +1,60 @@
+import { DefaultScheduler, type DefaultSchedulerCard, State } from 'ts-fsrs'
+
+export const DAY = 86_400_000
+export const NOW = new Date('2025-02-20T12:00:00.000Z')
+const cardFactory = await DefaultScheduler()
+export const scheduleStatusByState = {
+  [State.New]: 'new',
+  [State.Learning]: 'learning',
+  [State.Review]: 'review',
+  [State.Relearning]: 'learning',
+} as const satisfies Record<State, DefaultSchedulerCard['scheduleStatus']>
+
+export function createStateCard(state: State): DefaultSchedulerCard {
+  const cardId = `card-${state}`
+  if (state === State.New) {
+    return cardFactory.newCard({
+      now: new Date('2025-01-05T03:04:05.000Z'),
+      cardId,
+    })
+  }
+
+  const shared = {
+    cardId,
+    dueAt: NOW,
+    scheduledDays: 10,
+    reps: 8,
+    lastReviewAt: new Date(NOW.getTime() - 10 * DAY),
+    scheduleStatus: scheduleStatusByState[state],
+  }
+
+  switch (state) {
+    case State.Learning:
+      return {
+        ...shared,
+        stability: 1.4,
+        difficulty: 6.4,
+        learningStep: 1,
+        lapses: 0,
+        state,
+      }
+    case State.Review:
+      return {
+        ...shared,
+        stability: 12.4,
+        difficulty: 5.2,
+        learningStep: 0,
+        lapses: 1,
+        state,
+      }
+    case State.Relearning:
+      return {
+        ...shared,
+        stability: 2.8,
+        difficulty: 7.1,
+        learningStep: 1,
+        lapses: 2,
+        state,
+      }
+  }
+}

--- a/packages/fsrs/src/scheduler/default-scheduler.ts
+++ b/packages/fsrs/src/scheduler/default-scheduler.ts
@@ -1,0 +1,90 @@
+import type { SchedulerDefinition } from '@open-spaced-repetition/srs-kit'
+import type { dateChrono } from '@open-spaced-repetition/srs-kit/chrono/date'
+import type { AnyModel } from '@open-spaced-repetition/srs-kit/model'
+import {
+  defaultLearningSteps,
+  defaultRelearningSteps,
+} from '@/middlewares/learning-steps/schema.js'
+import type { StepUnit } from '@/middlewares/learning-steps/types.js'
+import { DEFAULT_MAXIMUM_INTERVAL } from '@/middlewares/monotonic-interval/schema.js'
+import type {
+  DefaultSchedulerCreate,
+  DefaultSchedulerVersion,
+} from './preset.js'
+import { getSchedulerPreset } from './preset.js'
+
+type DefaultSchedulerConfigInput =
+  Parameters<DefaultSchedulerCreate>[0]['config']
+
+export interface DefaultSchedulerOptions {
+  readonly weights?: readonly number[]
+  readonly enableShortTerm?: boolean
+  readonly desiredRetention?: number
+  readonly learningSteps?: readonly StepUnit[]
+  readonly relearningSteps?: readonly StepUnit[]
+  readonly enableFuzz?: boolean
+  readonly maximumInterval?: number
+  /** Whether forget clears reps and lapses; defaults to true. */
+  readonly clearStatsOnForget?: boolean
+  /** FSRS model and parameter migration version; defaults to FSRS-6. */
+  readonly version?: DefaultSchedulerVersion
+}
+
+type DefaultSchedulerCore = ReturnType<DefaultSchedulerCreate>
+type DefaultSchedulerModelCore = Omit<
+  DefaultSchedulerCore['model'],
+  'config' | 'algorithm'
+> & {
+  readonly config: Partial<DefaultSchedulerCore['model']['config']> &
+    Pick<DefaultSchedulerCore['model']['config'], 'weights'>
+  readonly algorithm: unknown
+}
+
+export type DefaultScheduler = Omit<
+  DefaultSchedulerCore,
+  'model' | 'definition'
+> & {
+  readonly model: DefaultSchedulerModelCore
+  readonly definition: SchedulerDefinition<AnyModel, typeof dateChrono>
+}
+export type DefaultSchedulerCard = ReturnType<DefaultScheduler['newCard']>
+export type DefaultSchedulerCardInput = Parameters<
+  DefaultScheduler['review']
+>[0]['card']
+export type DefaultSchedulerRevlog = ReturnType<
+  DefaultScheduler['review']
+>['revlog']
+
+export async function DefaultScheduler(
+  options: DefaultSchedulerOptions = {}
+): Promise<DefaultScheduler> {
+  const preset = await getSchedulerPreset(options.version)
+  const {
+    weights,
+    enableShortTerm = true,
+    desiredRetention = 0.9,
+    learningSteps = defaultLearningSteps,
+    relearningSteps = defaultRelearningSteps,
+    enableFuzz = false,
+    maximumInterval = DEFAULT_MAXIMUM_INTERVAL,
+  } = options
+  const migratedWeights = preset.migrateParameters(
+    weights ? Array.from(weights) : undefined,
+    relearningSteps.length,
+    enableShortTerm
+  )
+
+  return preset.definition.create({
+    config: {
+      weights: migratedWeights,
+      enableShortTerm,
+      numRelearningSteps: relearningSteps.length,
+      desiredRetention,
+      learningSteps: Array.from(learningSteps),
+      relearningSteps: Array.from(relearningSteps),
+      enableFuzz,
+      maximumInterval,
+      clearStatsOnForget: options.clearStatsOnForget,
+    } satisfies DefaultSchedulerConfigInput,
+  }) as unknown as DefaultScheduler
+}

--- a/packages/fsrs/src/scheduler/index.ts
+++ b/packages/fsrs/src/scheduler/index.ts
@@ -1,0 +1,7 @@
+export {
+  DefaultScheduler,
+  type DefaultSchedulerCard,
+  type DefaultSchedulerCardInput,
+  type DefaultSchedulerOptions,
+  type DefaultSchedulerRevlog,
+} from './default-scheduler.js'

--- a/packages/fsrs/src/scheduler/preset.ts
+++ b/packages/fsrs/src/scheduler/preset.ts
@@ -1,0 +1,159 @@
+import {
+  type AnyMiddleware,
+  type AnyScheduler,
+  defineScheduler,
+  type SchedulerCreate,
+  type SchedulerEnvFor,
+  schedulerStatsMiddleware,
+} from '@open-spaced-repetition/srs-kit'
+import { dateChrono } from '@open-spaced-repetition/srs-kit/chrono/date'
+import type { AnyModel, Model } from '@open-spaced-repetition/srs-kit/model'
+import { FSRSValidationError } from '../error.js'
+import type { FSRSMemoryStateSchema } from '../kit/schema.js'
+import { schedulerDesiredRetentionMiddleware } from '../middlewares/desired-retention/middleware.js'
+import { schedulerFuzzingMiddleware } from '../middlewares/fuzzing/middleware.js'
+import { schedulerLearningStepsMiddleware } from '../middlewares/learning-steps/middleware.js'
+import { schedulerMonotonicIntervalMiddleware } from '../middlewares/monotonic-interval/middleware.js'
+import { schedulerScheduledDaysMiddleware } from '../middlewares/scheduled-days/middleware.js'
+import type { fsrs6ConfigSchema } from '../models/fsrs-6/parameters.js'
+
+const defaultSchedulerMiddlewares = [
+  schedulerDesiredRetentionMiddleware,
+  schedulerFuzzingMiddleware,
+  schedulerStatsMiddleware,
+  schedulerScheduledDaysMiddleware,
+  schedulerLearningStepsMiddleware,
+  schedulerMonotonicIntervalMiddleware,
+] as const
+
+type DefaultSchedulerModel = Model<{
+  readonly name: string
+  readonly config: typeof fsrs6ConfigSchema
+  readonly memoryState: typeof FSRSMemoryStateSchema
+  readonly algorithm: unknown
+}>
+
+export type DefaultSchedulerCreate = SchedulerCreate<
+  SchedulerEnvFor<
+    DefaultSchedulerModel,
+    typeof dateChrono,
+    typeof defaultSchedulerMiddlewares
+  >,
+  DefaultSchedulerModel,
+  typeof dateChrono
+>
+
+// Runtime presets are widened to avoid expanding every model's middleware union.
+function createRuntimeDefaultSchedulerDefinition(
+  model: AnyModel
+): AnyScheduler {
+  const createDefinition = defineScheduler as unknown as (definition: {
+    readonly model: AnyModel
+    readonly chrono: typeof dateChrono
+  }) => {
+    readonly use: (...middlewares: AnyMiddleware[]) => AnyScheduler
+  }
+  return createDefinition({ model, chrono: dateChrono }).use(
+    ...defaultSchedulerMiddlewares
+  )
+}
+
+export type DefaultSchedulerVersion =
+  | 'FSRS-3'
+  | 'FSRS-4'
+  | 'FSRS-4.5'
+  | 'FSRS-5'
+  | 'FSRS-6'
+
+type MigrateParameters = (
+  parameters?: number[],
+  numRelearningSteps?: number,
+  enableShortTerm?: boolean
+) => number[]
+
+type SchedulerPreset = {
+  readonly definition: AnyScheduler
+  readonly migrateParameters: MigrateParameters
+}
+
+type SchedulerPresetSource = {
+  readonly model: AnyModel
+  readonly migrateParameters: MigrateParameters
+}
+
+const schedulerPresetLoaders: Record<
+  DefaultSchedulerVersion,
+  () => Promise<SchedulerPresetSource>
+> = {
+  'FSRS-3': async () => {
+    const { FSRS3Model, migrateFSRS3Parameters } = await import(
+      '../models/fsrs-3/index.js'
+    )
+    return {
+      model: FSRS3Model,
+      migrateParameters: migrateFSRS3Parameters,
+    }
+  },
+  'FSRS-4': async () => {
+    const { FSRS4Model, migrateFSRS4Parameters } = await import(
+      '../models/fsrs-4/index.js'
+    )
+    return {
+      model: FSRS4Model,
+      migrateParameters: migrateFSRS4Parameters,
+    }
+  },
+  'FSRS-4.5': async () => {
+    const { FSRS4Dot5Model, migrateFSRS4Dot5Parameters } = await import(
+      '../models/fsrs-4dot5/index.js'
+    )
+    return {
+      model: FSRS4Dot5Model,
+      migrateParameters: migrateFSRS4Dot5Parameters,
+    }
+  },
+  'FSRS-5': async () => {
+    const { FSRS5Model, migrateFSRS5Parameters } = await import(
+      '../models/fsrs-5/index.js'
+    )
+    return {
+      model: FSRS5Model,
+      migrateParameters: migrateFSRS5Parameters,
+    }
+  },
+  'FSRS-6': async () => {
+    const { FSRS6Model, migrateFSRS6Parameters } = await import(
+      '../models/fsrs-6/index.js'
+    )
+    return {
+      model: FSRS6Model,
+      migrateParameters: migrateFSRS6Parameters,
+    }
+  },
+}
+
+const schedulerPresetCache = new Map<
+  DefaultSchedulerVersion,
+  Promise<SchedulerPreset>
+>()
+
+export async function getSchedulerPreset(
+  version: DefaultSchedulerVersion | undefined
+): Promise<SchedulerPreset> {
+  const resolvedVersion = version ?? 'FSRS-6'
+  if (!Object.hasOwn(schedulerPresetLoaders, resolvedVersion)) {
+    throw new FSRSValidationError(`Unsupported FSRS version "${version}"`)
+  }
+
+  let preset = schedulerPresetCache.get(resolvedVersion)
+  if (!preset) {
+    preset = schedulerPresetLoaders[resolvedVersion]().then(
+      ({ model, migrateParameters }) => ({
+        definition: createRuntimeDefaultSchedulerDefinition(model),
+        migrateParameters,
+      })
+    )
+    schedulerPresetCache.set(resolvedVersion, preset)
+  }
+  return preset
+}

--- a/packages/fsrs/tsdown.config.ts
+++ b/packages/fsrs/tsdown.config.ts
@@ -43,6 +43,7 @@ export default defineConfig([
     sourcemap: false,
     minify: false,
     target: 'es2017',
+    outputOptions: { codeSplitting: false },
     outExtensions: () => ({ js: '.js' }),
   },
 ])


### PR DESCRIPTION
## Summary

- add the public asynchronous DefaultScheduler factory backed by srs-kit and date chrono
- support FSRS-3, FSRS-4, FSRS-4.5, FSRS-5, and FSRS-6 presets with parameter migration
- compose desired-retention, fuzzing, stats, scheduled-days, learning-steps, and monotonic-interval middleware
- export the API with legacy-parity coverage and a major changeset

## Root cause

The model and middleware architecture exposed composable building blocks but did not provide a high-level scheduler that preserved the legacy FSRS configuration and scheduling surface. Consumers otherwise had to assemble version selection, migration, chrono, and middleware policies themselves.

## Testing

- pnpm --filter ts-fsrs test (57 files passed; 533 passed, 1 skipped)
- pnpm --filter ts-fsrs typecheck
- pnpm --filter ts-fsrs check
- pnpm --filter ts-fsrs build