### PR TITLE
fix(kit): flatten preview result type displays

### DIFF
--- a/.changeset/flatten-preview-types.md
+++ b/.changeset/flatten-preview-types.md
@@ -1,0 +1,5 @@
+---
+"@open-spaced-repetition/srs-kit": patch
+---
+
+fix(kit): flatten preview card and revlog type displays.

--- a/packages/srs-kit/src/scheduler/scheduler.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.ts
@@ -31,10 +31,11 @@ export interface ScheduleResult<Card, Revlog> {
   revlog: Mutable<Revlog>
 }
 
-export interface PreviewItem<Card, Revlog>
-  extends ScheduleResult<Card, Revlog> {
+export type PreviewItem<Card, Revlog> = Prettify<{
+  card: Mutable<Card>
+  revlog: Mutable<Revlog>
   readonly grade: Grade
-}
+}>
 
 export interface PreviewResult<Card, Revlog>
   extends LazyIterable<PreviewItem<Card, Revlog>> {}

--- a/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
@@ -50,8 +50,10 @@ const auditMiddleware = defineMiddleware({
     },
   },
   handlers: {
-    review(_ctx, next) {
+    review(ctx, next) {
       next()
+      ctx.result.card.source = ctx.input.card.source
+      ctx.result.revlog.audit = 'default'
     },
   },
 })
@@ -97,6 +99,10 @@ const defaultNewCard = sm2NumericSchedulerWithMiddleware.defaultValue.newCard(
   },
   0
 )
+
+const mappedPreview = sm2NumericCoreWithMiddleware
+  .preview({ card: sm2NumericCoreWithMiddleware.newCard({ now: 0 }), now: 0 })
+  .map((item) => item)
 
 const SELF = 'src/scheduler/scheduler.type-display.spec.ts'
 
@@ -480,6 +486,31 @@ describe('defineScheduler type display', () => {
 }>, ChronoCore<number>>`,
   }
 
+  const expectedPreviews = {
+    mappedPreview: `const mappedPreview: {
+    card: Mutable<{
+        source: string;
+        interval: number;
+        easeFactor: number;
+        reviewStep: number;
+        reps: number;
+        lapses: number;
+        state: State;
+        scheduleStatus: "new" | "learning" | "review";
+    }>;
+    revlog: Mutable<{
+        interval: number;
+        easeFactor: number;
+        reviewStep: number;
+        audit: string;
+        state: State;
+        scheduleStatus: "new" | "learning" | "review";
+        rating: Grade;
+    }>;
+    readonly grade: Grade;
+}[]`,
+  }
+
   const expectedDefaultValues = {
     defaultNewCard: `const defaultNewCard: {
     source: string;
@@ -653,6 +684,12 @@ describe('defineScheduler type display', () => {
 
   it('shows SchedulerCore<T> for scheduler.create()', () => {
     for (const [marker, expected] of Object.entries(expectedCores)) {
+      expect(quickInfoAt(service, SELF, marker)).toBe(expected)
+    }
+  })
+
+  it('shows flat card and revlog fields for mapped previews', () => {
+    for (const [marker, expected] of Object.entries(expectedPreviews)) {
       expect(quickInfoAt(service, SELF, marker)).toBe(expected)
     }
   })


### PR DESCRIPTION
## Summary
- Flatten preview result items with the existing Prettify utility.
- Show card and revlog fields directly in IDE type displays without intersection output.
- Update type-display coverage for mapped preview arrays.

## Performance
- TypeScript 6 memory median: 343514K to 336023K, a 2.18% decrease
- Instantiations: 269519 to 270071, a 0.20% increase and within the 5% gate

## Testing
- srs-kit Vitest: 25 files and 220 tests passed
- TypeScript 6 typecheck
- Biome and git diff --check

## Changeset
- Patch release for @open-spaced-repetition/srs-kit

## Stack
- Depends on #471

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback</a></sub>