### PR TITLE
fix(fsrs): rename leech status to suspended

### DIFF
--- a/.changeset/leech-suspended-status.md
+++ b/.changeset/leech-suspended-status.md
@@ -1,0 +1,5 @@
+---
+"ts-fsrs": patch
+---
+
+fix(fsrs): rename the leech schedule status to `suspended`.

--- a/packages/fsrs/bench/leech.bench.ts
+++ b/packages/fsrs/bench/leech.bench.ts
@@ -13,7 +13,7 @@ let sink = 0
 
 function consume(lapses: number, scheduleStatus: string): void {
   sink =
-    (sink + lapses + Number(scheduleStatus === 'suspend')) %
+    (sink + lapses + Number(scheduleStatus === 'suspended')) %
     Number.MAX_SAFE_INTEGER
 }
 

--- a/packages/fsrs/src/middlewares/leech/index.ts
+++ b/packages/fsrs/src/middlewares/leech/index.ts
@@ -13,7 +13,7 @@
  *   reject values that are not non-negative integers. A threshold of `0`
  *   disables suspension.
  * - Define and validate a card field `lapses` as a non-negative integer.
- * - Use `defineMiddleware` with `scheduleStatus: ['suspend']`, the config and
+ * - Use `defineMiddleware` with `scheduleStatus: ['suspended']`, the config and
  *   card schemas, and no unnecessary factory or core abstraction.
  * - Default new-card `lapses` to `0`. During forget, preserve the input value
  *   only when the composed config has `clearStatsOnForget === false`;
@@ -23,7 +23,7 @@
  *   `ctx.input.grade === Rating.Again`. Use an existing
  *   `ctx.result.card.lapses` value when present; otherwise write the previous
  *   lapses plus one for a lapse, or the unchanged value for any other review.
- * - Set `ctx.result.card.scheduleStatus` to `'suspend'` only for a current
+ * - Set `ctx.result.card.scheduleStatus` to `'suspended'` only for a current
  *   lapse when `leechThreshold > 0` and the resulting lapses count is an exact
  *   multiple of the threshold.
  * - In rollback, call `next()` first and fill a missing result lapses value by

--- a/packages/fsrs/src/middlewares/leech/middleware.spec.ts
+++ b/packages/fsrs/src/middlewares/leech/middleware.spec.ts
@@ -44,7 +44,7 @@ describe('schedulerLeechMiddleware review', () => {
 
     expect(core.newCard({ now }).lapses).toBe(0)
     expect(core.config.leechThreshold).toBe(0)
-    expect(scheduler.schema.scheduleStatus.parse('suspend')).toBe('suspend')
+    expect(scheduler.schema.scheduleStatus.parse('suspended')).toBe('suspended')
   })
 
   it.each([
@@ -57,7 +57,7 @@ describe('schedulerLeechMiddleware review', () => {
     const result = core.review({ card, grade: Rating.Again, now: later })
 
     expect(result.card.lapses).toBe(after)
-    expect(result.card.scheduleStatus).toBe('suspend')
+    expect(result.card.scheduleStatus).toBe('suspended')
   })
 
   it('does not suspend before the next threshold multiple', () => {
@@ -110,7 +110,7 @@ describe('schedulerLeechMiddleware review', () => {
 
     expect(preview.map(({ card }) => card.lapses)).toEqual([8, 7, 7, 7])
     expect(preview.map(({ card }) => card.scheduleStatus)).toEqual([
-      'suspend',
+      'suspended',
       'review',
       'review',
       'review',
@@ -162,11 +162,11 @@ describe('schedulerLeechMiddleware review', () => {
     expect({
       lapses: leechFirstResult.card.lapses,
       scheduleStatus: leechFirstResult.card.scheduleStatus,
-    }).toEqual({ lapses: 8, scheduleStatus: 'suspend' })
+    }).toEqual({ lapses: 8, scheduleStatus: 'suspended' })
     expect({
       lapses: statsFirstResult.card.lapses,
       scheduleStatus: statsFirstResult.card.scheduleStatus,
-    }).toEqual({ lapses: 8, scheduleStatus: 'suspend' })
+    }).toEqual({ lapses: 8, scheduleStatus: 'suspended' })
   })
 
   it('uses lapses already assigned by an earlier middleware', () => {
@@ -195,7 +195,7 @@ describe('schedulerLeechMiddleware review', () => {
     const result = core.review({ card, grade: Rating.Again, now: later })
 
     expect(result.card.lapses).toBe(16)
-    expect(result.card.scheduleStatus).toBe('suspend')
+    expect(result.card.scheduleStatus).toBe('suspended')
   })
 
   it('overrides learning steps when registered before them', () => {
@@ -228,7 +228,7 @@ describe('schedulerLeechMiddleware review', () => {
     })
 
     expect(result.card.lapses).toBe(1)
-    expect(result.card.scheduleStatus).toBe('suspend')
+    expect(result.card.scheduleStatus).toBe('suspended')
   })
 })
 

--- a/packages/fsrs/src/middlewares/leech/middleware.ts
+++ b/packages/fsrs/src/middlewares/leech/middleware.ts
@@ -8,7 +8,7 @@ import { leechCardFieldsSchema, leechConfigSchema } from './schema.js'
 /** Register before middleware that writes scheduleStatus after next(). */
 export const schedulerLeechMiddleware = defineMiddleware({
   name: Symbol('ts-fsrs.leech'),
-  scheduleStatus: ['suspend'],
+  scheduleStatus: ['suspended'],
   schema: {
     config: leechConfigSchema,
     card: leechCardFieldsSchema,
@@ -35,7 +35,7 @@ export const schedulerLeechMiddleware = defineMiddleware({
       const { lapses } = ctx.result.card
       const { leechThreshold } = ctx.config
       if (isLapse && leechThreshold > 0 && lapses % leechThreshold === 0) {
-        ctx.result.card.scheduleStatus = 'suspend'
+        ctx.result.card.scheduleStatus = 'suspended'
       }
     },
 


### PR DESCRIPTION
## Summary

- Rename the leech schedule status from `suspend` to `suspended`.
- Update tests, benchmark coverage, and patch release metadata.

The previous verb form did not describe a persisted scheduler state. Consumers should use `suspended`.

## Validation

- `pnpm --filter ts-fsrs test` (543 passed, 1 skipped)
- `pnpm --filter ts-fsrs typecheck`
- `pnpm --filter @open-spaced-repetition/srs-kit build`
- `pnpm --filter ts-fsrs build`
- `pnpm exec changeset status`