### PR TITLE
fix(fsrs): preserve second precision for learning steps

### DIFF
--- a/.changeset/preserve-learning-step-seconds.md
+++ b/.changeset/preserve-learning-step-seconds.md
@@ -1,0 +1,5 @@
+---
+"ts-fsrs": patch
+---
+
+fix(fsrs): preserve second precision for learning-step intervals from 1 second through sub-day durations.

--- a/packages/fsrs/src/legacy/__tests__/middlewares/learning-steps/legacy.spec.ts
+++ b/packages/fsrs/src/legacy/__tests__/middlewares/learning-steps/legacy.spec.ts
@@ -20,7 +20,7 @@ describe('legacy FSRS learning-steps integration', () => {
     expect(record[Rating.Again].card.due.getTime() - now.getTime()).toBe(60_000)
     expect(record[Rating.Hard].card.learning_steps).toBe(0)
     expect(record[Rating.Hard].card.due.getTime() - now.getTime()).toBe(
-      6 * 60_000
+      5.5 * 60_000
     )
     expect(record[Rating.Good].card.learning_steps).toBe(1)
     expect(record[Rating.Good].card.due.getTime() - now.getTime()).toBe(
@@ -116,12 +116,12 @@ describe('legacy FSRS learning-steps integration', () => {
     )
   })
 
-  it('rounds decimal minutes exactly as the legacy scheduler did', () => {
+  it('preserves second precision in decimal learning steps', () => {
     const scheduler = fsrs({ learning_steps: ['1.5m'] })
     const now = new Date(2022, 11, 29, 12, 30)
     const result = scheduler.next(createEmptyCard(now), now, Rating.Again)
 
-    expect(result.card.due.getTime() - now.getTime()).toBe(2 * 60_000)
+    expect(result.card.due.getTime() - now.getTime()).toBe(1.5 * 60_000)
     expect(result.card.scheduled_days).toBe(0)
   })
 

--- a/packages/fsrs/src/legacy/impl/basic_scheduler.ts
+++ b/packages/fsrs/src/legacy/impl/basic_scheduler.ts
@@ -23,6 +23,8 @@ import { calculateScheduleDays } from '@/middlewares/monotonic-interval/core.js'
 import { AbstractScheduler } from '../abstract_scheduler.js'
 import { StrategyMode, type TStrategyHandler } from '../strategies/index.js'
 
+const SECONDS_PER_MINUTE = 60
+
 export default class BasicScheduler extends AbstractScheduler {
   private readonly learningSteps: LearningStepsResolver
   private readonly learningStepsConfig: LearningStepsConfig
@@ -63,7 +65,10 @@ export default class BasicScheduler extends AbstractScheduler {
       )
       this.learningStepsResult = steps
     }
-    const scheduled_minutes = Math.max(0, steps[grade]?.scheduledMinutes ?? 0)
+    const scheduled_minutes =
+      Math.round(
+        Math.max(0, steps[grade]?.scheduledMinutes ?? 0) * SECONDS_PER_MINUTE
+      ) / SECONDS_PER_MINUTE
     const next_steps = Math.max(0, steps[grade]?.nextStep ?? 0)
     return {
       scheduled_minutes,
@@ -94,7 +99,7 @@ export default class BasicScheduler extends AbstractScheduler {
       nextCard.state = to_state
       nextCard.due = date_scheduler(
         this.review_time,
-        Math.round(scheduled_minutes) as int,
+        scheduled_minutes,
         false /** true:days false: minute */
       )
     } else {
@@ -103,7 +108,7 @@ export default class BasicScheduler extends AbstractScheduler {
         nextCard.learning_steps = next_steps
         nextCard.due = date_scheduler(
           this.review_time,
-          Math.round(scheduled_minutes) as int,
+          scheduled_minutes,
           false /** true:days false: minute */
         )
         nextCard.scheduled_days = Math.floor(scheduled_minutes / 1440)

--- a/packages/fsrs/src/middlewares/learning-steps/core.spec.ts
+++ b/packages/fsrs/src/middlewares/learning-steps/core.spec.ts
@@ -49,12 +49,12 @@ describe('calculateLearningSteps', () => {
 
     expect(calculateLearningSteps(params, State.New, 0)).toEqual({
       [Rating.Again]: { scheduledMinutes: 1, nextStep: 0 },
-      [Rating.Hard]: { scheduledMinutes: 6, nextStep: 0 },
+      [Rating.Hard]: { scheduledMinutes: 5.5, nextStep: 0 },
       [Rating.Good]: { scheduledMinutes: 10, nextStep: 1 },
     })
     expect(calculateLearningSteps(params, State.Learning, 1)).toEqual({
       [Rating.Again]: { scheduledMinutes: 1, nextStep: 0 },
-      [Rating.Hard]: { scheduledMinutes: 6, nextStep: 1 },
+      [Rating.Hard]: { scheduledMinutes: 5.5, nextStep: 1 },
     })
   })
 
@@ -63,7 +63,7 @@ describe('calculateLearningSteps', () => {
 
     expect(calculateLearningSteps(params, State.Learning, 0)).toEqual({
       [Rating.Again]: { scheduledMinutes: 1, nextStep: 0 },
-      [Rating.Hard]: { scheduledMinutes: 2, nextStep: 0 },
+      [Rating.Hard]: { scheduledMinutes: 1.5, nextStep: 0 },
     })
     expect(calculateLearningSteps(params, State.Learning, 1)).toEqual({})
   })
@@ -93,7 +93,7 @@ describe('calculateLearningSteps', () => {
   it('uses the first step for a negative current step', () => {
     expect(calculateLearningSteps(config(['1m']), State.New, -1)).toEqual({
       [Rating.Again]: { scheduledMinutes: 1, nextStep: 0 },
-      [Rating.Hard]: { scheduledMinutes: 2, nextStep: -1 },
+      [Rating.Hard]: { scheduledMinutes: 1.5, nextStep: -1 },
       [Rating.Good]: { scheduledMinutes: 1, nextStep: 0 },
     })
   })
@@ -120,13 +120,13 @@ describe('calculateLearningSteps', () => {
     })
   })
 
-  it('preserves decimal Again intervals while rounding Hard and Good', () => {
+  it('preserves decimal intervals for all grades', () => {
     expect(
       calculateLearningSteps(config(['1.5m', '2.5m']), State.New, 0)
     ).toEqual({
       [Rating.Again]: { scheduledMinutes: 1.5, nextStep: 0 },
       [Rating.Hard]: { scheduledMinutes: 2, nextStep: 0 },
-      [Rating.Good]: { scheduledMinutes: 3, nextStep: 1 },
+      [Rating.Good]: { scheduledMinutes: 2.5, nextStep: 1 },
     })
   })
 })

--- a/packages/fsrs/src/middlewares/learning-steps/core.ts
+++ b/packages/fsrs/src/middlewares/learning-steps/core.ts
@@ -73,8 +73,8 @@ export const calculateLearningSteps: LearningStepsResolver = (
     stepsLength > 1 ? ConvertStepUnitToMinutes(steps[1]) : undefined
   const hardMinutes =
     secondMinutes === undefined
-      ? Math.round(firstMinutes * 1.5)
-      : Math.round((firstMinutes + secondMinutes) / 2)
+      ? firstMinutes * 1.5
+      : (firstMinutes + secondMinutes) / 2
   const result: LearningStepsResult = {
     [Rating.Again]: {
       scheduledMinutes: firstMinutes,
@@ -94,7 +94,7 @@ export const calculateLearningSteps: LearningStepsResolver = (
         : ConvertStepUnitToMinutes(nextStepUnit)
     if (nextMinutes > 0) {
       result[Rating.Good] = {
-        scheduledMinutes: Math.round(nextMinutes),
+        scheduledMinutes: nextMinutes,
         nextStep: learningStep + 1,
       }
     }

--- a/packages/fsrs/src/middlewares/learning-steps/middleware.spec.ts
+++ b/packages/fsrs/src/middlewares/learning-steps/middleware.spec.ts
@@ -63,7 +63,7 @@ describe('schedulerLearningStepsMiddleware integration', () => {
     const hard = previews.get(Rating.Hard)!
     expect(hard.card.state).toBe(State.Learning)
     expect(hard.card.learningStep).toBe(0)
-    expect(hard.card.dueAt.getTime() - now.getTime()).toBe(6 * 60_000)
+    expect(hard.card.dueAt.getTime() - now.getTime()).toBe(5.5 * 60_000)
 
     const good = previews.get(Rating.Good)!
     expect(good.card.state).toBe(State.Learning)
@@ -210,11 +210,11 @@ describe('schedulerLearningStepsMiddleware integration', () => {
   })
 
   it.each([
-    ['0.6m', State.Learning, 'learning', 1],
-    ['1439.4m', State.Learning, 'learning', 1439],
-    ['1439.6m', State.Review, 'review', 1440],
+    ['0.6m', State.Learning, 'learning', 0.6],
+    ['1439.4m', State.Learning, 'learning', 1439.4],
+    ['1439.6m', State.Learning, 'learning', 1439.6],
     ['1440m', State.Review, 'review', 1440],
-  ] as const)('rounds %s before applying the day threshold', (step, state, scheduleStatus, scheduledMinutes) => {
+  ] as const)('preserves second precision before applying the day threshold', (step, state, scheduleStatus, scheduledMinutes) => {
     const core = createCore({ learningSteps: [step] })
     const now = new Date(2022, 11, 29, 12, 30)
     const result = core.review({
@@ -247,8 +247,7 @@ describe('schedulerLearningStepsMiddleware integration', () => {
 
   it.each([
     '0m',
-    '0.4m',
-  ] as const)('falls back to the model interval when %s rounds to zero minutes', (step) => {
+  ] as const)('falls back to the model interval when %s has no positive duration', (step) => {
     const core = createCore({ learningSteps: [step] })
     const now = new Date(2022, 11, 29, 12, 30)
     const result = core.review({
@@ -264,8 +263,51 @@ describe('schedulerLearningStepsMiddleware integration', () => {
   })
 
   it.each([
+    ['0.017m', 1_000],
+    ['0.1m', 6_000],
+    ['0.4m', 24_000],
+  ] as const)('schedules %s with second precision instead of using the model interval', (step, expectedDelay) => {
+    const core = createCore({ learningSteps: [step] })
+    const now = new Date(2022, 11, 29, 12, 30)
+    const nextInterval = vi.spyOn(core.model, 'nextInterval')
+    const result = core.review({
+      card: core.newCard({ now }),
+      grade: Rating.Again,
+      now,
+    })
+
+    expect(result.card.state).toBe(State.Learning)
+    expect(result.card.scheduleStatus).toBe('learning')
+    expect(result.card.learningStep).toBe(0)
+    expect(result.card.dueAt.getTime() - now.getTime()).toBe(expectedDelay)
+    expect(nextInterval).not.toHaveBeenCalled()
+  })
+  it('keeps a sub-day relearning step in the relearning state', () => {
+    const core = createCore({ relearningSteps: ['1439.6m'] })
+    const now = new Date(2022, 11, 29, 12, 30)
+    const reviewed = core.review({
+      card: core.newCard({ now }),
+      grade: Rating.Easy,
+      now,
+    })
+    const nextInterval = vi.spyOn(core.model, 'nextInterval')
+    const result = core.review({
+      card: reviewed.card,
+      grade: Rating.Again,
+      now: reviewed.card.dueAt,
+    })
+
+    expect(result.card.state).toBe(State.Relearning)
+    expect(result.card.scheduleStatus).toBe('learning')
+    expect(result.card.learningStep).toBe(0)
+    expect(result.card.dueAt.getTime() - reviewed.card.dueAt.getTime()).toBe(
+      1439.6 * 60_000
+    )
+    expect(nextInterval).not.toHaveBeenCalled()
+  })
+
+  it.each([
     ['zero-minute', ['0m'], 0],
-    ['rounded zero-minute', ['0.4m', '0.4m'], 0],
     ['empty', [], 0],
     ['exhausted', ['1m'], 1],
   ] as const)('uses raw model intervals without monotonic middleware for %s steps', (_name, steps, learningStep) => {

--- a/packages/fsrs/src/middlewares/learning-steps/middleware.ts
+++ b/packages/fsrs/src/middlewares/learning-steps/middleware.ts
@@ -13,6 +13,7 @@ import {
 import type { LearningStepSchedule, LearningStepsResult } from './types.js'
 
 const MINUTES_PER_DAY = 1440
+const SECONDS_PER_MINUTE = 60
 const resolvedStepsSymbol = Symbol('ts-fsrs.learning-steps.resolved')
 
 type ResolvedLearningSteps = {
@@ -124,7 +125,9 @@ function getScheduledMinutes(
   const cached = resolved.scheduledMinutes[grade]
   if (cached !== undefined) return cached
 
-  const scheduledMinutes = Math.round(Math.max(0, step.scheduledMinutes))
+  const rawMinutes = Math.max(0, step.scheduledMinutes)
+  const scheduledMinutes =
+    Math.round(rawMinutes * SECONDS_PER_MINUTE) / SECONDS_PER_MINUTE
   resolved.scheduledMinutes[grade] = scheduledMinutes
   return scheduledMinutes
 }

--- a/packages/fsrs/src/middlewares/monotonic-interval/middleware.spec.ts
+++ b/packages/fsrs/src/middlewares/monotonic-interval/middleware.spec.ts
@@ -326,7 +326,7 @@ describe('schedulerMonotonicIntervalMiddleware integration', () => {
       preview.get(Rating.Again)!.card.dueAt.getTime() - now.getTime()
     ).toBe(60_000)
     expect(preview.get(Rating.Hard)!.card.dueAt.getTime() - now.getTime()).toBe(
-      6 * 60_000
+      5.5 * 60_000
     )
     expect(preview.get(Rating.Good)!.card.dueAt.getTime() - now.getTime()).toBe(
       10 * 60_000
@@ -368,8 +368,8 @@ describe('schedulerMonotonicIntervalMiddleware integration', () => {
     ['mixed-minute', ['0m', '10m'], 0, 100, [1440, 5, 10, 2880]],
     // Again 1d, Hard 2d, Good 3d, Easy 4d
     ['zero-minute', ['0m'], 0, 100, [1440, 2880, 4320, 5760]],
-    // Again 1d, Hard 2d, Good 3d, Easy 4d
-    ['rounded zero-minute', ['0.4m', '0.4m'], 0, 100, [1440, 2880, 4320, 5760]],
+    // Again 0.4m, Hard 0.4m, Good 0.4m, Easy 1d
+    ['sub-minute', ['0.4m', '0.4m'], 0, 100, [0.4, 0.4, 0.4, 1440]],
     // Again 1d, Hard 2d, Good 3d, Easy 4d
     ['empty', [], 0, 100, [1440, 2880, 4320, 5760]],
     // Again 1d, Hard 2d, Good 3d, Easy 4d

--- a/packages/fsrs/src/middlewares/scheduled-days/middleware.spec.ts
+++ b/packages/fsrs/src/middlewares/scheduled-days/middleware.spec.ts
@@ -109,7 +109,7 @@ describe('schedulerScheduledDaysMiddleware', () => {
     expect(result.card.scheduledDays).toBe(0)
   })
 
-  it('stores a rounded learning interval at the day threshold', () => {
+  it('stores a second-precision learning interval before the day threshold', () => {
     const core = defineScheduler({ model: FSRS6Model, chrono: dateChrono })
       .use(schedulerScheduledDaysMiddleware, schedulerLearningStepsMiddleware)
       .create({
@@ -128,9 +128,10 @@ describe('schedulerScheduledDaysMiddleware', () => {
       now,
     })
 
-    expect(result.card.state).toBe(State.Review)
-    expect(result.card.scheduledDays).toBe(1)
-    expect(result.card.dueAt.getTime() - now.getTime()).toBe(1440 * 60_000)
+    expect(result.card.state).toBe(State.Learning)
+    expect(result.card.scheduleStatus).toBe('learning')
+    expect(result.card.scheduledDays).toBe(0)
+    expect(result.card.dueAt.getTime() - now.getTime()).toBe(1439.6 * 60_000)
   })
 
   it('restores scheduledDays during rollback', () => {

--- a/packages/fsrs/src/scheduler/default-scheduler.legacy-parity.spec.ts
+++ b/packages/fsrs/src/scheduler/default-scheduler.legacy-parity.spec.ts
@@ -335,7 +335,7 @@ describe('DefaultScheduler legacy parity', () => {
       expect(scheduler.rollback(actual).scheduledDays).toBe(scheduledDays)
     })
 
-    it('keeps scheduledDays aligned with the rounded learning-step due', async () => {
+    it('keeps scheduledDays aligned with the second-precision learning-step due', async () => {
       const options = {
         enableShortTerm: true,
         learningSteps: ['23.999h'],
@@ -343,9 +343,15 @@ describe('DefaultScheduler legacy parity', () => {
       } satisfies DefaultSchedulerOptions
       const scheduler = await DefaultScheduler(options)
 
-      for (const [state, expectedDays] of [
-        [State.New, 1],
-        [State.Review, 2],
+      for (const [
+        state,
+        expectedSeconds,
+        expectedDays,
+        expectedState,
+        expectedScheduleStatus,
+      ] of [
+        [State.New, 86_396, 0, State.Learning, 'learning'],
+        [State.Review, 172_796, 1, State.Review, 'review'],
       ] as const) {
         const card = createStateCard(state)
         const actual = scheduler.review({
@@ -356,10 +362,12 @@ describe('DefaultScheduler legacy parity', () => {
         const legacy = legacyReview(options, card, NOW, Rating.Again)
 
         expect(actual.card.dueAt.getTime() - NOW.getTime()).toBe(
-          expectedDays * DAY
+          expectedSeconds * 1_000
         )
         expect(actual.card.scheduledDays).toBe(expectedDays)
-        expect(legacy.card.scheduledDays).toBe(expectedDays - 1)
+        expect(actual.card.state).toBe(expectedState)
+        expect(actual.card.scheduleStatus).toBe(expectedScheduleStatus)
+        expect(legacy.card.scheduledDays).toBe(expectedDays)
       }
     })
   })


### PR DESCRIPTION
## Summary

- preserve learning-step intervals with one-second precision
- keep 0.017m–0.4m steps out of FSRS interval fallback
- apply the same precision to Hard/Good and the legacy scheduler
- add a patch changeset and regression coverage

## Verification

- `pnpm --filter ts-fsrs test`
- `pnpm --filter ts-fsrs typecheck`
- `pnpm --filter ts-fsrs check`
- `git diff --check`