### PR TITLE
fix(kit): accept full Standard Schema types

### DIFF
--- a/.changeset/fix-standard-schema-validation.md
+++ b/.changeset/fix-standard-schema-validation.md
@@ -1,0 +1,5 @@
+---
+"@open-spaced-repetition/srs-kit": patch
+---
+
+fix(kit): accept full Standard Schema types.

--- a/packages/fsrs/src/kit/schema.spec.ts
+++ b/packages/fsrs/src/kit/schema.spec.ts
@@ -1,4 +1,6 @@
+import { defineMiddleware } from 'ts-fsrs'
 import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
 import { FSRSMemoryStateSchema } from './schema.js'
 import { isNumberArray } from './schema-utils.js'
 
@@ -12,5 +14,15 @@ describe('FSRS schemas', () => {
   it('rejects non-number and non-finite array items', () => {
     expect(isNumberArray(['1'])).toBe(false)
     expect(isNumberArray([Number.NaN])).toBe(false)
+  })
+
+  it('accepts Zod Standard Schemas', () => {
+    const configSchema = z.object({ enabled: z.boolean() })
+    const middleware = defineMiddleware({
+      name: 'zod-config',
+      schema: { config: configSchema },
+    })
+
+    expect(middleware.schema?.config).toBe(configSchema)
   })
 })

--- a/packages/srs-kit/src/scheduler/compose-schema.ts
+++ b/packages/srs-kit/src/scheduler/compose-schema.ts
@@ -14,6 +14,7 @@ import {
   isObject,
   type StandardSchemaV1,
 } from '@/schema/index.js'
+import { validateSync } from '@/schema/validate-sync.js'
 import type {
   SchedulerCoreFields,
   SchedulerRevlogCoreFields,
@@ -103,14 +104,12 @@ export function composeSchema(ctx: {
       return { issues: [{ message: 'Expected scheduler config object' }] }
     }
 
-    const modelResult = modelConfigSchema['~standard'].validate(value)
+    const modelResult = validateSync(modelConfigSchema, value)
     if (modelResult.issues) return modelResult
 
     let chronoValue: unknown = {}
     if (chronoConfigSchema) {
-      const chronoResult = chronoConfigSchema['~standard'].validate(
-        value.chrono
-      )
+      const chronoResult = validateSync(chronoConfigSchema, value.chrono)
       if (chronoResult.issues) return chronoResult
       chronoValue = chronoResult.value
     }
@@ -119,7 +118,7 @@ export function composeSchema(ctx: {
     assignObjectFields(result, modelResult.value)
 
     for (const schema of middlewareConfigSchemas) {
-      const middlewareResult = schema['~standard'].validate(value)
+      const middlewareResult = validateSync(schema, value)
       if (middlewareResult.issues) {
         return middlewareResult
       }
@@ -151,7 +150,7 @@ export function composeSchema(ctx: {
     let firstMiddlewareFields: Record<string, unknown> | undefined
     let combinedFields: Record<string, unknown> | undefined
     for (const schema of middlewareCardInitInputSchemas) {
-      const middlewareResult = schema['~standard'].validate(middlewareValue)
+      const middlewareResult = validateSync(schema, middlewareValue)
       if (middlewareResult.issues) return middlewareResult
       const fields = middlewareResult.value as Record<string, unknown>
       if (firstMiddlewareFields === undefined) {
@@ -172,14 +171,14 @@ export function composeSchema(ctx: {
       return { issues: [{ message: 'Expected card object' }] }
     }
 
-    const modelResult = model.schema.memoryState['~standard'].validate(value)
+    const modelResult = validateSync(model.schema.memoryState, value)
     if (modelResult.issues) return modelResult
 
     const memoryState = modelResult.value as Record<string, unknown>
     const card: Record<string, unknown> = Object.assign({}, memoryState)
 
     if (chronoCardSchema) {
-      const chronoCard = chronoCardSchema['~standard'].validate(value)
+      const chronoCard = validateSync(chronoCardSchema, value)
       if (chronoCard.issues) return chronoCard
       Object.assign(card, chronoCard.value)
     }
@@ -191,7 +190,7 @@ export function composeSchema(ctx: {
     card.scheduleStatus = coreFields.value.scheduleStatus
 
     for (const schema of middlewareCardSchemas) {
-      const middlewareCard = schema['~standard'].validate(value)
+      const middlewareCard = validateSync(schema, value)
       if (middlewareCard.issues) return middlewareCard
       Object.assign(card, middlewareCard.value)
     }
@@ -210,14 +209,14 @@ export function composeSchema(ctx: {
       return { issues: [{ message: 'Expected revlog object' }] }
     }
 
-    const modelResult = model.schema.memoryState['~standard'].validate(value)
+    const modelResult = validateSync(model.schema.memoryState, value)
     if (modelResult.issues) return modelResult
 
     // Reuse the parsed memory state for revlog hot paths to avoid another allocation.
     const result = modelResult.value as Record<string, unknown>
 
     if (chronoRevlogSchema) {
-      const chronoRevlog = chronoRevlogSchema['~standard'].validate(value)
+      const chronoRevlog = validateSync(chronoRevlogSchema, value)
       if (chronoRevlog.issues) return chronoRevlog
       Object.assign(result, chronoRevlog.value)
     }
@@ -232,7 +231,7 @@ export function composeSchema(ctx: {
     result.state = coreFields.value.state
 
     for (const schema of middlewareRevlogSchemas) {
-      const middlewareRevlog = schema['~standard'].validate(value)
+      const middlewareRevlog = validateSync(schema, value)
       if (middlewareRevlog.issues) return middlewareRevlog
       Object.assign(result, middlewareRevlog.value)
     }

--- a/packages/srs-kit/src/scheduler/compose-schema.ts
+++ b/packages/srs-kit/src/scheduler/compose-schema.ts
@@ -73,12 +73,10 @@ export function composeSchema(ctx: {
   ): StandardSchemaV1.Result<
     SchedulerCoreFields | SchedulerRevlogCoreFields
   > => {
-    const scheduleStatus = scheduleStatusSchema['~standard'].validate(
-      fields.scheduleStatus
-    )
+    const scheduleStatus = validateSync(scheduleStatusSchema, fields.scheduleStatus)
     if (scheduleStatus.issues) return scheduleStatus
 
-    const state = stateSchema['~standard'].validate(fields.state)
+    const state = validateSync(stateSchema, fields.state)
     if (state.issues) return state
 
     if (!options?.rating) {
@@ -87,7 +85,7 @@ export function composeSchema(ctx: {
       }
     }
 
-    const rating = gradeSchema['~standard'].validate(fields.rating)
+    const rating = validateSync(gradeSchema, fields.rating)
     if (rating.issues) return rating
 
     return {

--- a/packages/srs-kit/src/scheduler/compose-schema.ts
+++ b/packages/srs-kit/src/scheduler/compose-schema.ts
@@ -73,7 +73,10 @@ export function composeSchema(ctx: {
   ): StandardSchemaV1.Result<
     SchedulerCoreFields | SchedulerRevlogCoreFields
   > => {
-    const scheduleStatus = validateSync(scheduleStatusSchema, fields.scheduleStatus)
+    const scheduleStatus = validateSync(
+      scheduleStatusSchema,
+      fields.scheduleStatus
+    )
     if (scheduleStatus.issues) return scheduleStatus
 
     const state = validateSync(stateSchema, fields.state)

--- a/packages/srs-kit/src/scheduler/scheduler.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.spec.ts
@@ -5,7 +5,12 @@ import { defineMiddleware } from '@/middleware/index.js'
 import { schedulerStatsMiddleware } from '@/middleware/stats/index.js'
 import { SM2Model } from '@/model/sm2.test.js'
 import { type Grade, Rating, State } from '@/primitives/index.js'
-import { defineSchema, isObject, numberSchema } from '@/schema/index.js'
+import {
+  defineSchema,
+  isObject,
+  numberSchema,
+  type StandardSchemaV1,
+} from '@/schema/index.js'
 import { defineScheduler } from './define-scheduler.js'
 import type {
   SchedulerCardInitInputOf,
@@ -344,6 +349,27 @@ describe('defineScheduler', () => {
   it('validates middleware config while composing scheduler config', () => {
     expect(() => middlewareScheduler.schema.config.parse(config)).toThrow(
       'Expected source config'
+    )
+  })
+
+  it('rejects async middleware schema validation', () => {
+    const asyncConfigSchema: StandardSchemaV1<unknown, object> = {
+      '~standard': {
+        version: 1,
+        vendor: 'test',
+        async validate() {
+          return { value: {} }
+        },
+      },
+    }
+    const asyncMiddleware = defineMiddleware({
+      name: 'async-config',
+      schema: { config: asyncConfigSchema },
+    })
+    const asyncScheduler = createSM2NumericScheduler().use(asyncMiddleware)
+
+    expect(() => asyncScheduler.schema.config.parse(config)).toThrow(
+      'Async Standard Schema validation is not supported'
     )
   })
 

--- a/packages/srs-kit/src/schema/standard.spec.ts
+++ b/packages/srs-kit/src/schema/standard.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, expectTypeOf, it } from 'vitest'
+import { describe, expect, expectTypeOf, it, vi } from 'vitest'
 import type { SchemaOutput, StandardSchemaV1 } from './index.js'
 import { defineSchema, parse, SRSSchemaError } from './validators.js'
 
@@ -45,15 +45,15 @@ describe('standard schema helpers', () => {
     expect(() => parse(sizeSchema, 'medium')).toThrow(SRSSchemaError)
   })
 
-  it('rejects async Standard Schema validation', () => {
+  it('rejects async Standard Schema validation and logs rejections', async () => {
+    const error = new Error('Validation failed')
+    const logger = vi.spyOn(console, 'error').mockImplementation(() => {})
     const schema: StandardSchemaV1<string> = {
       '~standard': {
         version: 1,
         vendor: 'test',
-        async validate(value) {
-          return typeof value === 'string'
-            ? { value }
-            : { issues: [{ message: 'Expected string' }] }
+        async validate() {
+          throw error
         },
       },
     }
@@ -61,5 +61,11 @@ describe('standard schema helpers', () => {
     expect(() => parse(schema, 'value')).toThrow(
       'Async Standard Schema validation is not supported'
     )
+    await Promise.resolve()
+    expect(logger).toHaveBeenCalledWith(
+      'Async Standard Schema validation rejected',
+      error
+    )
+    logger.mockRestore()
   })
 })

--- a/packages/srs-kit/src/schema/standard.spec.ts
+++ b/packages/srs-kit/src/schema/standard.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, expectTypeOf, it } from 'vitest'
-import type { SchemaOutput } from './standard.js'
+import type { SchemaOutput, StandardSchemaV1 } from './index.js'
 import { defineSchema, parse, SRSSchemaError } from './validators.js'
 
 const sizeSchema = defineSchema<'small' | 'large'>((value) =>
@@ -43,5 +43,23 @@ describe('standard schema helpers', () => {
 
   it('parse() throws SRSSchemaError on invalid input', () => {
     expect(() => parse(sizeSchema, 'medium')).toThrow(SRSSchemaError)
+  })
+
+  it('rejects async Standard Schema validation', () => {
+    const schema: StandardSchemaV1<string> = {
+      '~standard': {
+        version: 1,
+        vendor: 'test',
+        async validate(value) {
+          return typeof value === 'string'
+            ? { value }
+            : { issues: [{ message: 'Expected string' }] }
+        },
+      },
+    }
+
+    expect(() => parse(schema, 'value')).toThrow(
+      'Async Standard Schema validation is not supported'
+    )
   })
 })

--- a/packages/srs-kit/src/schema/standard.ts
+++ b/packages/srs-kit/src/schema/standard.ts
@@ -29,6 +29,15 @@ export type SRSSchemaTypes<Input = unknown, Output = Input> = {
 
 export interface SRSSchema<Definition extends SRSSchemaTypes>
   extends StandardSchemaV1<Definition['input'], Definition['output']> {
+  readonly '~standard': Omit<
+    StandardSchemaV1.Props<Definition['input'], Definition['output']>,
+    'validate'
+  > & {
+    readonly validate: (
+      value: unknown,
+      options?: StandardSchemaV1.Options | undefined
+    ) => StandardSchemaV1.Result<Definition['output']>
+  }
   parse(input: unknown): Definition['output']
   safeParse(input: unknown): SafeParseResult<Definition['output']>
 }

--- a/packages/srs-kit/src/schema/validate-sync.ts
+++ b/packages/srs-kit/src/schema/validate-sync.ts
@@ -1,0 +1,17 @@
+import type { StandardSchemaV1 } from '@vendor/standard-schema.js'
+import type { AnySchema, SchemaOutput } from './standard.js'
+
+function isPromiseLike(value: object): value is PromiseLike<unknown> {
+  return 'then' in value && typeof value.then === 'function'
+}
+
+export function validateSync<Schema extends AnySchema>(
+  schema: Schema,
+  input: unknown
+): StandardSchemaV1.Result<SchemaOutput<Schema>> {
+  const result = schema['~standard'].validate(input)
+  if (isPromiseLike(result)) {
+    throw new TypeError('Async Standard Schema validation is not supported')
+  }
+  return result
+}

--- a/packages/srs-kit/src/schema/validate-sync.ts
+++ b/packages/srs-kit/src/schema/validate-sync.ts
@@ -11,6 +11,9 @@ export function validateSync<Schema extends AnySchema>(
 ): StandardSchemaV1.Result<SchemaOutput<Schema>> {
   const result = schema['~standard'].validate(input)
   if (isPromiseLike(result)) {
+    void Promise.resolve(result).catch((error: unknown) => {
+      console.error('Async Standard Schema validation rejected', error)
+    })
     throw new TypeError('Async Standard Schema validation is not supported')
   }
   return result

--- a/packages/srs-kit/src/schema/validators.ts
+++ b/packages/srs-kit/src/schema/validators.ts
@@ -1,6 +1,7 @@
 import type { StandardSchemaV1 } from '@vendor/standard-schema.js'
 import type { Prettify } from '@/schema/index.js'
 import type { AnySchema, SchemaOutput, SRSSchema } from './standard.js'
+import { validateSync } from './validate-sync.js'
 
 export function defineSchema<Input, Output = Input>(
   validate: (value: unknown) => StandardSchemaV1.Result<Output>
@@ -32,7 +33,7 @@ export function parse<S extends AnySchema>(
   schema: S,
   input: unknown
 ): SchemaOutput<S> {
-  const result = schema['~standard'].validate(input)
+  const result = validateSync(schema, input)
   if (result.issues) {
     throw new SRSSchemaError(result.issues)
   }

--- a/packages/srs-kit/vendor/standard-schema.d.ts
+++ b/packages/srs-kit/vendor/standard-schema.d.ts
@@ -3,7 +3,7 @@
  * @license MIT
  */
 
-// Vendored from Standard Schema v1, narrowed to synchronous validation.
+// Vendored from Standard Schema v1.
 export interface StandardTypedV1<Input = unknown, Output = Input> {
   readonly '~standard': StandardTypedV1.Props<Input, Output>
 }
@@ -39,7 +39,7 @@ export declare namespace StandardSchemaV1 {
     readonly validate: (
       value: unknown,
       options?: StandardSchemaV1.Options | undefined
-    ) => Result<Output>
+    ) => Result<Output> | Promise<Result<Output>>
   }
 
   export type Result<Output> = SuccessResult<Output> | FailureResult


### PR DESCRIPTION
## Summary
- restore the complete Standard Schema validation signature
- reject async validation at synchronous srs-kit boundaries
- add Zod compatibility coverage and a patch changeset

## Root cause
The vendored Standard Schema type narrowed `validate()` to synchronous results, making compliant schemas such as Zod incompatible at the type level.

## Validation
- `pnpm --filter @open-spaced-repetition/srs-kit check`
- `pnpm --filter @open-spaced-repetition/srs-kit test:coverage`
- `pnpm --filter @open-spaced-repetition/srs-kit build`
- `pnpm --filter ts-fsrs check`
- `pnpm --filter ts-fsrs typecheck`
- `pnpm --filter ts-fsrs test`
- `pnpm --filter ts-fsrs build`