### PR TITLE
fix(release): support npm 12 publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.4.15",
     "@changesets/changelog-github": "^0.7.0",
-    "@changesets/cli": "^2.31.0",
+    "@changesets/cli": "^2.31.1",
     "@types/node": "^25.6.2",
     "@vitest/coverage-istanbul": "4.1.5",
     "rimraf": "^6.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^0.7.0
         version: 0.7.0
       '@changesets/cli':
-        specifier: ^2.31.0
-        version: 2.31.0(@types/node@25.6.2)
+        specifier: ^2.31.1
+        version: 2.31.1(@types/node@25.6.2)
       '@types/node':
         specifier: ^25.6.2
         version: 25.6.2
@@ -370,8 +370,8 @@ packages:
   '@changesets/changelog-github@0.7.0':
     resolution: {integrity: sha512-rBsbRvc4TVn+FvFnOVM3LxlFJfTXXCp8gfVJ+0BubxWNSVnLuAzowi5j+IEraLLP52w8AAs9QfKbPS3MMiXQJA==}
 
-  '@changesets/cli@2.31.0':
-    resolution: {integrity: sha512-AhI4enNTgHu2IZr6K4WZyf0EPch4XVMn1yOMFmCD9gsfBGqMYaHXls5HyDv6/CL5axVQABz68eG30eCtbr2wFg==}
+  '@changesets/cli@2.31.1':
+    resolution: {integrity: sha512-uO05WTcRBwuVOJVSW8Cmpqw6q0WDL53ajGCMyszutvOe5toOnunbpM4jZzf+qxBOz7i0AzopZ8diBuewjmF40w==}
     hasBin: true
 
   '@changesets/config@3.1.4':
@@ -3095,7 +3095,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@changesets/cli@2.31.0(@types/node@25.6.2)':
+  '@changesets/cli@2.31.1(@types/node@25.6.2)':
     dependencies:
       '@changesets/apply-release-plan': 7.1.1
       '@changesets/assemble-release-plan': 6.0.10


### PR DESCRIPTION
## Summary

- update `@changesets/cli` from 2.31.0 to 2.31.1
- refresh the pnpm lockfile

## Root cause

npm 12 always wraps successful `npm info --json` output in an array. Changesets 2.31.0 treated already-published packages as unpublished and attempted to publish them again, causing the Release job to fail.

Changesets 2.31.1 includes the npm 12 compatibility fix, so existing package versions are skipped and only unpublished versions are released.

Failed job: https://github.com/open-spaced-repetition/ts-fsrs/actions/runs/31878500201/job/94997946906

## Verification

- `pnpm install --frozen-lockfile --config.confirmModulesPurge=false --child-concurrency=1`
- `pnpm exec changeset --version` (`2.31.1`)
- `pnpm run check`
- `git diff --check`