### PR TITLE
fix(fsrs): clamp initial stability to model bounds

### DIFF
--- a/.changeset/fix-initial-stability-bounds.md
+++ b/.changeset/fix-initial-stability-bounds.md
@@ -1,0 +1,5 @@
+---
+"ts-fsrs": patch
+---
+
+fix(fsrs): clamp FSRS-4.5 through FSRS-6 initial stability to each model's configured bounds.

--- a/packages/fsrs/src/models/fsrs-4dot5/algorithm.spec.ts
+++ b/packages/fsrs/src/models/fsrs-4dot5/algorithm.spec.ts
@@ -65,6 +65,16 @@ describe('FSRS4Dot5Algorithm', () => {
       weights[2],
       weights[3],
     ])
+    const clamped = new FSRS4Dot5Algorithm(
+      [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY, ...weights.slice(2)],
+      FSRS4Dot5_MODEL_BOUNDS
+    )
+    expect(clamped.init_stability(Rating.Again)).toBe(
+      FSRS4Dot5_MODEL_BOUNDS.sMin
+    )
+    expect(clamped.init_stability(Rating.Hard)).toBe(
+      FSRS4Dot5_MODEL_BOUNDS.sMax
+    )
     expectCloseArray(
       grades.map((rating) => algorithm.init_difficulty(rating)),
       [

--- a/packages/fsrs/src/models/fsrs-4dot5/algorithm.ts
+++ b/packages/fsrs/src/models/fsrs-4dot5/algorithm.ts
@@ -35,7 +35,7 @@ export class FSRS4Dot5Algorithm {
   }
 
   init_stability(g: Grade): number {
-    return Math.max(this.weights[g - 1], 0.1)
+    return clamp(this.weights[g - 1], this.bounds.sMin, this.bounds.sMax)
   }
 
   init_difficulty(g: Grade): number {

--- a/packages/fsrs/src/models/fsrs-5/algorithm.spec.ts
+++ b/packages/fsrs/src/models/fsrs-5/algorithm.spec.ts
@@ -46,6 +46,18 @@ describe('FSRS5Algorithm', () => {
     expect(states.map((state) => state.difficulty)).toEqual([
       7.1949, 6.48830527, 5.28243442, 3.22450159,
     ])
+
+    const clamped = new FSRS5Algorithm(
+      [
+        Number.NEGATIVE_INFINITY,
+        Number.POSITIVE_INFINITY,
+        ...FSRS5_DEFAULT_WEIGHTS.slice(2),
+      ],
+      true,
+      FSRS5_MODEL_BOUNDS
+    )
+    expect(clamped.init_stability(Rating.Again)).toBe(FSRS5_MODEL_BOUNDS.sMin)
+    expect(clamped.init_stability(Rating.Hard)).toBe(FSRS5_MODEL_BOUNDS.sMax)
   })
 
   it('validates state inputs and handles every review rating', () => {

--- a/packages/fsrs/src/models/fsrs-5/algorithm.ts
+++ b/packages/fsrs/src/models/fsrs-5/algorithm.ts
@@ -32,7 +32,7 @@ export class FSRS5Algorithm {
   }
 
   init_stability(g: Grade): number {
-    return Math.max(this.weights[g - 1], 0.1)
+    return clamp(this.weights[g - 1], this.bounds.sMin, this.bounds.sMax)
   }
 
   init_difficulty(g: Grade): number {

--- a/packages/fsrs/src/models/fsrs-6/algorithm.spec.ts
+++ b/packages/fsrs/src/models/fsrs-6/algorithm.spec.ts
@@ -9,6 +9,21 @@ it('rejects an invalid FSRS-6 weight count', () => {
   )
 })
 
+it('clamps initial stability to the FSRS-6 model bounds', () => {
+  const algorithm = new FSRS6Algorithm(
+    [
+      Number.NEGATIVE_INFINITY,
+      Number.POSITIVE_INFINITY,
+      ...FSRS6_DEFAULT_WEIGHTS.slice(2),
+    ],
+    true,
+    FSRS6_MODEL_BOUNDS
+  )
+
+  expect(algorithm.init_stability(Rating.Again)).toBe(FSRS6_MODEL_BOUNDS.sMin)
+  expect(algorithm.init_stability(Rating.Hard)).toBe(FSRS6_MODEL_BOUNDS.sMax)
+})
+
 it('keeps the memory state for a manual rating', () => {
   const algorithm = new FSRS6Algorithm(
     Array.from(FSRS6_DEFAULT_WEIGHTS),

--- a/packages/fsrs/src/models/fsrs-6/algorithm.ts
+++ b/packages/fsrs/src/models/fsrs-6/algorithm.ts
@@ -80,7 +80,7 @@ export class FSRS6Algorithm {
   }
 
   init_stability(g: Grade): number {
-    return Math.max(this.weights[g - 1], 0.1)
+    return clamp(this.weights[g - 1], this.bounds.sMin, this.bounds.sMax)
   }
 
   init_difficulty(g: Grade): number {


### PR DESCRIPTION
- https://github.com/open-spaced-repetition/ts-fsrs/pull/400#discussion_r3541406447

## Summary

- Clamp `init_stability` to each model's configured stability bounds in FSRS-4.5, FSRS-5, and FSRS-6, matching FSRS-4 behavior.
- Add regression coverage for both lower and upper stability bounds.
- Add a patch changeset for `ts-fsrs`.

## Testing

- `pnpm build --filter=ts-fsrs`
- `pnpm --filter ts-fsrs typecheck`
- `pnpm --dir packages/fsrs exec vitest run --config=vitest.config.ts src/models/fsrs-4dot5/algorithm.spec.ts src/models/fsrs-5/algorithm.spec.ts src/models/fsrs-6/algorithm.spec.ts`
- `pnpm --filter ts-fsrs test`
- `pnpm --filter ts-fsrs check`
- `git diff --check`
- `pnpm exec changeset status`
