### PR TITLE
feat: expose stats middleware APIs

### DIFF
--- a/.changeset/expose-scheduler-stats-middleware.md
+++ b/.changeset/expose-scheduler-stats-middleware.md
@@ -1,0 +1,6 @@
+---
+"@open-spaced-repetition/srs-kit": patch
+"ts-fsrs": patch
+---
+
+feat: export stats middleware APIs.

--- a/packages/fsrs/src/middlewares/index.ts
+++ b/packages/fsrs/src/middlewares/index.ts
@@ -1,3 +1,8 @@
+export {
+  schedulerStatsMiddleware,
+  statsConfigSchema,
+  statsFieldsSchema,
+} from '@open-spaced-repetition/srs-kit/middleware'
 export * from './desired-retention/index.js'
 export * from './fuzzing/index.js'
 export * from './learning-steps/index.js'

--- a/packages/fsrs/tsdown.config.ts
+++ b/packages/fsrs/tsdown.config.ts
@@ -37,7 +37,7 @@ export default defineConfig([
     deps: {
       alwaysBundle: [
         '@open-spaced-repetition/srs-kit',
-        '@open-spaced-repetition/srs-kit/chrono/*',
+        '@open-spaced-repetition/srs-kit/**',
       ],
     },
     sourcemap: false,

--- a/packages/srs-kit/src/middleware/index.ts
+++ b/packages/srs-kit/src/middleware/index.ts
@@ -1,3 +1,7 @@
 export * from './infer.js'
 export * from './middleware.js'
-export { schedulerStatsMiddleware } from './stats/index.js'
+export {
+  schedulerStatsMiddleware,
+  statsConfigSchema,
+  statsFieldsSchema,
+} from './stats/index.js'


### PR DESCRIPTION
## Summary

- export `schedulerStatsMiddleware`, `statsConfigSchema`, and `statsFieldsSchema` from `ts-fsrs`
- expose the stats schemas through the public `@open-spaced-repetition/srs-kit` middleware and root entries
- add patch changesets for both packages

Consumers can now use the stats middleware APIs through `ts-fsrs` without importing them from `srs-kit` directly.

## Validation

- `pnpm --filter @open-spaced-repetition/srs-kit test:coverage`
- `pnpm --filter ts-fsrs test:coverage`
- package-scoped check, typecheck, test, and build commands
- ESM/CJS root and subpath export smoke checks
- UMD export smoke check