### PR TITLE
fix(fsrs): flatten reschedule result type displays

### DIFF
--- a/.changeset/flatten-reschedule-types.md
+++ b/.changeset/flatten-reschedule-types.md
@@ -1,0 +1,5 @@
+---
+"ts-fsrs": patch
+---
+
+fix(fsrs): flatten reschedule card and revlog type displays.

--- a/packages/fsrs/src/reschedule/infer.ts
+++ b/packages/fsrs/src/reschedule/infer.ts
@@ -1,6 +1,7 @@
 import type {
   AnySchedulerCore,
   ForwardItem,
+  Prettify,
   Rating,
 } from '@open-spaced-repetition/srs-kit'
 
@@ -59,7 +60,7 @@ export interface ReplayResult<MemoryState extends object> {
   readonly memoryStates: MemoryState[]
 }
 
-export interface RescheduleResult<Scheduler extends AnySchedulerCore> {
-  readonly results: ScheduleResultOf<Scheduler>[]
+export type RescheduleResult<Scheduler extends AnySchedulerCore> = Prettify<{
+  readonly results: Prettify<ScheduleResultOf<Scheduler>>[]
   readonly card: ScheduleResultOf<Scheduler>['card']
-}
+}>


### PR DESCRIPTION
## Summary
- Flatten RescheduleResult and each scheduled result with the existing Prettify utility.
- Show results card and revlog fields directly in IDE type displays without intersection output.
- Keep the runtime rescheduling behavior unchanged.

## Performance
- TypeScript 6 memory median: 399329K to 401447K, a 0.53% increase
- Instantiations: 379687 to 380019, a 0.09% increase and within the 5% gate

## Testing
- ts-fsrs Vitest: 58 files, 545 tests passed, and 1 test skipped
- TypeScript 7 package and benchmark typechecks
- TypeScript 6 type-display verification
- Biome and git diff --check

## Changeset
- Patch release for ts-fsrs

## Stack
- Depends on #472

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback</a></sub>