### PR TITLE
chore: update packageManager to pnpm@10.34.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,5 +60,5 @@
       "@napi-rs/cli": "patches/@napi-rs__cli.patch"
     }
   },
-  "packageManager": "pnpm@10.15.0+sha512.486ebc259d3e999a4e8691ce03b5cac4a71cbeca39372a9b762cb500cfdf0873e2cb16abe3d951b1ee2cf012503f027b98b6584e4df22524e0c7450d9ec7aa7b"
+  "packageManager": "pnpm@10.34.5+sha512.a4ee05f2f73658255bd6a89859c065a45c28a57daefae2c893a168ee2b73168c37b91e83e57ea67654ad03f03031746430e8bce38e362e042605fb8abc80192e"
 }


### PR DESCRIPTION
## Summary

- https://github.com/open-spaced-repetition/ts-fsrs/actions/runs/33460688050/job/99710527966
- https://github.com/pnpm/pnpm/blob/702ad5f860ffd50d64a3a711d9f8a3da16fc796e/releasing/plugin-commands-publishing/src/publish.ts#L22-L36

## Related Issues

- Closes #

## Changes

- 

## Changeset

- [ ] Added a changeset with `pnpm changeset`
- [ ] Not needed because this change does not affect published package behavior or contents

