### PR TITLE
fix(release): use Node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Setup Node & pnpm
         uses: ./.github/actions/setup-node-pnpm
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Run checks
         run: pnpm run check


### PR DESCRIPTION
## Summary

- run the release job with Node.js 24
- allow npm 12 to install during trusted publishing setup

## Validation

- parsed release.yml with Ruby Psych
- git diff --check