### PR TITLE
feat(kit): map preview results to arrays

### DIFF
--- a/.changeset/lazy-preview-map.md
+++ b/.changeset/lazy-preview-map.md
@@ -1,0 +1,5 @@
+---
+"@open-spaced-repetition/srs-kit": minor
+---
+
+feat(kit): support mapping preview results to arrays.

--- a/packages/srs-kit/src/scheduler/base.spec.ts
+++ b/packages/srs-kit/src/scheduler/base.spec.ts
@@ -1129,6 +1129,23 @@ describe('SchedulerCore.preview', () => {
     expect(items.every((item) => item.card && item.revlog)).toBe(true)
   })
 
+  it('maps preview results to an array', () => {
+    const card = core.newCard()
+    const calls: number[] = []
+    const grades = core.preview({ card: card, now: 0 }).map((preview) => {
+      calls.push(preview.grade)
+      return preview.grade
+    })
+
+    expect(grades).toEqual([
+      Rating.Again,
+      Rating.Hard,
+      Rating.Good,
+      Rating.Easy,
+    ])
+    expect(calls).toEqual([Rating.Again, Rating.Hard, Rating.Good, Rating.Easy])
+  })
+
   it('matches individual review calls', () => {
     const card = core.newCard()
     const previews = Array.from(core.preview({ card: card, now: 0 }))

--- a/packages/srs-kit/src/scheduler/scheduler.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.ts
@@ -9,6 +9,7 @@ import type {
   AnySchema,
   Assign,
   EmptyPart,
+  LazyIterable,
   Mutable,
   Prettify,
   SchemaInput,
@@ -35,9 +36,8 @@ export interface PreviewItem<Card, Revlog>
   readonly grade: Grade
 }
 
-export interface PreviewResult<Card, Revlog> {
-  [Symbol.iterator](): IterableIterator<PreviewItem<Card, Revlog>>
-}
+export interface PreviewResult<Card, Revlog>
+  extends LazyIterable<PreviewItem<Card, Revlog>> {}
 
 // ==========
 // Scheduler Core

--- a/packages/srs-kit/src/schema/iterable.spec.ts
+++ b/packages/srs-kit/src/schema/iterable.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, expectTypeOf, it } from 'vitest'
 import { createLazyIterable } from './iterable.js'
 
 describe('createLazyIterable', () => {
@@ -37,5 +37,24 @@ describe('createLazyIterable', () => {
 
     expect(Array.from(iterable)).toEqual(['missing', 'next'])
     expect(calls).toEqual([undefined, 'next'])
+  })
+
+  it('maps values to an array and supports chaining', () => {
+    const sourceCalls: number[] = []
+    const mapCalls: number[] = []
+    const mapped = createLazyIterable([1, 2, 3], (key) => {
+      sourceCalls.push(key)
+      return key * 2
+    })
+      .map((value) => {
+        mapCalls.push(value)
+        return value + 1
+      })
+      .map(String)
+
+    expectTypeOf(mapped).toEqualTypeOf<string[]>()
+    expect(mapped).toEqual(['3', '5', '7'])
+    expect(sourceCalls).toEqual([1, 2, 3])
+    expect(mapCalls).toEqual([2, 4, 6])
   })
 })

--- a/packages/srs-kit/src/schema/iterable.ts
+++ b/packages/srs-kit/src/schema/iterable.ts
@@ -1,4 +1,5 @@
 export interface LazyIterable<Value> extends Iterable<Value> {
+  map<MappedValue>(callback: (value: Value) => MappedValue): MappedValue[]
   [Symbol.iterator](): IterableIterator<Value>
 }
 
@@ -6,10 +7,11 @@ export function createLazyIterable<const Key, Value>(
   keys: readonly Key[],
   getValue: (key: Key) => Value
 ): LazyIterable<Value> {
-  const result = Object.create(null)
-  Object.defineProperty(result, Symbol.iterator, {
-    enumerable: false,
-    value() {
+  return {
+    map(callback) {
+      return Array.from(this, (value) => callback(value))
+    },
+    [Symbol.iterator]() {
       let index = 0
       const iterator: IterableIterator<Value> = {
         next() {
@@ -25,7 +27,5 @@ export function createLazyIterable<const Key, Value>(
       }
       return iterator
     },
-  })
-
-  return result as LazyIterable<Value>
+  }
 }


### PR DESCRIPTION
## Summary
- Add LazyIterable.map so lazy preview results can be mapped directly into an array.
- Keep preview evaluation deferred until iteration or map is invoked.
- Support direct and chained mapping without adding an index parameter or other array methods.

## Testing
- srs-kit Vitest: 25 files and 220 tests passed
- TypeScript 6 typecheck
- Biome and git diff --check

## Changeset
- Minor release for @open-spaced-repetition/srs-kit

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback</a></sub>