### PR TITLE
feat(fsrs): expose srs-kit types

### DIFF
--- a/.changeset/expose-scheduler-types.md
+++ b/.changeset/expose-scheduler-types.md
@@ -1,0 +1,5 @@
+---
+"ts-fsrs": minor
+---
+
+feat(fsrs): expose srs-kit types and bundle their declarations.

--- a/packages/fsrs/src/index.ts
+++ b/packages/fsrs/src/index.ts
@@ -1,3 +1,4 @@
+export type * from '@open-spaced-repetition/srs-kit'
 export {
   defineChrono,
   defineMiddleware,

--- a/packages/fsrs/src/scheduler/public-types.spec.ts
+++ b/packages/fsrs/src/scheduler/public-types.spec.ts
@@ -1,0 +1,28 @@
+import {
+  dateChrono,
+  defineScheduler,
+  type SchedulerCreate,
+  type SchedulerEnvFor,
+} from 'ts-fsrs'
+import { schedulerStatsMiddleware } from 'ts-fsrs/middlewares'
+import { FSRS6Model } from 'ts-fsrs/models/fsrs-6'
+import { describe, expectTypeOf, it } from 'vitest'
+
+const middlewares = [schedulerStatsMiddleware] as const
+
+type PublicSchedulerCreate = SchedulerCreate<
+  SchedulerEnvFor<typeof FSRS6Model, typeof dateChrono, typeof middlewares>,
+  typeof FSRS6Model,
+  typeof dateChrono
+>
+
+describe('public scheduler types', () => {
+  it('names a composed scheduler without importing srs-kit', () => {
+    const definition = defineScheduler({
+      model: FSRS6Model,
+      chrono: dateChrono,
+    }).use(...middlewares)
+
+    expectTypeOf(definition.create).toEqualTypeOf<PublicSchedulerCreate>()
+  })
+})

--- a/packages/fsrs/tsdown.config.ts
+++ b/packages/fsrs/tsdown.config.ts
@@ -20,6 +20,14 @@ export default defineConfig([
     format: ['esm', 'cjs'],
     outDir: 'dist',
     dts: true,
+    deps: {
+      dts: {
+        alwaysBundle: [
+          '@open-spaced-repetition/srs-kit',
+          '@open-spaced-repetition/srs-kit/**',
+        ],
+      },
+    },
     clean: true,
     sourcemap: false,
     minify: false,


### PR DESCRIPTION
## Summary

- Re-export srs-kit types through the ts-fsrs public entry point.
- Bundle srs-kit declarations while keeping the runtime dependency external.
- Add coverage for composing a scheduler without importing srs-kit directly.

## Testing

- `pnpm --filter ts-fsrs check`
- `pnpm --filter ts-fsrs typecheck`
- `pnpm --filter ts-fsrs test -- public-types.spec.ts`
- `pnpm --filter ts-fsrs build`
- Linked the local package into a downstream package and verified declaration generation succeeds without a direct srs-kit dependency.