### PR TITLE
ci: bootstrap docs preview delivery

### DIFF
--- a/.github/workflows/docs-preview-delivery.yml
+++ b/.github/workflows/docs-preview-delivery.yml
@@ -3,9 +3,21 @@ name: Docs Preview Delivery
 on:
   workflow_dispatch:
     inputs:
-      run_id:
-        description: Successful Docs Preview workflow run ID
+      action:
+        description: Action to perform
         required: true
+        default: deploy
+        type: choice
+        options:
+          - deploy
+          - cleanup
+      run_id:
+        description: Successful Docs Preview workflow run ID (deploy only)
+        required: false
+        type: string
+      pr_number:
+        description: Pull request number (cleanup only)
+        required: false
         type: string
   workflow_run:
     workflows: [Docs Preview]
@@ -16,23 +28,48 @@ on:
 permissions: {}
 
 jobs:
-  deploy:
+  resolve:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'workflow_run' &&
       github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion == 'success')
+      github.event.workflow_run.conclusion == 'success') ||
+      (github.event_name == 'pull_request_target' &&
+      (github.event.action == 'closed' ||
+      (github.event.action == 'unlabeled' && github.event.label.name == 'docs-preview')))
     runs-on: ubuntu-latest
-    concurrency:
-      group: docs-preview-delivery-${{ github.event_name == 'workflow_run' && format('{0}-{1}', github.event.workflow_run.head_repository.full_name, github.event.workflow_run.head_branch) || format('manual-{0}', inputs.run_id) }}
-      cancel-in-progress: false
+    outputs:
+      action: ${{ steps.resolve-cleanup.outputs.action || steps.authorize.outputs.action }}
+      proceed: ${{ steps.resolve-cleanup.outputs.proceed || steps.authorize.outputs.proceed }}
+      pr-number: ${{ steps.resolve-cleanup.outputs.pr-number || steps.authorize.outputs.pr-number }}
+      run-id: ${{ steps.authorize.outputs.run-id }}
+      run-head-branch: ${{ steps.authorize.outputs.run-head-branch }}
+      run-head-repository: ${{ steps.authorize.outputs.run-head-repository }}
+      run-head-sha: ${{ steps.authorize.outputs.run-head-sha }}
     permissions:
       actions: read
       contents: read
-      deployments: write
-      pull-requests: write
+      pull-requests: read
     steps:
+      - name: Resolve cleanup
+        id: resolve-cleanup
+        if: >-
+          (github.event_name == 'workflow_dispatch' && inputs.action == 'cleanup') ||
+          github.event_name == 'pull_request_target'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.pull_request.number }}
+        run: |
+          [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]
+          gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" > /dev/null
+          echo 'action=cleanup' >> "$GITHUB_OUTPUT"
+          echo 'proceed=true' >> "$GITHUB_OUTPUT"
+          echo "pr-number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
       - name: Download docs artifact
+        if: >-
+          github.event_name == 'workflow_run' ||
+          (github.event_name == 'workflow_dispatch' && inputs.action == 'deploy')
         uses: actions/download-artifact@v8
         with:
           name: docs-preview
@@ -42,6 +79,9 @@ jobs:
 
       - name: Authorize deployment
         id: authorize
+        if: >-
+          github.event_name == 'workflow_run' ||
+          (github.event_name == 'workflow_dispatch' && inputs.action == 'deploy')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_ID: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.id || inputs.run_id }}
@@ -62,6 +102,11 @@ jobs:
           [[ "$head_sha" =~ ^[0-9a-f]{40,64}$ ]]
           [[ "$head_sha" == "$run_head_sha" ]]
 
+          echo "run-id=$RUN_ID" >> "$GITHUB_OUTPUT"
+          echo "run-head-branch=$run_head_branch" >> "$GITHUB_OUTPUT"
+          echo "run-head-repository=$run_head_repository" >> "$GITHUB_OUTPUT"
+          echo "run-head-sha=$run_head_sha" >> "$GITHUB_OUTPUT"
+
           gh api "repos/$GITHUB_REPOSITORY/pulls/$pr_number" > "$RUNNER_TEMP/pull-request.json"
           if ! jq -e \
             --arg branch "$run_head_branch" \
@@ -69,41 +114,94 @@ jobs:
             --arg sha "$run_head_sha" \
             '.state == "open" and .head.ref == $branch and .head.repo.full_name == $repository and .head.sha == $sha' \
             "$RUNNER_TEMP/pull-request.json" > /dev/null; then
-            echo 'deploy=false' >> "$GITHUB_OUTPUT"
+            echo 'action=deploy' >> "$GITHUB_OUTPUT"
+            echo 'proceed=false' >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
+          echo 'action=deploy' >> "$GITHUB_OUTPUT"
           echo "pr-number=$pr_number" >> "$GITHUB_OUTPUT"
           if jq -e '(.head.repo.full_name == .base.repo.full_name) or any(.labels[]?; .name == "docs-preview")' \
+            "$RUNNER_TEMP/pull-request.json" > /dev/null; then
+            echo 'proceed=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'proceed=false' >> "$GITHUB_OUTPUT"
+          fi
+
+  deploy:
+    needs: resolve
+    if: >-
+      needs.resolve.outputs.action == 'deploy' &&
+      needs.resolve.outputs.proceed == 'true'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: docs-preview-delivery-pr-${{ needs.resolve.outputs.pr-number }}
+      cancel-in-progress: false
+    permissions:
+      actions: read
+      contents: read
+      deployments: write
+      pull-requests: write
+    steps:
+      - name: Reauthorize deployment
+        id: reauthorize
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ needs.resolve.outputs.pr-number }}
+          RUN_HEAD_BRANCH: ${{ needs.resolve.outputs.run-head-branch }}
+          RUN_HEAD_REPOSITORY: ${{ needs.resolve.outputs.run-head-repository }}
+          RUN_HEAD_SHA: ${{ needs.resolve.outputs.run-head-sha }}
+        run: |
+          [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]
+          gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" > "$RUNNER_TEMP/pull-request.json"
+          if jq -e \
+            --arg branch "$RUN_HEAD_BRANCH" \
+            --arg repository "$RUN_HEAD_REPOSITORY" \
+            --arg sha "$RUN_HEAD_SHA" \
+            '.state == "open" and .head.ref == $branch and .head.repo.full_name == $repository and .head.sha == $sha and ((.head.repo.full_name == .base.repo.full_name) or any(.labels[]?; .name == "docs-preview"))' \
             "$RUNNER_TEMP/pull-request.json" > /dev/null; then
             echo 'deploy=true' >> "$GITHUB_OUTPUT"
           else
             echo 'deploy=false' >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Download docs artifact
+        if: steps.reauthorize.outputs.deploy == 'true'
+        uses: actions/download-artifact@v8
+        with:
+          name: docs-preview
+          path: ${{ runner.temp }}/docs-preview
+          run-id: ${{ needs.resolve.outputs.run-id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Set preview details
-        if: steps.authorize.outputs.deploy == 'true'
+        if: steps.reauthorize.outputs.deploy == 'true'
         env:
-          PR_NUMBER: ${{ steps.authorize.outputs.pr-number }}
+          PR_NUMBER: ${{ needs.resolve.outputs.pr-number }}
         run: |
           echo "PREVIEW_BRANCH=ts-pr${PR_NUMBER}" >> "$GITHUB_ENV"
           echo "PREVIEW_URL=https://ts-pr${PR_NUMBER}.${{ vars.CLOUDFLARE_PROJECT_NAME }}.pages.dev" >> "$GITHUB_ENV"
 
       - name: Validate static artifact
-        if: steps.authorize.outputs.deploy == 'true'
+        if: steps.reauthorize.outputs.deploy == 'true'
+        env:
+          PR_NUMBER: ${{ needs.resolve.outputs.pr-number }}
+          RUN_HEAD_SHA: ${{ needs.resolve.outputs.run-head-sha }}
         run: |
           test -f "$RUNNER_TEMP/docs-preview/index.html"
           test -z "$(find "$RUNNER_TEMP/docs-preview" -type l -print -quit)"
           test ! -e "$RUNNER_TEMP/docs-preview/_worker.js"
+          test "$(tr -d '[:space:]' < "$RUNNER_TEMP/docs-preview/docs-preview-pr.txt")" = "$PR_NUMBER"
+          test "$(tr -d '[:space:]' < "$RUNNER_TEMP/docs-preview/docs-preview-sha.txt")" = "$RUN_HEAD_SHA"
           rm \
             "$RUNNER_TEMP/docs-preview/docs-preview-pr.txt" \
             "$RUNNER_TEMP/docs-preview/docs-preview-sha.txt"
 
       - name: Comment deployment started
-        if: steps.authorize.outputs.deploy == 'true'
+        if: steps.reauthorize.outputs.deploy == 'true'
         uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
-          number_force: ${{ steps.authorize.outputs.pr-number }}
+          number_force: ${{ needs.resolve.outputs.pr-number }}
           header: docs-preview
           message: |
             ### Docs Preview
@@ -113,7 +211,7 @@ jobs:
 
       - name: Deploy Cloudflare Pages preview
         id: deploy
-        if: steps.authorize.outputs.deploy == 'true'
+        if: steps.reauthorize.outputs.deploy == 'true'
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -126,10 +224,10 @@ jobs:
             --branch=${{ env.PREVIEW_BRANCH }}
 
       - name: Comment deployment complete
-        if: steps.authorize.outputs.deploy == 'true'
+        if: steps.reauthorize.outputs.deploy == 'true'
         uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
-          number_force: ${{ steps.authorize.outputs.pr-number }}
+          number_force: ${{ needs.resolve.outputs.pr-number }}
           header: docs-preview
           message: |
             ### Docs Preview
@@ -141,7 +239,7 @@ jobs:
         if: failure() && steps.deploy.conclusion == 'failure'
         uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
-          number_force: ${{ steps.authorize.outputs.pr-number }}
+          number_force: ${{ needs.resolve.outputs.pr-number }}
           header: docs-preview
           message: |
             ### Docs Preview
@@ -150,20 +248,19 @@ jobs:
             - Preview URL: [${{ env.PREVIEW_URL }}](${{ env.PREVIEW_URL }})
 
   cleanup:
+    needs: resolve
     if: >-
-      github.event_name == 'pull_request_target' &&
-      (github.event.action == 'closed' ||
-      (github.event.action == 'unlabeled' && github.event.label.name == 'docs-preview'))
+      needs.resolve.outputs.action == 'cleanup' &&
+      needs.resolve.outputs.proceed == 'true'
     runs-on: ubuntu-latest
     concurrency:
-      group: docs-preview-delivery-${{ github.event.pull_request.head.repo.full_name }}-${{ github.event.pull_request.head.ref }}
+      group: docs-preview-delivery-pr-${{ needs.resolve.outputs.pr-number }}
       cancel-in-progress: true
     permissions:
       pull-requests: write
     env:
       CLOUDFLARE_PROJECT_NAME: ${{ vars.CLOUDFLARE_PROJECT_NAME }}
-      PREVIEW_BRANCH: ts-pr${{ github.event.pull_request.number }}
-      PREVIEW_URL: https://ts-pr${{ github.event.pull_request.number }}.${{ vars.CLOUDFLARE_PROJECT_NAME }}.pages.dev
+      PREVIEW_BRANCH: ts-pr${{ needs.resolve.outputs.pr-number }}
     steps:
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -220,9 +317,9 @@ jobs:
         if: steps.cleanup.outputs.cleaned == 'true'
         uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
+          number_force: ${{ needs.resolve.outputs.pr-number }}
           header: docs-preview
           message: |
             ### Docs Preview
 
             - Status: Cleaned
-            - Preview URL: [${{ env.PREVIEW_URL }}](${{ env.PREVIEW_URL }})

--- a/.github/workflows/docs-preview-delivery.yml
+++ b/.github/workflows/docs-preview-delivery.yml
@@ -86,8 +86,8 @@ jobs:
         env:
           PR_NUMBER: ${{ steps.authorize.outputs.pr-number }}
         run: |
-          echo "PREVIEW_BRANCH=pr${PR_NUMBER}-ts-fsrs" >> "$GITHUB_ENV"
-          echo "PREVIEW_URL=https://pr${PR_NUMBER}-ts-fsrs.${{ vars.CLOUDFLARE_PROJECT_NAME }}.pages.dev" >> "$GITHUB_ENV"
+          echo "PREVIEW_BRANCH=ts-pr${PR_NUMBER}" >> "$GITHUB_ENV"
+          echo "PREVIEW_URL=https://ts-pr${PR_NUMBER}.${{ vars.CLOUDFLARE_PROJECT_NAME }}.pages.dev" >> "$GITHUB_ENV"
 
       - name: Validate static artifact
         if: steps.authorize.outputs.deploy == 'true'
@@ -162,8 +162,8 @@ jobs:
       pull-requests: write
     env:
       CLOUDFLARE_PROJECT_NAME: ${{ vars.CLOUDFLARE_PROJECT_NAME }}
-      PREVIEW_BRANCH: pr${{ github.event.pull_request.number }}-ts-fsrs
-      PREVIEW_URL: https://pr${{ github.event.pull_request.number }}-ts-fsrs.${{ vars.CLOUDFLARE_PROJECT_NAME }}.pages.dev
+      PREVIEW_BRANCH: ts-pr${{ github.event.pull_request.number }}
+      PREVIEW_URL: https://ts-pr${{ github.event.pull_request.number }}.${{ vars.CLOUDFLARE_PROJECT_NAME }}.pages.dev
     steps:
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/docs-preview-delivery.yml
+++ b/.github/workflows/docs-preview-delivery.yml
@@ -53,17 +53,20 @@ jobs:
             "$RUNNER_TEMP/workflow-run.json" > /dev/null
           run_head_branch=$(jq -er '.head_branch' "$RUNNER_TEMP/workflow-run.json")
           run_head_repository=$(jq -er '.head_repository.full_name' "$RUNNER_TEMP/workflow-run.json")
+          run_head_sha=$(jq -er '.head_sha' "$RUNNER_TEMP/workflow-run.json")
+          [[ "$run_head_sha" =~ ^[0-9a-f]{40,64}$ ]]
 
           pr_number=$(tr -d '[:space:]' < "$RUNNER_TEMP/docs-preview/docs-preview-pr.txt")
           head_sha=$(tr -d '[:space:]' < "$RUNNER_TEMP/docs-preview/docs-preview-sha.txt")
           [[ "$pr_number" =~ ^[1-9][0-9]*$ ]]
           [[ "$head_sha" =~ ^[0-9a-f]{40,64}$ ]]
+          [[ "$head_sha" == "$run_head_sha" ]]
 
           gh api "repos/$GITHUB_REPOSITORY/pulls/$pr_number" > "$RUNNER_TEMP/pull-request.json"
           if ! jq -e \
             --arg branch "$run_head_branch" \
             --arg repository "$run_head_repository" \
-            --arg sha "$head_sha" \
+            --arg sha "$run_head_sha" \
             '.state == "open" and .head.ref == $branch and .head.repo.full_name == $repository and .head.sha == $sha' \
             "$RUNNER_TEMP/pull-request.json" > /dev/null; then
             echo 'deploy=false' >> "$GITHUB_OUTPUT"

--- a/.github/workflows/docs-preview-delivery.yml
+++ b/.github/workflows/docs-preview-delivery.yml
@@ -1,0 +1,225 @@
+name: Docs Preview Delivery
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: Successful Docs Preview workflow run ID
+        required: true
+        type: string
+  workflow_run:
+    workflows: [Docs Preview]
+    types: [completed]
+  pull_request_target:
+    types: [closed, unlabeled]
+
+permissions: {}
+
+jobs:
+  deploy:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success')
+    runs-on: ubuntu-latest
+    concurrency:
+      group: docs-preview-delivery-${{ github.event_name == 'workflow_run' && format('{0}-{1}', github.event.workflow_run.head_repository.full_name, github.event.workflow_run.head_branch) || format('manual-{0}', inputs.run_id) }}
+      cancel-in-progress: false
+    permissions:
+      actions: read
+      contents: read
+      deployments: write
+      pull-requests: write
+    steps:
+      - name: Download docs artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: docs-preview
+          path: ${{ runner.temp }}/docs-preview
+          run-id: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.id || inputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Authorize deployment
+        id: authorize
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.id || inputs.run_id }}
+        run: |
+          [[ "$RUN_ID" =~ ^[1-9][0-9]*$ ]]
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID" > "$RUNNER_TEMP/workflow-run.json"
+          jq -e \
+            '.name == "Docs Preview" and .event == "pull_request" and .conclusion == "success"' \
+            "$RUNNER_TEMP/workflow-run.json" > /dev/null
+          run_head_branch=$(jq -er '.head_branch' "$RUNNER_TEMP/workflow-run.json")
+          run_head_repository=$(jq -er '.head_repository.full_name' "$RUNNER_TEMP/workflow-run.json")
+
+          pr_number=$(tr -d '[:space:]' < "$RUNNER_TEMP/docs-preview/docs-preview-pr.txt")
+          head_sha=$(tr -d '[:space:]' < "$RUNNER_TEMP/docs-preview/docs-preview-sha.txt")
+          [[ "$pr_number" =~ ^[1-9][0-9]*$ ]]
+          [[ "$head_sha" =~ ^[0-9a-f]{40,64}$ ]]
+
+          gh api "repos/$GITHUB_REPOSITORY/pulls/$pr_number" > "$RUNNER_TEMP/pull-request.json"
+          if ! jq -e \
+            --arg branch "$run_head_branch" \
+            --arg repository "$run_head_repository" \
+            --arg sha "$head_sha" \
+            '.state == "open" and .head.ref == $branch and .head.repo.full_name == $repository and .head.sha == $sha' \
+            "$RUNNER_TEMP/pull-request.json" > /dev/null; then
+            echo 'deploy=false' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "pr-number=$pr_number" >> "$GITHUB_OUTPUT"
+          if jq -e '(.head.repo.full_name == .base.repo.full_name) or any(.labels[]?; .name == "docs-preview")' \
+            "$RUNNER_TEMP/pull-request.json" > /dev/null; then
+            echo 'deploy=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'deploy=false' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set preview details
+        if: steps.authorize.outputs.deploy == 'true'
+        env:
+          PR_NUMBER: ${{ steps.authorize.outputs.pr-number }}
+        run: |
+          echo "PREVIEW_BRANCH=pr${PR_NUMBER}-ts-fsrs" >> "$GITHUB_ENV"
+          echo "PREVIEW_URL=https://pr${PR_NUMBER}-ts-fsrs.${{ vars.CLOUDFLARE_PROJECT_NAME }}.pages.dev" >> "$GITHUB_ENV"
+
+      - name: Validate static artifact
+        if: steps.authorize.outputs.deploy == 'true'
+        run: |
+          test -f "$RUNNER_TEMP/docs-preview/index.html"
+          test -z "$(find "$RUNNER_TEMP/docs-preview" -type l -print -quit)"
+          test ! -e "$RUNNER_TEMP/docs-preview/_worker.js"
+          rm \
+            "$RUNNER_TEMP/docs-preview/docs-preview-pr.txt" \
+            "$RUNNER_TEMP/docs-preview/docs-preview-sha.txt"
+
+      - name: Comment deployment started
+        if: steps.authorize.outputs.deploy == 'true'
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        with:
+          number_force: ${{ steps.authorize.outputs.pr-number }}
+          header: docs-preview
+          message: |
+            ### Docs Preview
+
+            - Status: Deploying
+            - Preview URL: [${{ env.PREVIEW_URL }}](${{ env.PREVIEW_URL }})
+
+      - name: Deploy Cloudflare Pages preview
+        id: deploy
+        if: steps.authorize.outputs.deploy == 'true'
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          wranglerVersion: '4.125.0'
+          command: >-
+            pages deploy ${{ runner.temp }}/docs-preview
+            --project-name=${{ vars.CLOUDFLARE_PROJECT_NAME }}
+            --branch=${{ env.PREVIEW_BRANCH }}
+
+      - name: Comment deployment complete
+        if: steps.authorize.outputs.deploy == 'true'
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        with:
+          number_force: ${{ steps.authorize.outputs.pr-number }}
+          header: docs-preview
+          message: |
+            ### Docs Preview
+
+            - Status: Deployed
+            - Preview URL: [${{ env.PREVIEW_URL }}](${{ env.PREVIEW_URL }})
+
+      - name: Comment deployment failed
+        if: failure() && steps.deploy.conclusion == 'failure'
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        with:
+          number_force: ${{ steps.authorize.outputs.pr-number }}
+          header: docs-preview
+          message: |
+            ### Docs Preview
+
+            - Status: Deployment failed
+            - Preview URL: [${{ env.PREVIEW_URL }}](${{ env.PREVIEW_URL }})
+
+  cleanup:
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      (github.event.action == 'closed' ||
+      (github.event.action == 'unlabeled' && github.event.label.name == 'docs-preview'))
+    runs-on: ubuntu-latest
+    concurrency:
+      group: docs-preview-delivery-${{ github.event.pull_request.head.repo.full_name }}-${{ github.event.pull_request.head.ref }}
+      cancel-in-progress: true
+    permissions:
+      pull-requests: write
+    env:
+      CLOUDFLARE_PROJECT_NAME: ${{ vars.CLOUDFLARE_PROJECT_NAME }}
+      PREVIEW_BRANCH: pr${{ github.event.pull_request.number }}-ts-fsrs
+      PREVIEW_URL: https://pr${{ github.event.pull_request.number }}-ts-fsrs.${{ vars.CLOUDFLARE_PROJECT_NAME }}.pages.dev
+    steps:
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 26
+
+      - name: Replace preview and delete old deployments
+        id: cleanup
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          endpoint="https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$CLOUDFLARE_PROJECT_NAME/deployments"
+          deployments=()
+          page=1
+          while true; do
+            response="$RUNNER_TEMP/deployments-$page.json"
+            curl --fail --silent --show-error "$endpoint?page=$page&per_page=100" \
+              --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+              --output "$response"
+            jq -e '.success' "$response" > /dev/null
+            mapfile -t page_deployments < <(
+              jq -r --arg branch "$PREVIEW_BRANCH" \
+                '.result[] | select(.deployment_trigger.metadata.branch == $branch) | .id' \
+                "$response"
+            )
+            deployments+=("${page_deployments[@]}")
+            total_pages=$(jq -r '.result_info.total_pages // 1' "$response")
+            ((page >= total_pages)) && break
+            ((page += 1))
+          done
+
+          if ((${#deployments[@]} == 0)); then
+            echo 'cleaned=false' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          mkdir -p "$RUNNER_TEMP/closed-preview"
+          printf '<!doctype html><title>Preview closed</title><p>This pull request preview has expired.</p>\n' \
+            > "$RUNNER_TEMP/closed-preview/index.html"
+          npx --yes wrangler@4.125.0 pages deploy "$RUNNER_TEMP/closed-preview" \
+            --project-name="$CLOUDFLARE_PROJECT_NAME" \
+            --branch="$PREVIEW_BRANCH"
+
+          for deployment in "${deployments[@]}"; do
+            curl --fail --silent --show-error \
+              --request DELETE "$endpoint/$deployment?force=true" \
+              --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" |
+              jq -e '.success' > /dev/null
+          done
+          echo 'cleaned=true' >> "$GITHUB_OUTPUT"
+
+      - name: Comment cleanup complete
+        if: steps.cleanup.outputs.cleaned == 'true'
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        with:
+          header: docs-preview
+          message: |
+            ### Docs Preview
+
+            - Status: Cleaned
+            - Preview URL: [${{ env.PREVIEW_URL }}](${{ env.PREVIEW_URL }})


### PR DESCRIPTION
## Background

The documentation work currently lives on a preview-based stack and is not yet present on main. After FSRS-7 development is complete and the documentation has been fully written, the complete docs changes will be brought into main through the project's cherry-pick flow. Until then, GitHub cannot register Docs Preview Delivery because workflow_run and workflow_dispatch workflows must exist on the default branch.

This small bootstrap PR moves only the trusted delivery controller into main ahead of the later documentation cherry-pick. It does not bring the Rspress site or package changes into main. Once merged, the controller can receive Docs Preview completion events from the current preview work and can redeploy a verified successful run by run_id. When FSRS-7 development and the full documentation are complete, the docs changes will be cherry-picked into main while keeping this already-established workflow.

## Summary

- register the trusted Docs Preview Delivery workflow on the default branch
- deploy successful Docs Preview artifacts automatically through workflow_run
- allow maintainers to retry a successful Docs Preview run manually with workflow_dispatch and run_id
- retain PR, head SHA, repository, label, and static artifact validation before Cloudflare deployment

## Validation

- YAML parsing
- embedded Bash syntax checks
- git diff --check

Refs #373, #481