### PR TITLE
fix(fsrs): incorrect clamping of w[19] when migrating

### DIFF
--- a/.changeset/twenty-beds-sniff.md
+++ b/.changeset/twenty-beds-sniff.md
@@ -1,0 +1,5 @@
+---
+"ts-fsrs": patch
+---
+
+fix(migrateParameters): condition lower clamp for w[19] on the value of enable_short_term when migrating from v5 (length 19) weights

--- a/.changeset/twenty-beds-sniff.md
+++ b/.changeset/twenty-beds-sniff.md
@@ -2,4 +2,4 @@
 "ts-fsrs": patch
 ---
 
-fix(migrateParameters): condition lower clamp for w[19] on the value of enable_short_term when migrating from v5 (length 19) weights
+fix(fsrs): clip parameters after migrating

--- a/packages/fsrs/__tests__/FSRS-5.test.ts
+++ b/packages/fsrs/__tests__/FSRS-5.test.ts
@@ -59,7 +59,7 @@ describe('FSRS-5', () => {
       scheduling_cards = f.repeat(card, now)
     }
     expect(ivl_history).toEqual([
-      0, 4, 14, 44, 125, 328, 0, 0, 7, 16, 34, 71, 142,
+      0, 4, 14, 44, 125, 328, 0, 0, 6, 14, 31, 65, 130,
     ])
   })
 
@@ -95,7 +95,7 @@ describe('FSRS-5', () => {
     it('memory state[short-term]', () => {
       const f = fsrs({ w, enable_short_term: true })
       console.debug('memory state[short-term] weight', f.parameters.w)
-      assertMemoryState(f, 'short-term', 48.26549438, 7.10441712)
+      assertMemoryState(f, 'short-term', 48.27115294, 7.10441712)
     })
     it('memory state[long-term]', () => {
       const f = fsrs({ w, enable_short_term: false })

--- a/packages/fsrs/__tests__/default.test.ts
+++ b/packages/fsrs/__tests__/default.test.ts
@@ -79,6 +79,10 @@ describe('default params', () => {
     expect(fsrs({ ...params, enable_short_term: false }).parameters.w[19]).toBe(
       0
     )
+
+    const f = fsrs({ enable_short_term: true })
+    f.parameters.w = w
+    expect(f.parameters.w[19]).toBe(0.01)
   })
 
   it('revert to default params', () => {

--- a/packages/fsrs/__tests__/default.test.ts
+++ b/packages/fsrs/__tests__/default.test.ts
@@ -43,12 +43,13 @@ describe('default params', () => {
   })
 
   it('convert FSRS-5 to FSRS-6', () => {
+    const w = [
+      0.40255, 1.18385, 3.173, 15.69105, 7.1949, 0.5345, 1.4604, 0.0046,
+      1.54575, 0.1192, 1.01925, 1.9395, 0.11, 0.29605, 2.2698, 0.2315, 2.9898,
+      0.51655, 0.6621,
+    ]
     const params = generatorParameters({
-      w: [
-        0.40255, 1.18385, 3.173, 15.69105, 7.1949, 0.5345, 1.4604, 0.0046,
-        1.54575, 0.1192, 1.01925, 1.9395, 0.11, 0.29605, 2.2698, 0.2315, 2.9898,
-        0.51655, 0.6621,
-      ],
+      w,
     })
     expect(params.w).toEqual([
       0.40255,
@@ -73,6 +74,11 @@ describe('default params', () => {
       0.0,
       FSRS5_DEFAULT_DECAY,
     ])
+    expect(fsrs({ w, enable_short_term: true }).parameters.w[19]).toBe(0.01)
+    expect(fsrs(params).parameters.w[19]).toBe(0.01)
+    expect(fsrs({ ...params, enable_short_term: false }).parameters.w[19]).toBe(
+      0
+    )
   })
 
   it('revert to default params', () => {

--- a/packages/fsrs/__tests__/fixed/calc-elapsed-days.test.ts
+++ b/packages/fsrs/__tests__/fixed/calc-elapsed-days.test.ts
@@ -21,7 +21,7 @@ test('TS-FSRS-Simulator', () => {
   })
   const rids = [1704468957000, 1704469645000, 1704599572000, 1705509507000]
 
-  const expected = [13.1205, 17.3668145, 21.28550751, 39.63452215]
+  const expected = [13.1205, 16.92546705, 20.85552323, 39.23212599]
   let card = createEmptyCard(new Date(rids[0]))
   const grades: Grade[] = [Rating.Good, Rating.Good, Rating.Good, Rating.Good]
   for (let i = 0; i < rids.length; i++) {
@@ -75,7 +75,7 @@ test('SSE use next_state', () => {
     )
     memoryState = nextStates
   }
-  expect(memoryState?.stability).toBeCloseTo(71.77)
+  expect(memoryState?.stability).toBeCloseTo(66.75687516)
 })
 
 test.skip('SSE 71.77', () => {

--- a/packages/fsrs/src/algorithm.ts
+++ b/packages/fsrs/src/algorithm.ts
@@ -1,6 +1,10 @@
 import { alea } from './alea'
-import { default_enable_short_term, default_relearning_steps, S_MIN } from './constant'
-import { clipParameters, generatorParameters, migrateParameters } from './default'
+import { S_MIN } from './constant'
+import {
+  clipParameters,
+  generatorParameters,
+  migrateParameters,
+} from './default'
 import { FSRSValidationError } from './error'
 import { clamp, get_fuzz_range, roundTo } from './help'
 import {
@@ -61,13 +65,8 @@ export class FSRSAlgorithm {
 
   constructor(params: Partial<FSRSParameters>) {
     this.param = new Proxy(
-      generatorParameters(params),
+      this.prepare_parameters(params),
       this.params_handler_proxy()
-    )
-    this.param.w = clipParameters(
-      Array.from(this.param.w),
-      this.param.relearning_steps?.length ?? default_relearning_steps.length,
-      this.param.enable_short_term ?? default_enable_short_term
     )
     this.intervalModifier = this.calculate_interval_modifier(
       this.param.request_retention
@@ -150,17 +149,24 @@ export class FSRSAlgorithm {
   }
 
   private update_parameters(params: Partial<FSRSParameters>): void {
-    const _params = generatorParameters(params)
-    _params.w = clipParameters(
-      Array.from(_params.w),
-      params.relearning_steps?.length ?? default_relearning_steps.length,
-      params.enable_short_term ?? default_enable_short_term
-    )
+    const _params = this.prepare_parameters(params)
     for (const key in _params) {
       // All keys in _params are guaranteed to exist in this.param due to generatorParameters()
       const paramKey = key as keyof FSRSParameters
       this.param[paramKey] = _params[paramKey] as never
     }
+  }
+
+  private prepare_parameters = (
+    params: Partial<FSRSParameters>
+  ): FSRSParameters => {
+    const generated = generatorParameters(params)
+    generated.w = clipParameters(
+      Array.from(generated.w),
+      generated.relearning_steps.length,
+      generated.enable_short_term
+    )
+    return generated
   }
 
   /**

--- a/packages/fsrs/src/algorithm.ts
+++ b/packages/fsrs/src/algorithm.ts
@@ -1,6 +1,6 @@
 import { alea } from './alea'
-import { S_MIN } from './constant'
-import { generatorParameters, migrateParameters } from './default'
+import { default_enable_short_term, default_relearning_steps, S_MIN } from './constant'
+import { clipParameters, generatorParameters, migrateParameters } from './default'
 import { FSRSValidationError } from './error'
 import { clamp, get_fuzz_range, roundTo } from './help'
 import {
@@ -63,6 +63,11 @@ export class FSRSAlgorithm {
     this.param = new Proxy(
       generatorParameters(params),
       this.params_handler_proxy()
+    )
+    this.param.w = clipParameters(
+      Array.from(this.param.w),
+      this.param.relearning_steps?.length ?? default_relearning_steps.length,
+      this.param.enable_short_term ?? default_enable_short_term
     )
     this.intervalModifier = this.calculate_interval_modifier(
       this.param.request_retention
@@ -128,6 +133,11 @@ export class FSRSAlgorithm {
             target.relearning_steps.length,
             target.enable_short_term
           )
+          value = clipParameters(
+            Array.from(value),
+            target.relearning_steps.length,
+            target.enable_short_term
+          )
           _this.forgetting_curve = forgetting_curve.bind(this, value)
           _this.intervalModifier = _this.calculate_interval_modifier(
             Number(target.request_retention)
@@ -141,6 +151,11 @@ export class FSRSAlgorithm {
 
   private update_parameters(params: Partial<FSRSParameters>): void {
     const _params = generatorParameters(params)
+    _params.w = clipParameters(
+      Array.from(_params.w),
+      params.relearning_steps?.length ?? default_relearning_steps.length,
+      params.enable_short_term ?? default_enable_short_term
+    )
     for (const key in _params) {
       // All keys in _params are guaranteed to exist in this.param due to generatorParameters()
       const paramKey = key as keyof FSRSParameters

--- a/packages/fsrs/src/default.ts
+++ b/packages/fsrs/src/default.ts
@@ -97,10 +97,10 @@ export const migrateParameters = (
     case 19:
       console.debug('[FSRS-6]auto fill w from 19 to 21 length')
       return clipParameters(
-        Array.from(parameters),
+        Array.from(parameters).concat([0.0, FSRS5_DEFAULT_DECAY]),
         numRelearningSteps,
         enableShortTerm
-      ).concat([0.0, FSRS5_DEFAULT_DECAY])
+      )
     case 17: {
       const w = clipParameters(
         Array.from(parameters),

--- a/packages/fsrs/src/default.ts
+++ b/packages/fsrs/src/default.ts
@@ -97,10 +97,10 @@ export const migrateParameters = (
     case 19:
       console.debug('[FSRS-6]auto fill w from 19 to 21 length')
       return clipParameters(
-        Array.from(parameters).concat([0.0, FSRS5_DEFAULT_DECAY]),
+        Array.from(parameters),
         numRelearningSteps,
         enableShortTerm
-      )
+      ).concat([0.0, FSRS5_DEFAULT_DECAY])
     case 17: {
       const w = clipParameters(
         Array.from(parameters),

--- a/packages/fsrs/src/fsrs.ts
+++ b/packages/fsrs/src/fsrs.ts
@@ -1,6 +1,6 @@
 import { FSRSAlgorithm, forgetting_curve } from './algorithm'
 import { TypeConvert } from './convert'
-import { createEmptyCard, migrateParameters } from './default'
+import { clipParameters, createEmptyCard, migrateParameters } from './default'
 import { FSRSValidationError } from './error'
 import { date_diff } from './help'
 import BasicScheduler from './impl/basic_scheduler'
@@ -133,6 +133,11 @@ export class FSRS extends FSRSAlgorithm implements IFSRS {
         } else if (prop === 'w') {
           value = migrateParameters(
             value as FSRSParameters['w'],
+            target.relearning_steps.length,
+            target.enable_short_term
+          )
+          value = clipParameters(
+            Array.from(value),
             target.relearning_steps.length,
             target.enable_short_term
           )


### PR DESCRIPTION
## Summary

w[19] is meant to have a floor of 0.01 when `enable_short_term` is true, but this clamp is not applied when migrating weights to FSRS-6.

## Related Issues

- Closes #485 

## Changes

When migrating, new weights are now appended before calling `clipParameters`, so that clamping is applied properly.

6 tests break with this change. Will add a commit fixing them after confirmation that this change is valid.

## Changeset

- [x] Added a changeset with `pnpm changeset`
- [ ] Not needed because this change does not affect published package behavior or contents

