### PR TITLE
fix(kit): preserve new card due date on rollback

### DIFF
--- a/.changeset/preserve-new-card-due-at.md
+++ b/.changeset/preserve-new-card-due-at.md
@@ -1,0 +1,5 @@
+---
+"@open-spaced-repetition/srs-kit": patch
+---
+
+fix(kit): preserve new-card rollback state while keeping elapsed days at zero.

--- a/packages/fsrs/src/scheduler/default-scheduler.legacy-parity.spec.ts
+++ b/packages/fsrs/src/scheduler/default-scheduler.legacy-parity.spec.ts
@@ -129,7 +129,9 @@ describe('DefaultScheduler legacy parity', () => {
       }
 
       if (state === State.New) {
-        expect(actual.every((item) => +item.revlog.dueAt === +NOW)).toBe(true)
+        expect(actual.every((item) => +item.revlog.dueAt === +card.dueAt)).toBe(
+          true
+        )
         expect(+card.dueAt).not.toBe(+NOW)
       }
     })
@@ -183,8 +185,7 @@ describe('DefaultScheduler legacy parity', () => {
         expectSequenceParity(actual, expected, card, enableShortTerm)
         expectRollbackParity(
           scheduler.rollback(actual),
-          legacyRollback(options, expected),
-          actual.revlog
+          legacyRollback(options, expected)
         )
 
         card = actual.card
@@ -202,11 +203,7 @@ describe('DefaultScheduler legacy parity', () => {
 
       for (const grade of grades) {
         const reviewed = scheduler.review({ card, grade, now: NOW })
-        expectRollbackParity(
-          scheduler.rollback(reviewed),
-          card,
-          reviewed.revlog
-        )
+        expectRollbackParity(scheduler.rollback(reviewed), card)
       }
     })
   })
@@ -333,8 +330,7 @@ describe('DefaultScheduler legacy parity', () => {
       expectFullParity(actual, expected)
       expectRollbackParity(
         scheduler.rollback(actual),
-        legacyRollback(options, expected),
-        actual.revlog
+        legacyRollback(options, expected)
       )
       expect(scheduler.rollback(actual).scheduledDays).toBe(scheduledDays)
     })

--- a/packages/fsrs/src/scheduler/default-scheduler.legacy-test-utils.ts
+++ b/packages/fsrs/src/scheduler/default-scheduler.legacy-test-utils.ts
@@ -136,27 +136,18 @@ export function legacyRollback(
 
 export function expectRollbackParity(
   actual: DefaultSchedulerCard,
-  expected: Card | DefaultSchedulerCard,
-  revlog?: ReviewResult['revlog']
+  expected: Card | DefaultSchedulerCard
 ): void {
   const expectedCard =
     'cardId' in expected ? expected : fromLegacyCard(expected, actual.cardId)
-  expect(actual).toEqual({
-    ...expectedCard,
-    dueAt: revlog?.state === State.New ? revlog.reviewTime : expectedCard.dueAt,
-    lastReviewAt:
-      revlog?.state === State.New ? null : expectedCard.lastReviewAt,
-  })
+  expect(actual).toEqual(expectedCard)
 }
 
 export function expectRevlogParity(
   actual: ReviewResult['revlog'],
   expected: ReviewResult['revlog']
 ): void {
-  expect(actual).toEqual({
-    ...expected,
-    dueAt: expected.state === State.New ? actual.dueAt : expected.dueAt,
-  })
+  expect(actual).toEqual(expected)
 }
 
 export function expectFullParity(

--- a/packages/srs-kit/src/chrono/presets/date/chrono.spec.ts
+++ b/packages/srs-kit/src/chrono/presets/date/chrono.spec.ts
@@ -93,7 +93,7 @@ describe('dateChrono', () => {
         },
         time: later,
       })
-    ).toEqual({ previous: later, current: later })
+    ).toEqual({ previous: now, current: later })
     expect(
       parse(dateChrono.projection, {
         card: parse(dateChrono.schema.card, {
@@ -102,7 +102,7 @@ describe('dateChrono', () => {
         }),
         time: later,
       })
-    ).toEqual({ previous: later, current: later })
+    ).toEqual({ previous: now, current: later })
     expect(
       parse(dateChrono.projection, {
         card: parse(dateChrono.schema.card, {
@@ -110,7 +110,7 @@ describe('dateChrono', () => {
         }),
         time: later,
       })
-    ).toEqual({ previous: later, current: later })
+    ).toEqual({ previous: now, current: later })
     expect(
       parse(dateChrono.projection, {
         revlog: {

--- a/packages/srs-kit/src/chrono/presets/date/chrono.ts
+++ b/packages/srs-kit/src/chrono/presets/date/chrono.ts
@@ -31,7 +31,7 @@ export const dateChrono = defineChrono({
 
       return {
         value: {
-          previous: card.value.lastReviewAt ?? time.value,
+          previous: card.value.lastReviewAt ?? card.value.dueAt,
           current: time.value,
         },
       }

--- a/packages/srs-kit/src/chrono/presets/temporal-instant/chrono.spec.ts
+++ b/packages/srs-kit/src/chrono/presets/temporal-instant/chrono.spec.ts
@@ -178,7 +178,7 @@ describe('temporalInstantChrono', () => {
         },
         time: later,
       })
-    ).toEqual({ previous: later, current: later })
+    ).toEqual({ previous: now, current: later })
     expect(
       parse(temporalInstantChrono.projection, {
         card: parse(temporalInstantChrono.schema.card, {
@@ -187,7 +187,7 @@ describe('temporalInstantChrono', () => {
         }),
         time: later,
       })
-    ).toEqual({ previous: later, current: later })
+    ).toEqual({ previous: now, current: later })
     expect(
       parse(temporalInstantChrono.projection, {
         card: parse(temporalInstantChrono.schema.card, {
@@ -195,7 +195,7 @@ describe('temporalInstantChrono', () => {
         }),
         time: later,
       })
-    ).toEqual({ previous: later, current: later })
+    ).toEqual({ previous: now, current: later })
     expect(
       parse(temporalInstantChrono.projection, {
         revlog: {

--- a/packages/srs-kit/src/chrono/presets/temporal-instant/chrono.ts
+++ b/packages/srs-kit/src/chrono/presets/temporal-instant/chrono.ts
@@ -68,7 +68,7 @@ export const temporalInstantChrono = defineChrono({
 
       return {
         value: {
-          previous: card.value.lastReviewAt ?? time.value,
+          previous: card.value.lastReviewAt ?? card.value.dueAt,
           current: time.value,
         },
       }

--- a/packages/srs-kit/src/scheduler/base.spec.ts
+++ b/packages/srs-kit/src/scheduler/base.spec.ts
@@ -818,6 +818,36 @@ describe('SchedulerCore middleware handlers', () => {
     )
   })
 
+  it('uses zero elapsed days for a new card', () => {
+    const elapsedDays: number[] = []
+    const middleware = defineMiddleware({
+      name: Symbol('new-card-elapsed-days'),
+      handlers: {
+        review(ctx, next) {
+          elapsedDays.push(ctx.elapsedDays)
+          next()
+        },
+      },
+    })
+    const dateCore = defineScheduler({
+      model: SM2Model,
+      chrono: dateChrono,
+    })
+      .use(middleware)
+      .create({ config })
+    const card = dateCore.newCard({
+      now: new Date('2026-01-01T00:00:00.000Z'),
+    })
+
+    dateCore.review({
+      card,
+      grade: Rating.Good,
+      now: new Date('2026-01-10T00:00:00.000Z'),
+    })
+
+    expect(elapsedDays).toEqual([0])
+  })
+
   it('applies rollback chrono defaults after middleware unwinds', () => {
     const seen: unknown[] = []
     const middleware = defineMiddleware({
@@ -847,7 +877,8 @@ describe('SchedulerCore middleware handlers', () => {
     const restored = dateCore.rollback(reviewed)
 
     expect(seen[0]).not.toHaveProperty('dueAt')
-    expect(restored.dueAt).toEqual(reviewed.revlog.dueAt)
+    expect(reviewed.revlog.dueAt).toEqual(card.dueAt)
+    expect(restored.dueAt).toEqual(card.dueAt)
     expect(restored.lastReviewAt).toBe(null)
   })
 
@@ -1581,30 +1612,29 @@ describe('SchedulerCore.rollback', () => {
     expect('audit' in restoredFields).toBe(false)
   })
 
-  it('restores new Date card fields from revlog projection', () => {
+  it('restores a new Date card original due date', () => {
     const dateCore = defineScheduler({
       model: SM2Model,
       chrono: dateChrono,
     }).create({ config })
     const dueAt = new Date('2026-06-28T00:00:00.000Z')
     const reviewTime = new Date('2026-06-30T00:00:00.000Z')
+    const card = dateCore.newCard({ now: dueAt })
     const reviewed = dateCore.review({
-      card: dateCore.newCard({ now: dueAt }),
+      card,
       grade: Rating.Good,
       now: reviewTime,
     })
 
-    const restored = dateCore.rollback({
-      card: reviewed.card,
-      revlog: { ...reviewed.revlog, dueAt, reviewTime },
-    })
+    const restored = dateCore.rollback(reviewed)
 
     expect(restored.scheduleStatus).toBe('new')
-    expect(restored.dueAt).toEqual(dueAt)
+    expect(reviewed.revlog.dueAt).toEqual(card.dueAt)
+    expect(restored.dueAt).toEqual(card.dueAt)
     expect(restored.lastReviewAt).toBe(null)
   })
 
-  it('restores new Temporal.Instant card fields from revlog projection', () => {
+  it('restores a new Temporal.Instant card original due date', () => {
     const temporalCore = defineScheduler({
       model: SM2Model,
       chrono: temporalInstantChrono,
@@ -1616,19 +1646,18 @@ describe('SchedulerCore.rollback', () => {
     })
     const dueAt = Temporal.Instant.from('2026-06-28T00:00:00Z')
     const reviewTime = Temporal.Instant.from('2026-06-30T00:00:00Z')
+    const card = temporalCore.newCard({ now: dueAt })
     const reviewed = temporalCore.review({
-      card: temporalCore.newCard({ now: dueAt }),
+      card,
       grade: Rating.Good,
       now: reviewTime,
     })
 
-    const restored = temporalCore.rollback({
-      card: reviewed.card,
-      revlog: { ...reviewed.revlog, dueAt, reviewTime },
-    })
+    const restored = temporalCore.rollback(reviewed)
 
     expect(restored.scheduleStatus).toBe('new')
-    expect(restored.dueAt).toBe(dueAt)
+    expect(reviewed.revlog.dueAt).toBe(card.dueAt)
+    expect(restored.dueAt).toBe(card.dueAt)
     expect(restored.lastReviewAt).toBe(null)
   })
 

--- a/packages/srs-kit/src/scheduler/base.ts
+++ b/packages/srs-kit/src/scheduler/base.ts
@@ -409,7 +409,10 @@ export class BaseScheduler<
       }
     ) as PreparedReview<Env>['time']
 
-    const elapsedDays = this.chrono.difference(time.previous, time.current)
+    const elapsedDays =
+      card.state === State.New
+        ? 0
+        : this.chrono.difference(time.previous, time.current)
 
     const retrievability = this.model.forgettingCurve(memoryState, elapsedDays)
     const memoryStateByGrade = new Map<Grade, Record<string, unknown>>()


### PR DESCRIPTION
## Summary

- Preserve a new card's original `dueAt` in its review log so rollback restores the pre-review value.
- Keep `elapsedDays` at zero for new cards regardless of the review time.
- Cover Date and Temporal.Instant chronos and tighten legacy parity assertions.
- Add a patch changeset for `@open-spaced-repetition/srs-kit`.

## Root cause

When a card had no `lastReviewAt`, the chrono projection used the current review time as `previous`. This discarded the new card's original `dueAt`, so rollback restored the review time instead.

## Validation

- srs-kit: 25 test files, 217 tests passed
- fsrs: 57 test files, 544 tests passed, 1 skipped
- srs-kit and fsrs type checks passed
- srs-kit build passed
- Biome and diff checks passed