### PR TITLE
fix(kit): label and flatten preview result types

### DIFF
--- a/.changeset/flatten-composed-preview-fields.md
+++ b/.changeset/flatten-composed-preview-fields.md
@@ -1,0 +1,5 @@
+---
+"@open-spaced-repetition/srs-kit": patch
+---
+
+fix(kit): flatten composed schedule fields and label preview card and revlog types.

--- a/packages/fsrs/src/scheduler/public-types.spec.ts
+++ b/packages/fsrs/src/scheduler/public-types.spec.ts
@@ -1,10 +1,22 @@
 import {
   dateChrono,
   defineScheduler,
+  type Grade,
+  type PreviewResult,
   type SchedulerCreate,
   type SchedulerEnvFor,
+  type State,
 } from 'ts-fsrs'
-import { schedulerStatsMiddleware } from 'ts-fsrs/middlewares'
+import {
+  schedulerDesiredRetentionMiddleware,
+  schedulerFuzzingMiddleware,
+  schedulerLearningStepsMiddleware,
+  schedulerLeechMiddleware,
+  schedulerMaximumIntervalMiddleware,
+  schedulerMonotonicIntervalMiddleware,
+  schedulerScheduledDaysMiddleware,
+  schedulerStatsMiddleware,
+} from 'ts-fsrs/middlewares'
 import { FSRS6Model } from 'ts-fsrs/models/fsrs-6'
 import { describe, expectTypeOf, it } from 'vitest'
 
@@ -16,6 +28,25 @@ type PublicSchedulerCreate = SchedulerCreate<
   typeof dateChrono
 >
 
+const previewSchedulerDefinition = defineScheduler({
+  model: FSRS6Model,
+  chrono: dateChrono,
+}).use(
+  schedulerLeechMiddleware,
+  schedulerDesiredRetentionMiddleware,
+  schedulerFuzzingMiddleware,
+  schedulerStatsMiddleware,
+  schedulerScheduledDaysMiddleware,
+  schedulerLearningStepsMiddleware,
+  schedulerMaximumIntervalMiddleware,
+  schedulerMonotonicIntervalMiddleware
+)
+
+type FSRSScheduler = ReturnType<typeof previewSchedulerDefinition.create>
+type SchedulerPreviews = ReturnType<FSRSScheduler['preview']>
+type SchedulerPreview =
+  SchedulerPreviews extends Iterable<infer Preview> ? Preview : never
+
 describe('public scheduler types', () => {
   it('names a composed scheduler without importing srs-kit', () => {
     const definition = defineScheduler({
@@ -24,5 +55,42 @@ describe('public scheduler types', () => {
     }).use(...middlewares)
 
     expectTypeOf(definition.create).toEqualTypeOf<PublicSchedulerCreate>()
+  })
+
+  it('flattens previews from a full middleware stack', () => {
+    expectTypeOf<SchedulerPreviews>().toEqualTypeOf<
+      PreviewResult<{
+        card: SchedulerPreview['card']
+        revlog: SchedulerPreview['revlog']
+      }>
+    >()
+    expectTypeOf<SchedulerPreview>().toEqualTypeOf<{
+      card: {
+        state: State
+        scheduleStatus: 'new' | 'learning' | 'review' | 'suspended'
+        dueAt: Date
+        lastReviewAt: Date | null
+        stability: number
+        difficulty: number
+        learningStep: number
+        scheduledDays: number
+        cardId: string | number
+        reps: number
+        lapses: number
+      }
+      revlog: {
+        state: State
+        scheduleStatus: 'new' | 'learning' | 'review' | 'suspended'
+        rating: Grade
+        dueAt: Date
+        reviewTime: Date
+        stability: number
+        difficulty: number
+        learningStep: number
+        scheduledDays: number
+        cardId: string | number
+      }
+      readonly grade: Grade
+    }>()
   })
 })

--- a/packages/srs-kit/src/scheduler/base.ts
+++ b/packages/srs-kit/src/scheduler/base.ts
@@ -323,8 +323,10 @@ export class BaseScheduler<
     readonly card: SchedulerCoreEnv<Env>['card']['input']
     readonly now?: SchedulerCoreEnv<Env>['chrono']
   }): PreviewResult<
-    SchedulerCoreEnv<Env>['card']['output'],
-    SchedulerCoreEnv<Env>['revlog']['output']
+    ScheduleResult<
+      SchedulerCoreEnv<Env>['card']['output'],
+      SchedulerCoreEnv<Env>['revlog']['output']
+    >
   > => {
     const inputCard = input.card
     const now = this.parseNow(input.now)

--- a/packages/srs-kit/src/scheduler/scheduler.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.ts
@@ -26,19 +26,19 @@ import type { ExtendSchedulerEnv } from './infer.js'
 // Schedule Result
 // ==========
 
-export interface ScheduleResult<Card, Revlog> {
-  card: Mutable<Card>
-  revlog: Mutable<Revlog>
-}
+export type ScheduleResult<Card, Revlog> = Prettify<{
+  card: { -readonly [Key in keyof Card]: Card[Key] }
+  revlog: { -readonly [Key in keyof Revlog]: Revlog[Key] }
+}>
 
 export type PreviewItem<Card, Revlog> = Prettify<{
-  card: Mutable<Card>
-  revlog: Mutable<Revlog>
+  card: ScheduleResult<Card, Revlog>['card']
+  revlog: ScheduleResult<Card, Revlog>['revlog']
   readonly grade: Grade
 }>
 
-export interface PreviewResult<Card, Revlog>
-  extends LazyIterable<PreviewItem<Card, Revlog>> {}
+export interface PreviewResult<Env extends { card: object; revlog: object }>
+  extends LazyIterable<PreviewItem<Env['card'], Env['revlog']>> {}
 
 // ==========
 // Scheduler Core
@@ -117,7 +117,9 @@ export interface SchedulerCore<
   readonly preview: (input: {
     readonly card: Env['card']['input']
     readonly now?: Env['chrono']
-  }) => PreviewResult<Env['card']['output'], Env['revlog']['output']>
+  }) => PreviewResult<
+    ScheduleResult<Env['card']['output'], Env['revlog']['output']>
+  >
   readonly rollback: (input: {
     readonly card: Env['card']['output']
     readonly revlog: Env['revlog']['output']

--- a/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
@@ -4,8 +4,11 @@ import { numericChrono } from '@/chrono/presets/numeric/chrono.js'
 import { defineMiddleware } from '@/middleware/index.js'
 import { schedulerStatsMiddleware } from '@/middleware/stats/index.js'
 import { SM2_DEFAULT_WEIGHTS, SM2Model } from '@/model/sm2.test.js'
+import type { Grade } from '@/primitives/rating.js'
+import type { Mutable } from '@/schema/index.js'
 import { defineStringFieldOutputSchema } from '@/schema/string-field.test.js'
 import { defineScheduler } from './define-scheduler.js'
+import type { PreviewResult, ScheduleResult } from './scheduler.js'
 
 const sm2NumericScheduler = defineScheduler({
   model: SM2Model,
@@ -103,6 +106,54 @@ const defaultNewCard = sm2NumericSchedulerWithMiddleware.defaultValue.newCard(
 const mappedPreview = sm2NumericCoreWithMiddleware
   .preview({ card: sm2NumericCoreWithMiddleware.newCard({ now: 0 }), now: 0 })
   .map((item) => item)
+
+type ComposedCardForDisplay = Mutable<
+  Omit<
+    Mutable<{ stability: number; dueAt: Date }> & {
+      readonly reps: number
+    },
+    'dueAt'
+  > & {
+    readonly dueAt: Date
+    readonly learningStep: number
+  }
+>
+
+type ComposedRevlogForDisplay = Mutable<
+  Omit<Mutable<{ reviewedAt: Date; readonly rating: Grade }>, 'rating'> & {
+    readonly rating: Grade
+  }
+>
+
+interface FSRSSchedulerForDisplay {
+  readonly preview: () => PreviewResult<
+    ScheduleResult<ComposedCardForDisplay, ComposedRevlogForDisplay>
+  >
+}
+
+type SchedulerPreviews = ReturnType<FSRSSchedulerForDisplay['preview']>
+type SchedulerPreview =
+  SchedulerPreviews extends Iterable<infer Preview> ? Preview : never
+
+declare const previewCollectionForDisplay: SchedulerPreviews
+
+function displaySchedulerPreview(preview: SchedulerPreview) {
+  return preview
+}
+
+const inferredSchedulerPreview = displaySchedulerPreview({
+  card: {
+    stability: 1,
+    dueAt: new Date(0),
+    reps: 0,
+    learningStep: 0,
+  },
+  revlog: {
+    reviewedAt: new Date(0),
+    rating: 1,
+  },
+  grade: 1,
+})
 
 const SELF = 'src/scheduler/scheduler.type-display.spec.ts'
 
@@ -487,8 +538,20 @@ describe('defineScheduler type display', () => {
   }
 
   const expectedPreviews = {
+    previewCollectionForDisplay: `const previewCollectionForDisplay: PreviewResult<{
+    card: {
+        reps: number;
+        stability: number;
+        dueAt: Date;
+        learningStep: number;
+    };
+    revlog: {
+        reviewedAt: Date;
+        rating: Grade;
+    };
+}>`,
     mappedPreview: `const mappedPreview: {
-    card: Mutable<{
+    card: {
         source: string;
         interval: number;
         easeFactor: number;
@@ -497,8 +560,8 @@ describe('defineScheduler type display', () => {
         lapses: number;
         state: State;
         scheduleStatus: "new" | "learning" | "review";
-    }>;
-    revlog: Mutable<{
+    };
+    revlog: {
         interval: number;
         easeFactor: number;
         reviewStep: number;
@@ -506,9 +569,22 @@ describe('defineScheduler type display', () => {
         state: State;
         scheduleStatus: "new" | "learning" | "review";
         rating: Grade;
-    }>;
+    };
     readonly grade: Grade;
 }[]`,
+    inferredSchedulerPreview: `const inferredSchedulerPreview: {
+    card: {
+        reps: number;
+        stability: number;
+        dueAt: Date;
+        learningStep: number;
+    };
+    revlog: {
+        reviewedAt: Date;
+        rating: Grade;
+    };
+    readonly grade: Grade;
+}`,
   }
 
   const expectedDefaultValues = {
@@ -688,7 +764,7 @@ describe('defineScheduler type display', () => {
     }
   })
 
-  it('shows flat card and revlog fields for mapped previews', () => {
+  it('shows labeled preview types and flat mapped fields', () => {
     for (const [marker, expected] of Object.entries(expectedPreviews)) {
       expect(quickInfoAt(service, SELF, marker)).toBe(expected)
     }


### PR DESCRIPTION
## Summary

- change `PreviewResult<Card, Revlog>` to a single labeled environment: `PreviewResult<{ card; revlog }>`
- flatten preview environment arguments through `ScheduleResult` at the public return boundary
- avoid the `ScheduleResult & { grade }` intersection in `PreviewItem`
- preserve the existing `PreviewItem<Card, Revlog>` API and lazy iterable behavior
- cover the full FSRS middleware composition, including scheduled-days, in the `fsrs` package
- add LanguageService regression coverage for labeled and flat preview fields
- add a patch changeset for `@open-spaced-repetition/srs-kit`

## TypeScript performance

Measured with Node v26.5.0, TypeScript 6.0.3, and a 1536 MB heap limit.

| Metric | Preview baseline | This change |
| --- | ---: | ---: |
| Memory samples | 344390K / 350560K / 348329K | 353958K / 336197K / 347855K |
| Memory median | 348329K | 347855K (-0.14%) |
| Types | 140145 | 140378 |
| Instantiations | 270071 | 271158 (+0.40%) |
| Check time samples | 2.05s / 2.06s / 2.06s | 2.35s / 2.26s / 2.03s |

No OOM or TS2590 occurred.

## Verification

- srs-kit Vitest: 25 files, 220 tests passed
- fsrs Vitest: 58 files, 546 passed and 1 skipped
- srs-kit TypeScript 6.0.3 typecheck passed
- fsrs TypeScript 7.0.2 typecheck passed
- srs-kit and fsrs builds passed
- built ts-fsrs declarations consumed by read-frog TypeScript 6 show flat `SchedulerPreviews` and `SchedulerPreview`
- read-frog consumer semantic diagnostics: 0
- Biome checks passed
- `git diff --check` passed
- no new type assertions or diagnostic suppressions