### PR TITLE
fix: preserve learning steps while keeping graduations monotonic

### DIFF
--- a/.changeset/add-review-candidate-grade-lookup.md
+++ b/.changeset/add-review-candidate-grade-lookup.md
@@ -1,0 +1,5 @@
+---
+"@open-spaced-repetition/srs-kit": minor
+---
+
+feat: add cached grade lookup to review candidates

--- a/.changeset/fix-learning-graduation-interval.md
+++ b/.changeset/fix-learning-graduation-interval.md
@@ -1,0 +1,5 @@
+---
+"ts-fsrs": patch
+---
+
+fix: preserve model intervals when learning steps graduate.

--- a/.changeset/fix-learning-graduation-interval.md
+++ b/.changeset/fix-learning-graduation-interval.md
@@ -2,4 +2,4 @@
 "ts-fsrs": patch
 ---
 
-fix: preserve model intervals for genuine learning-step graduations while keeping empty, exhausted, and non-positive steps monotonic.
+fix: preserve explicit learning-step intervals while keeping graduation intervals monotonic, and require `maximumInterval` to be a positive integer.

--- a/.changeset/fix-learning-graduation-interval.md
+++ b/.changeset/fix-learning-graduation-interval.md
@@ -2,4 +2,4 @@
 "ts-fsrs": patch
 ---
 
-fix: preserve model intervals when learning steps graduate.
+fix: preserve model intervals for genuine learning-step graduations while keeping empty, exhausted, and non-positive steps monotonic.

--- a/packages/fsrs/src/middlewares/fuzzing/schema.spec.ts
+++ b/packages/fsrs/src/middlewares/fuzzing/schema.spec.ts
@@ -21,6 +21,7 @@ describe('fuzzingConfigSchema', () => {
     {},
     { enableFuzz: 1, maximumInterval: 365 },
     { enableFuzz: true, maximumInterval: 0 },
+    { enableFuzz: true, maximumInterval: 1.5 },
     { enableFuzz: true, maximumInterval: Number.NaN },
   ])('rejects invalid config %#', (value) => {
     expect(() => fuzzingConfigSchema.parse(value)).toThrow()

--- a/packages/fsrs/src/middlewares/fuzzing/schema.ts
+++ b/packages/fsrs/src/middlewares/fuzzing/schema.ts
@@ -35,10 +35,12 @@ export const fuzzingConfigSchema = defineSchema<FuzzingConfig>((value) => {
   }
   if (
     typeof maximumInterval !== 'number' ||
-    !Number.isFinite(maximumInterval) ||
+    !Number.isInteger(maximumInterval) ||
     maximumInterval <= 0
   ) {
-    return { issues: [{ message: 'Expected positive maximumInterval' }] }
+    return {
+      issues: [{ message: 'Expected positive integer maximumInterval' }],
+    }
   }
 
   return { value: { enableFuzz, maximumInterval } }

--- a/packages/fsrs/src/middlewares/learning-steps/middleware.spec.ts
+++ b/packages/fsrs/src/middlewares/learning-steps/middleware.spec.ts
@@ -1,4 +1,9 @@
-import { defineScheduler, Rating, State } from '@open-spaced-repetition/srs-kit'
+import {
+  defineMiddleware,
+  defineScheduler,
+  Rating,
+  State,
+} from '@open-spaced-repetition/srs-kit'
 import { dateChrono } from '@open-spaced-repetition/srs-kit/chrono/date'
 import { describe, expect, it, vi } from 'vitest'
 import { FSRS6_DEFAULT_WEIGHTS, FSRS6Model } from '@/models/fsrs-6/index.js'
@@ -81,6 +86,41 @@ describe('schedulerLearningStepsMiddleware integration', () => {
     expect(nextInterval).not.toHaveBeenCalled()
 
     core.review({ card, grade: Rating.Easy, now })
+    expect(nextInterval).toHaveBeenCalledOnce()
+  })
+
+  it('delegates intervals for uncached candidate memory states', () => {
+    let interval: number | undefined
+    const probe = defineMiddleware({
+      name: Symbol('uncached-candidate'),
+      handlers: {
+        review(ctx, next) {
+          const memoryState = { ...ctx.candidate.step(Rating.Easy) }
+          interval = ctx.candidate.nextInterval(
+            memoryState,
+            ctx.desiredRetention
+          )
+          next()
+        },
+      },
+    })
+    const core = defineScheduler({ model: FSRS6Model, chrono: dateChrono })
+      .use(schedulerLearningStepsMiddleware, probe)
+      .create({
+        config: {
+          weights: [...FSRS6_DEFAULT_WEIGHTS],
+          enableShortTerm: true,
+          numRelearningSteps: 1,
+          learningSteps: ['1m'],
+          relearningSteps: ['10m'],
+        },
+      })
+    const nextInterval = vi.spyOn(core.model, 'nextInterval')
+    const now = new Date(2022, 11, 29, 12, 30)
+
+    core.review({ card: core.newCard({ now }), grade: Rating.Again, now })
+
+    expect(interval).toBeGreaterThan(0)
     expect(nextInterval).toHaveBeenCalledOnce()
   })
 

--- a/packages/fsrs/src/middlewares/learning-steps/middleware.spec.ts
+++ b/packages/fsrs/src/middlewares/learning-steps/middleware.spec.ts
@@ -223,6 +223,51 @@ describe('schedulerLearningStepsMiddleware integration', () => {
     expect(result.card.dueAt.getTime()).toBeGreaterThan(now.getTime())
   })
 
+  it.each([
+    ['zero-minute', ['0m'], 0],
+    ['rounded zero-minute', ['0.4m', '0.4m'], 0],
+    ['empty', [], 0],
+    ['exhausted', ['1m'], 1],
+  ] as const)('uses raw model intervals without monotonic middleware for %s steps', (_name, steps, learningStep) => {
+    const seedCore = createCore()
+    const now = new Date(2022, 11, 29, 12, 30)
+    const learningCard = seedCore.review({
+      card: seedCore.newCard({ now }),
+      grade: Rating.Again,
+      now,
+    }).card
+    const reviewCard = seedCore.review({
+      card: seedCore.newCard({ now }),
+      grade: Rating.Easy,
+      now,
+    }).card
+    const relearningCard = seedCore.review({
+      card: reviewCard,
+      grade: Rating.Again,
+      now: reviewCard.dueAt,
+    }).card
+    const core = createCore({
+      learningSteps: steps,
+      relearningSteps: steps,
+    })
+    const previewDueDays = (card: typeof learningCard) => {
+      const reviewTime = card.dueAt
+      return Array.from(
+        core.preview({
+          card: { ...card, learningStep },
+          now: reviewTime,
+        }),
+        (item) =>
+          (item.card.dueAt.getTime() - reviewTime.getTime()) / 86_400_000
+      )
+    }
+
+    expect(learningCard.state).toBe(State.Learning)
+    expect(relearningCard.state).toBe(State.Relearning)
+    expect(previewDueDays(learningCard)).toEqual([1, 1, 1, 1])
+    expect(previewDueDays(relearningCard)).toEqual([1, 1, 1, 2])
+  })
+
   it('bypasses learning steps when short-term scheduling is disabled', () => {
     const core = createCore({ enableShortTerm: false })
     const now = new Date(2022, 11, 29, 12, 30)

--- a/packages/fsrs/src/middlewares/learning-steps/middleware.ts
+++ b/packages/fsrs/src/middlewares/learning-steps/middleware.ts
@@ -76,9 +76,11 @@ export const schedulerLearningStepsMiddleware = defineMiddleware({
       }
       next()
 
-      // Restore after schedulerMonotonicIntervalMiddleware normalizes the interval.
+      // Keep explicit steps exact; graduation still respects a lower maximum.
       if (scheduledDays !== undefined) {
-        ctx.scheduledDays = scheduledDays
+        ctx.scheduledDays = hasScheduledLearningStep
+          ? scheduledDays
+          : Math.min(scheduledDays, ctx.scheduledDays ?? scheduledDays)
       }
 
       ctx.result.revlog.learningStep = card.learningStep

--- a/packages/fsrs/src/middlewares/learning-steps/middleware.ts
+++ b/packages/fsrs/src/middlewares/learning-steps/middleware.ts
@@ -54,16 +54,31 @@ export const schedulerLearningStepsMiddleware = defineMiddleware({
       const scheduledMinutes = step
         ? Math.round(Math.max(0, step.scheduledMinutes))
         : undefined
+      const hasScheduledLearningStep =
+        scheduledMinutes !== undefined && scheduledMinutes > 0
+      const isGraduatingFromLearning =
+        step === undefined &&
+        (card.state === State.Learning || card.state === State.Relearning)
+      let scheduledDays: number | undefined
+
+      if (hasScheduledLearningStep) {
+        scheduledDays = scheduledMinutes / MINUTES_PER_DAY
+      } else if (isGraduatingFromLearning) {
+        scheduledDays = candidate.nextInterval(
+          candidate.step(ctx.input.grade),
+          ctx.desiredRetention
+        )
+      }
 
       // Set before BaseScheduler.finalizeReview() falls back to model.nextInterval().
-      if (scheduledMinutes !== undefined && scheduledMinutes > 0) {
-        ctx.scheduledDays = scheduledMinutes / MINUTES_PER_DAY
+      if (scheduledDays !== undefined) {
+        ctx.scheduledDays = scheduledDays
       }
       next()
 
       // Restore after schedulerMonotonicIntervalMiddleware normalizes the interval.
-      if (scheduledMinutes !== undefined && scheduledMinutes > 0) {
-        ctx.scheduledDays = scheduledMinutes / MINUTES_PER_DAY
+      if (scheduledDays !== undefined) {
+        ctx.scheduledDays = scheduledDays
       }
 
       ctx.result.revlog.learningStep = card.learningStep

--- a/packages/fsrs/src/middlewares/learning-steps/middleware.ts
+++ b/packages/fsrs/src/middlewares/learning-steps/middleware.ts
@@ -1,5 +1,6 @@
 import {
   defineMiddleware,
+  type Grade,
   type ReviewCandidateContext,
   State,
 } from '@open-spaced-repetition/srs-kit'
@@ -9,14 +10,14 @@ import {
   learningStepFieldsSchema,
   learningStepsConfigSchema,
 } from './schema.js'
-import type { LearningStepsResult } from './types.js'
+import type { LearningStepSchedule, LearningStepsResult } from './types.js'
 
 const MINUTES_PER_DAY = 1440
 const resolvedStepsSymbol = Symbol('ts-fsrs.learning-steps.resolved')
 
 type ResolvedLearningSteps = {
   readonly steps: LearningStepsResult
-  readonly hasAnyScheduledLearningStep: boolean
+  readonly scheduledMinutes: Partial<Record<Grade, number>>
 }
 
 type LearningStepsCandidate = ReviewCandidateContext & {
@@ -48,53 +49,42 @@ export const schedulerLearningStepsMiddleware = defineMiddleware({
       const candidate = ctx.candidate as Mutable<LearningStepsCandidate>
       let resolved = candidate[resolvedStepsSymbol]
       if (!resolved) {
-        const steps = calculateLearningSteps(
-          ctx.config,
-          card.state,
-          card.learningStep
-        )
         resolved = {
-          steps,
-          hasAnyScheduledLearningStep: Object.values(steps).some(
-            ({ scheduledMinutes }) =>
-              Math.round(Math.max(0, scheduledMinutes)) > 0
+          steps: calculateLearningSteps(
+            ctx.config,
+            card.state,
+            card.learningStep
           ),
+          scheduledMinutes: {},
         }
         candidate[resolvedStepsSymbol] = resolved
+        const resolvedSteps = resolved
+        const nextInterval = candidate.nextInterval
+        candidate.nextInterval = (memoryState, desiredRetention) => {
+          const grade = candidate.findGrade(memoryState)
+          if (grade === undefined) {
+            return nextInterval(memoryState, desiredRetention)
+          }
+
+          const step = resolvedSteps.steps[grade]
+          const scheduledMinutes = step
+            ? getScheduledMinutes(resolvedSteps, grade, step)
+            : undefined
+          if (scheduledMinutes !== undefined && scheduledMinutes > 0) {
+            return scheduledMinutes / MINUTES_PER_DAY
+          }
+          return nextInterval(memoryState, desiredRetention)
+        }
       }
-      const { steps, hasAnyScheduledLearningStep } = resolved
-      const step = steps[ctx.input.grade]
+      const step = resolved.steps[ctx.input.grade]
       const scheduledMinutes = step
-        ? Math.round(Math.max(0, step.scheduledMinutes))
+        ? getScheduledMinutes(resolved, ctx.input.grade, step)
         : undefined
-      const hasScheduledLearningStep =
-        scheduledMinutes !== undefined && scheduledMinutes > 0
-      const isGraduatingFromLearning =
-        step === undefined &&
-        hasAnyScheduledLearningStep &&
-        (card.state === State.Learning || card.state === State.Relearning)
-      let scheduledDays: number | undefined
-
-      if (hasScheduledLearningStep) {
-        scheduledDays = scheduledMinutes / MINUTES_PER_DAY
-      } else if (isGraduatingFromLearning) {
-        scheduledDays = candidate.nextInterval(
-          candidate.step(ctx.input.grade),
-          ctx.desiredRetention
-        )
-      }
-
-      // Set before BaseScheduler.finalizeReview() falls back to model.nextInterval().
-      if (scheduledDays !== undefined) {
-        ctx.scheduledDays = scheduledDays
-      }
       next()
 
-      // Keep explicit steps exact; graduation still respects a lower maximum.
-      if (scheduledDays !== undefined) {
-        ctx.scheduledDays = hasScheduledLearningStep
-          ? scheduledDays
-          : Math.min(scheduledDays, ctx.scheduledDays ?? scheduledDays)
+      // Restore the exact learning step after downstream day-level middleware.
+      if (scheduledMinutes !== undefined && scheduledMinutes > 0) {
+        ctx.scheduledDays = scheduledMinutes / MINUTES_PER_DAY
       }
 
       ctx.result.revlog.learningStep = card.learningStep
@@ -124,4 +114,17 @@ function nextLearningState(state: State): State {
   if (state === State.New) return State.Learning
   if (state === State.Review) return State.Relearning
   return state
+}
+
+function getScheduledMinutes(
+  resolved: ResolvedLearningSteps,
+  grade: Grade,
+  step: LearningStepSchedule
+): number {
+  const cached = resolved.scheduledMinutes[grade]
+  if (cached !== undefined) return cached
+
+  const scheduledMinutes = Math.round(Math.max(0, step.scheduledMinutes))
+  resolved.scheduledMinutes[grade] = scheduledMinutes
+  return scheduledMinutes
 }

--- a/packages/fsrs/src/middlewares/learning-steps/middleware.ts
+++ b/packages/fsrs/src/middlewares/learning-steps/middleware.ts
@@ -14,8 +14,13 @@ import type { LearningStepsResult } from './types.js'
 const MINUTES_PER_DAY = 1440
 const resolvedStepsSymbol = Symbol('ts-fsrs.learning-steps.resolved')
 
+type ResolvedLearningSteps = {
+  readonly steps: LearningStepsResult
+  readonly hasAnyScheduledLearningStep: boolean
+}
+
 type LearningStepsCandidate = ReviewCandidateContext & {
-  [resolvedStepsSymbol]?: LearningStepsResult
+  [resolvedStepsSymbol]?: ResolvedLearningSteps
 }
 
 export const schedulerLearningStepsMiddleware = defineMiddleware({
@@ -41,15 +46,23 @@ export const schedulerLearningStepsMiddleware = defineMiddleware({
       }
 
       const candidate = ctx.candidate as Mutable<LearningStepsCandidate>
-      let steps = candidate[resolvedStepsSymbol]
-      if (!steps) {
-        steps = calculateLearningSteps(
+      let resolved = candidate[resolvedStepsSymbol]
+      if (!resolved) {
+        const steps = calculateLearningSteps(
           ctx.config,
           card.state,
           card.learningStep
         )
-        candidate[resolvedStepsSymbol] = steps
+        resolved = {
+          steps,
+          hasAnyScheduledLearningStep: Object.values(steps).some(
+            ({ scheduledMinutes }) =>
+              Math.round(Math.max(0, scheduledMinutes)) > 0
+          ),
+        }
+        candidate[resolvedStepsSymbol] = resolved
       }
+      const { steps, hasAnyScheduledLearningStep } = resolved
       const step = steps[ctx.input.grade]
       const scheduledMinutes = step
         ? Math.round(Math.max(0, step.scheduledMinutes))
@@ -58,6 +71,7 @@ export const schedulerLearningStepsMiddleware = defineMiddleware({
         scheduledMinutes !== undefined && scheduledMinutes > 0
       const isGraduatingFromLearning =
         step === undefined &&
+        hasAnyScheduledLearningStep &&
         (card.state === State.Learning || card.state === State.Relearning)
       let scheduledDays: number | undefined
 

--- a/packages/fsrs/src/middlewares/monotonic-interval/core.spec.ts
+++ b/packages/fsrs/src/middlewares/monotonic-interval/core.spec.ts
@@ -49,4 +49,15 @@ describe('calculateScheduleDays', () => {
     expect(calculateScheduleDay([98, 99, 100, 101], 100)).toBe(100)
     expect(calculateScheduleDay([102], 100)).toBe(100)
   })
+
+  it('preserves the current interval when every candidate is sub-day', () => {
+    expect(calculateScheduleDay([1 / 1440], 100)).toBe(1 / 1440)
+    expect(calculateScheduleDay([1 / 1440, 5 / 1440], 100)).toBe(5 / 1440)
+  })
+
+  it('ignores sub-day candidates when a day interval exists', () => {
+    expect(calculateScheduleDay([1, 5 / 1440], 100)).toBe(1)
+    expect(calculateScheduleDay([1 / 1440, 5 / 1440, 1, 1], 100)).toBe(2)
+    expect(calculateScheduleDay([1, 5 / 1440, 10 / 1440, 1], 100)).toBe(2)
+  })
 })

--- a/packages/fsrs/src/middlewares/monotonic-interval/core.ts
+++ b/packages/fsrs/src/middlewares/monotonic-interval/core.ts
@@ -54,12 +54,19 @@ export function calculateScheduleDay(
   candidates: IntervalCandidates,
   maximumInterval: number
 ): number {
-  let scheduledDay = Math.min(candidates[0], maximumInterval)
-  for (let index = 1; index < candidates.length; index++) {
-    scheduledDay = Math.min(
-      Math.max(candidates[index], scheduledDay === 0 ? 0 : scheduledDay + 1),
-      maximumInterval
-    )
+  const currentInterval = candidates[candidates.length - 1]
+  let scheduledDay: number | undefined
+  for (const interval of candidates) {
+    if (interval < 1) continue
+
+    if (scheduledDay === undefined) {
+      scheduledDay = Math.min(interval, maximumInterval)
+    } else {
+      scheduledDay = Math.min(
+        Math.max(interval, scheduledDay + 1),
+        maximumInterval
+      )
+    }
   }
-  return scheduledDay
+  return scheduledDay ?? currentInterval
 }

--- a/packages/fsrs/src/middlewares/monotonic-interval/middleware.spec.ts
+++ b/packages/fsrs/src/middlewares/monotonic-interval/middleware.spec.ts
@@ -299,7 +299,7 @@ describe('schedulerMonotonicIntervalMiddleware integration', () => {
     expect(combinedRng).toHaveBeenCalled()
   })
 
-  it('lets learning steps own short-term due dates', () => {
+  it('lets learning steps own short-term and graduation intervals', () => {
     const core = defineScheduler({ model: FSRS6Model, chrono: dateChrono })
       .use(
         createSchedulerFuzzingMiddleware({ rng: () => () => 0.5 }),
@@ -332,5 +332,32 @@ describe('schedulerMonotonicIntervalMiddleware integration', () => {
       10 * 60_000
     )
     expect(preview.get(Rating.Easy)!.card.state).toBe(State.Review)
+
+    const learningCard = preview.get(Rating.Good)!.card
+    const learningGraduation = core.review({
+      card: learningCard,
+      grade: Rating.Good,
+      now: learningCard.dueAt,
+    })
+    expect(learningGraduation.card.state).toBe(State.Review)
+    expect(dueDays(learningGraduation.card.dueAt, learningCard.dueAt)).toBe(2)
+
+    const reviewCard = preview.get(Rating.Easy)!.card
+    const relearningCard = core.review({
+      card: reviewCard,
+      grade: Rating.Again,
+      now: reviewCard.dueAt,
+    }).card
+    expect(relearningCard.state).toBe(State.Relearning)
+
+    const relearningGraduation = core.review({
+      card: relearningCard,
+      grade: Rating.Good,
+      now: relearningCard.dueAt,
+    })
+    expect(relearningGraduation.card.state).toBe(State.Review)
+    expect(dueDays(relearningGraduation.card.dueAt, relearningCard.dueAt)).toBe(
+      1
+    )
   })
 })

--- a/packages/fsrs/src/middlewares/monotonic-interval/middleware.spec.ts
+++ b/packages/fsrs/src/middlewares/monotonic-interval/middleware.spec.ts
@@ -55,7 +55,7 @@ function createReviewContext({
     desiredRetention: 0.9,
     elapsedDays: 9,
     scheduledDays,
-    candidate: { step, nextInterval },
+    candidate: { step, findGrade: () => undefined, nextInterval },
     result: { card: {}, revlog: {} },
   } as unknown as ReviewContext
   const next = vi.fn(() => {
@@ -362,11 +362,21 @@ describe('schedulerMonotonicIntervalMiddleware integration', () => {
   })
 
   it.each([
-    ['zero-minute', ['0m'], 0],
-    ['rounded zero-minute', ['0.4m', '0.4m'], 0],
-    ['empty', [], 0],
-    ['exhausted', ['1m'], 1],
-  ] as const)('keeps %s learning graduations monotonic', (_name, learningSteps, learningStep) => {
+    // Again 1m, Hard 5m, Good 1d, Easy 2d
+    ['positive-minute', ['1m', '9m'], 1, 100, [1, 5, 1440, 2880]],
+    // Again 1d, Hard 5m, Good 10m, Easy 2d
+    ['mixed-minute', ['0m', '10m'], 0, 100, [1440, 5, 10, 2880]],
+    // Again 1d, Hard 2d, Good 3d, Easy 4d
+    ['zero-minute', ['0m'], 0, 100, [1440, 2880, 4320, 5760]],
+    // Again 1d, Hard 2d, Good 3d, Easy 4d
+    ['rounded zero-minute', ['0.4m', '0.4m'], 0, 100, [1440, 2880, 4320, 5760]],
+    // Again 1d, Hard 2d, Good 3d, Easy 4d
+    ['empty', [], 0, 100, [1440, 2880, 4320, 5760]],
+    // Again 1d, Hard 2d, Good 3d, Easy 4d
+    ['exhausted', ['1m'], 1, 100, [1440, 2880, 4320, 5760]],
+    // Again 1m, Hard 5m, Good 1d, Easy capped at 1d
+    ['maximum interval', ['1m', '9m'], 1, 1, [1, 5, 1440, 1440]],
+  ] as const)('keeps %s learning intervals monotonic', (_name, learningSteps, learningStep, maximum, expected) => {
     const modelConfig = {
       weights: [...FSRS6_DEFAULT_WEIGHTS],
       enableShortTerm: true,
@@ -394,7 +404,7 @@ describe('schedulerMonotonicIntervalMiddleware integration', () => {
         config: {
           ...modelConfig,
           numRelearningSteps: learningSteps.length,
-          maximumInterval,
+          maximumInterval: maximum,
           learningSteps,
           relearningSteps: learningSteps,
         },
@@ -412,8 +422,8 @@ describe('schedulerMonotonicIntervalMiddleware integration', () => {
           card: { ...learningCard, learningStep },
           now: reviewTime,
         }),
-        (item) => dueDays(item.card.dueAt, reviewTime)
+        (item) => (item.card.dueAt.getTime() - reviewTime.getTime()) / 60_000
       )
-    ).toEqual([1, 2, 3, 4])
+    ).toEqual(expected)
   })
 })

--- a/packages/fsrs/src/middlewares/monotonic-interval/middleware.spec.ts
+++ b/packages/fsrs/src/middlewares/monotonic-interval/middleware.spec.ts
@@ -360,4 +360,59 @@ describe('schedulerMonotonicIntervalMiddleware integration', () => {
       1
     )
   })
+
+  it.each([
+    ['zero-minute', ['0m'], 0],
+    ['rounded zero-minute', ['0.4m', '0.4m'], 0],
+    ['empty', [], 0],
+    ['exhausted', ['1m'], 1],
+  ] as const)('keeps %s learning graduations monotonic', (_name, learningSteps, learningStep) => {
+    const modelConfig = {
+      weights: [...FSRS6_DEFAULT_WEIGHTS],
+      enableShortTerm: true,
+    }
+    const learningCore = defineScheduler({
+      model: FSRS6Model,
+      chrono: dateChrono,
+    })
+      .use(schedulerLearningStepsMiddleware)
+      .create({
+        config: {
+          ...modelConfig,
+          numRelearningSteps: 1,
+          learningSteps: ['1m', '10m'],
+          relearningSteps: ['10m'],
+        },
+      })
+    const core = defineScheduler({ model: FSRS6Model, chrono: dateChrono })
+      .use(
+        schedulerLearningStepsMiddleware,
+        schedulerMonotonicIntervalMiddleware
+      )
+      .create({
+        config: {
+          ...modelConfig,
+          numRelearningSteps: learningSteps.length,
+          maximumInterval,
+          learningSteps,
+          relearningSteps: learningSteps,
+        },
+      })
+    const learningCard = learningCore.review({
+      card: learningCore.newCard({ now }),
+      grade: Rating.Again,
+      now,
+    }).card
+    const reviewTime = learningCard.dueAt
+
+    expect(
+      Array.from(
+        core.preview({
+          card: { ...learningCard, learningStep },
+          now: reviewTime,
+        }),
+        (item) => dueDays(item.card.dueAt, reviewTime)
+      )
+    ).toEqual([1, 2, 3, 4])
+  })
 })

--- a/packages/fsrs/src/middlewares/monotonic-interval/middleware.spec.ts
+++ b/packages/fsrs/src/middlewares/monotonic-interval/middleware.spec.ts
@@ -371,10 +371,11 @@ describe('schedulerMonotonicIntervalMiddleware integration', () => {
       weights: [...FSRS6_DEFAULT_WEIGHTS],
       enableShortTerm: true,
     }
-    const learningCore = defineScheduler({
+    const baseScheduler = defineScheduler({
       model: FSRS6Model,
       chrono: dateChrono,
     })
+    const learningCore = baseScheduler
       .use(schedulerLearningStepsMiddleware)
       .create({
         config: {
@@ -384,7 +385,7 @@ describe('schedulerMonotonicIntervalMiddleware integration', () => {
           relearningSteps: ['10m'],
         },
       })
-    const core = defineScheduler({ model: FSRS6Model, chrono: dateChrono })
+    const monotonicCore = baseScheduler
       .use(
         schedulerLearningStepsMiddleware,
         schedulerMonotonicIntervalMiddleware
@@ -407,7 +408,7 @@ describe('schedulerMonotonicIntervalMiddleware integration', () => {
 
     expect(
       Array.from(
-        core.preview({
+        monotonicCore.preview({
           card: { ...learningCard, learningStep },
           now: reviewTime,
         }),

--- a/packages/fsrs/src/middlewares/monotonic-interval/schema.spec.ts
+++ b/packages/fsrs/src/middlewares/monotonic-interval/schema.spec.ts
@@ -20,6 +20,7 @@ describe('monotonicIntervalConfigSchema', () => {
     null,
     { maximumInterval: 0 },
     { maximumInterval: -1 },
+    { maximumInterval: 1.5 },
     { maximumInterval: null },
     { maximumInterval: Number.NaN },
     { maximumInterval: Number.POSITIVE_INFINITY },

--- a/packages/fsrs/src/middlewares/monotonic-interval/schema.ts
+++ b/packages/fsrs/src/middlewares/monotonic-interval/schema.ts
@@ -24,10 +24,12 @@ export const monotonicIntervalConfigSchema = defineSchema<
       : value.maximumInterval
   if (
     typeof maximumInterval !== 'number' ||
-    !Number.isFinite(maximumInterval) ||
+    !Number.isInteger(maximumInterval) ||
     maximumInterval <= 0
   ) {
-    return { issues: [{ message: 'Expected positive maximumInterval' }] }
+    return {
+      issues: [{ message: 'Expected positive integer maximumInterval' }],
+    }
   }
 
   return { value: { maximumInterval } }

--- a/packages/srs-kit/src/middleware/middleware.ts
+++ b/packages/srs-kit/src/middleware/middleware.ts
@@ -51,6 +51,10 @@ export type MiddlewareDefaultValueContext<
 
 export interface ReviewCandidateContext {
   readonly step: (grade: Grade) => Readonly<Record<string, unknown>>
+  /** Finds the most recently cached grade for a memory state. */
+  readonly findGrade: (
+    memoryState: Readonly<Record<string, unknown>>
+  ) => Grade | undefined
   readonly nextInterval: (
     memoryState: Readonly<Record<string, unknown>>,
     desiredRetention: number

--- a/packages/srs-kit/src/middleware/stats/middleware.spec.ts
+++ b/packages/srs-kit/src/middleware/stats/middleware.spec.ts
@@ -38,6 +38,7 @@ function reviewContext({
     scheduledDays: undefined,
     candidate: {
       step: () => ({}),
+      findGrade: () => undefined,
       nextInterval: () => 1,
     },
     result: {

--- a/packages/srs-kit/src/scheduler/base.spec.ts
+++ b/packages/srs-kit/src/scheduler/base.spec.ts
@@ -506,23 +506,23 @@ describe('SchedulerCore.newCard', () => {
     expect(seen).toEqual([1, 7])
   })
 
-  it('lets middleware read the previous grade candidate separately', () => {
+  it('finds the latest grade for a cached candidate memory state', () => {
     const seen: unknown[] = []
     const candidateMiddleware = defineMiddleware({
       name: Symbol('previous-candidate'),
       handlers: {
         review(ctx, next) {
-          const previousMemoryState = ctx.candidate.step(Rating.Hard)
+          const previousMemoryState = ctx.candidate.step(Rating.Again)
+          const previousGrade = ctx.candidate.findGrade(previousMemoryState)
           const hardMemoryState = ctx.candidate.step(Rating.Hard)
+          const hardGrade = ctx.candidate.findGrade(hardMemoryState)
+          const cachedPreviousMemoryState = ctx.candidate.step(Rating.Again)
           seen.push({
             sameMemoryState: previousMemoryState === hardMemoryState,
-            previousScheduledDays: ctx.candidate.nextInterval(
-              previousMemoryState,
-              ctx.desiredRetention
-            ),
-            hardScheduledDays: ctx.candidate.nextInterval(
-              hardMemoryState,
-              ctx.desiredRetention
+            previousGrade,
+            hardGrade,
+            cachedPreviousGrade: ctx.candidate.findGrade(
+              cachedPreviousMemoryState
             ),
           })
           next()
@@ -532,6 +532,11 @@ describe('SchedulerCore.newCard', () => {
     const candidateCore = createSM2NumericScheduler()
       .use(candidateMiddleware, schedulerStatsMiddleware)
       .create({ config: { weights: SM2_DEFAULT_WEIGHTS } })
+    vi.spyOn(candidateCore.model, 'step').mockReturnValue({
+      interval: 1,
+      easeFactor: 2.5,
+      reviewStep: 1,
+    })
     const card = candidateCore.newCard({ now: 0 })
 
     candidateCore.review({
@@ -543,8 +548,9 @@ describe('SchedulerCore.newCard', () => {
     expect(seen).toEqual([
       {
         sameMemoryState: true,
-        previousScheduledDays: 1,
-        hardScheduledDays: 1,
+        previousGrade: Rating.Again,
+        hardGrade: Rating.Hard,
+        cachedPreviousGrade: Rating.Again,
       },
     ])
   })

--- a/packages/srs-kit/src/scheduler/base.ts
+++ b/packages/srs-kit/src/scheduler/base.ts
@@ -15,12 +15,7 @@ import {
 } from '@/scheduler/compose-schema.js'
 import { getAttachedValue } from '@/schema/attached-value.js'
 import type { Mutable, SchemaInput } from '@/schema/index.js'
-import {
-  composeMiddleware,
-  createLazyIterable,
-  parse,
-  withCache,
-} from '@/schema/index.js'
+import { composeMiddleware, createLazyIterable, parse } from '@/schema/index.js'
 import type {
   BlankSchedulerEnv,
   PreviewResult,
@@ -60,6 +55,9 @@ interface PreparedReview<Env extends BlankSchedulerEnv> {
   readonly retrievability?: number
   readonly candidate: {
     readonly step: (grade: Grade) => Record<string, unknown>
+    readonly findGrade: (
+      memoryState: Readonly<Record<string, unknown>>
+    ) => Grade | undefined
     readonly nextInterval: (
       memoryState: Readonly<Record<string, unknown>>,
       desiredRetention: number
@@ -414,16 +412,27 @@ export class BaseScheduler<
     const elapsedDays = this.chrono.difference(time.previous, time.current)
 
     const retrievability = this.model.forgettingCurve(memoryState, elapsedDays)
-    const step = withCache(
-      (grade: Grade) =>
-        this.model.step({
+    const memoryStateByGrade = new Map<Grade, Record<string, unknown>>()
+    const gradeByMemoryState = new Map<
+      Readonly<Record<string, unknown>>,
+      Grade
+    >()
+    const step = (grade: Grade): Record<string, unknown> => {
+      let nextMemoryState = memoryStateByGrade.get(grade)
+      if (nextMemoryState === undefined) {
+        nextMemoryState = this.model.step({
           memoryState,
           rating: grade,
           elapsedDays,
           retrievability,
-        }),
-      { lru: false }
-    )
+        }) as Record<string, unknown>
+        memoryStateByGrade.set(grade, nextMemoryState)
+      }
+      gradeByMemoryState.set(nextMemoryState, grade)
+      return nextMemoryState
+    }
+    const findGrade = (nextMemoryState: Readonly<Record<string, unknown>>) =>
+      gradeByMemoryState.get(nextMemoryState)
     const intervalCache = new Map<
       Readonly<Record<string, unknown>>,
       Map<number, number>
@@ -453,6 +462,7 @@ export class BaseScheduler<
       retrievability,
       candidate: {
         step,
+        findGrade,
         nextInterval,
       },
     }


### PR DESCRIPTION
## Summary

- add cached candidate-grade lookup without changing the `nextInterval` signature
- resolve explicit learning steps through the candidate interval pipeline
- preserve exact sub-day learning and relearning delays through downstream middleware
- ignore sub-day candidates when building day-level monotonic graduation intervals
- keep empty, exhausted, rounded-zero, and graduated steps on the model interval chain
- require `maximumInterval` to be a positive integer and expand regression coverage

## Root cause

The previous implementation wrote learning-step delays directly to `scheduledDays` and identified graduation from a missing grade step. That split explicit learning delays from the candidate interval pipeline and made active, empty, exhausted, and rounded-zero configurations behave differently when monotonic middleware was present.

The learning-steps middleware now resolves the grade associated with each cached candidate state and decorates `nextInterval` only for explicit positive steps. Day-level monotonic scheduling ignores sub-day candidates, while the learning middleware restores the current explicit step after downstream middleware runs. Model-driven graduations therefore remain monotonic without changing exact learning-step delays.

## Testing

- `pnpm --filter @open-spaced-repetition/srs-kit typecheck`
- `pnpm --filter @open-spaced-repetition/srs-kit test` (25 files passed; 214 passed)
- `pnpm --filter ts-fsrs typecheck`
- `pnpm --filter ts-fsrs test` (56 files passed; 546 passed, 1 skipped)
- `pnpm dlx @biomejs/biome@2.4.15 check packages/srs-kit/src packages/fsrs/src`