### PR TITLE
feat(fsrs): support parameter clipping controls

### DIFF
--- a/.changeset/clip-model-parameters.md
+++ b/.changeset/clip-model-parameters.md
@@ -1,0 +1,6 @@
+---
+"ts-fsrs": patch
+"@open-spaced-repetition/srs-kit": patch
+---
+
+feat: separate model parameter migration, clipping, and validation

--- a/packages/fsrs/__tests__/constant.test.ts
+++ b/packages/fsrs/__tests__/constant.test.ts
@@ -5,6 +5,7 @@ import {
   default_request_retention,
   default_w,
   FSRS6_DEFAULT_DECAY,
+  fsrs,
   generatorParameters,
   W17_W18_Ceiling,
 } from 'ts-fsrs'
@@ -37,16 +38,16 @@ describe('default params', () => {
 
   it('clamp w to limit the minimum', () => {
     const w = Array.from({ length: 21 }, () => 0)
-    const params = generatorParameters({ w })
     const w_min = CLAMP_PARAMETERS(W17_W18_Ceiling).map((x) => x[0])
-    expect(params.w).toEqual(w_min)
+    expect(generatorParameters({ w }).w).toEqual(w)
+    expect(fsrs({ w }).parameters.w).toEqual(w_min)
   })
 
   it('clamp w to limit the maximum', () => {
     const w = Array.from({ length: 21 }, () => Number.MAX_VALUE)
-    const params = generatorParameters({ w })
     const w_max = CLAMP_PARAMETERS(W17_W18_Ceiling).map((x) => x[1])
-    expect(params.w).toEqual(w_max)
+    expect(generatorParameters({ w }).w).toEqual(w)
+    expect(fsrs({ w }).parameters.w).toEqual(w_max)
   })
 
   it('default w can not be overwritten', () => {

--- a/packages/fsrs/__tests__/default.test.ts
+++ b/packages/fsrs/__tests__/default.test.ts
@@ -125,9 +125,9 @@ describe('default params', () => {
     // enable short term = true
     expect(migrateFSRS6Parameters(params21)).toEqual(params21)
 
-    // enable short term = false
+    // migration is independent of short-term clipping
     params21[19] = 0
-    expect(migrateFSRS6Parameters(params21, 0, false)).toEqual(params21)
+    expect(migrateFSRS6Parameters(params21)).toEqual(params21)
 
     // parameters with length 19 (FSRS 5)
     const params19 = default_w.slice(0, 19)
@@ -170,14 +170,10 @@ describe('default params', () => {
       /^Invalid parameters length/
     )
 
-    const { w: NaNParams, relearning_steps } = generatorParameters()
+    const { w: NaNParams } = generatorParameters()
     // @ts-expect-error Simulate NaN in parameters
     NaNParams[0] = NaN
-    const expectedParams = [...default_w]
-    expectedParams[0] = 0
-    expect(migrateFSRS6Parameters(Array.from(NaNParams))).toEqual(
-      clipFSRS6Parameters(expectedParams, relearning_steps.length)
-    )
+    expect(migrateFSRS6Parameters(Array.from(NaNParams))).toEqual(NaNParams)
   })
 
   it('if num relearning steps > 1', () => {
@@ -226,12 +222,10 @@ describe('default params', () => {
   })
 
   it('single relearning step uses default ceiling of 2.0', () => {
-    const params = generatorParameters({
-      relearning_steps: ['10m'],
-      w: default_w.map((v, i) => (i === 17 || i === 18 ? 2.5 : v)),
-    })
-    expect(params.w[17]).toEqual(2.0)
-    expect(params.w[18]).toEqual(2.0)
+    const weights = default_w.map((v, i) => (i === 17 || i === 18 ? 2.5 : v))
+    const clipped = clipFSRS6Parameters(weights, 1)
+    expect(clipped[17]).toEqual(2.0)
+    expect(clipped[18]).toEqual(2.0)
   })
 
   it('negative value produces finite ceiling via sqrt guard', () => {

--- a/packages/fsrs/__tests__/default.test.ts
+++ b/packages/fsrs/__tests__/default.test.ts
@@ -45,12 +45,13 @@ describe('default params', () => {
   })
 
   it('convert FSRS-5 to FSRS-6', () => {
+    const w = [
+      0.40255, 1.18385, 3.173, 15.69105, 7.1949, 0.5345, 1.4604, 0.0046,
+      1.54575, 0.1192, 1.01925, 1.9395, 0.11, 0.29605, 2.2698, 0.2315, 2.9898,
+      0.51655, 0.6621,
+    ]
     const params = generatorParameters({
-      w: [
-        0.40255, 1.18385, 3.173, 15.69105, 7.1949, 0.5345, 1.4604, 0.0046,
-        1.54575, 0.1192, 1.01925, 1.9395, 0.11, 0.29605, 2.2698, 0.2315, 2.9898,
-        0.51655, 0.6621,
-      ],
+      w,
     })
     expect(params.w).toEqual([
       0.40255,
@@ -75,6 +76,15 @@ describe('default params', () => {
       0.0,
       FSRS5_DEFAULT_DECAY,
     ])
+    expect(fsrs({ w, enable_short_term: true }).parameters.w[19]).toBe(0.01)
+    expect(fsrs(params).parameters.w[19]).toBe(0.01)
+    expect(fsrs({ ...params, enable_short_term: false }).parameters.w[19]).toBe(
+      0
+    )
+
+    const f = fsrs({ enable_short_term: true })
+    f.parameters.w = w
+    expect(f.parameters.w[19]).toBe(0.01)
   })
 
   it('revert to default params', () => {

--- a/packages/fsrs/src/legacy/__tests__/FSRS-5.test.ts
+++ b/packages/fsrs/src/legacy/__tests__/FSRS-5.test.ts
@@ -1,25 +1,62 @@
 import {
   createEmptyCard,
+  dateChrono,
+  defineScheduler,
   FSRS,
-  fsrs,
   type Grade,
   Grades,
   generatorParameters,
   Rating,
   State,
 } from 'ts-fsrs'
+import {
+  schedulerDesiredRetentionMiddleware,
+  schedulerFuzzingMiddleware,
+  schedulerLearningStepsMiddleware,
+  schedulerMaximumIntervalMiddleware,
+  schedulerMonotonicIntervalMiddleware,
+  schedulerScheduledDaysMiddleware,
+  schedulerStatsMiddleware,
+} from 'ts-fsrs/middlewares'
+import { FSRS5Model } from 'ts-fsrs/models/fsrs-5'
+
+const w = [
+  0.40255, 1.18385, 3.173, 15.69105, 7.1949, 0.5345, 1.4604, 0.0046, 1.54575,
+  0.1192, 1.01925, 1.9395, 0.11, 0.29605, 2.2698, 0.2315, 2.9898, 0.51655,
+  0.6621,
+]
+
+const FSRS5Scheduler = defineScheduler({
+  model: FSRS5Model,
+  chrono: dateChrono,
+}).use(
+  schedulerDesiredRetentionMiddleware,
+  schedulerFuzzingMiddleware,
+  schedulerStatsMiddleware,
+  schedulerScheduledDaysMiddleware,
+  schedulerLearningStepsMiddleware,
+  schedulerMaximumIntervalMiddleware,
+  schedulerMonotonicIntervalMiddleware
+)
+
+const createFSRS5Scheduler = (enableShortTerm = true) =>
+  FSRS5Scheduler.create({
+    config: {
+      weights: w,
+      enableShortTerm,
+      desiredRetention: 0.9,
+      enableFuzz: false,
+      maximumInterval: 36500,
+      learningSteps: ['1m', '10m'],
+      relearningSteps: ['10m'],
+    },
+  })
 
 describe('FSRS-5', () => {
-  const w = [
-    0.40255, 1.18385, 3.173, 15.69105, 7.1949, 0.5345, 1.4604, 0.0046, 1.54575,
-    0.1192, 1.01925, 1.9395, 0.11, 0.29605, 2.2698, 0.2315, 2.9898, 0.51655,
-    0.6621,
-  ]
-  const f: FSRS = fsrs({ w })
+  const scheduler = createFSRS5Scheduler()
   it('ivl_history', () => {
-    let card = createEmptyCard()
     let now = new Date(2022, 11, 29, 12, 30, 0, 0)
-    let scheduling_cards = f.repeat(card, now)
+    let card = scheduler.newCard({ now })
     const ratings: Grade[] = [
       Rating.Good,
       Rating.Good,
@@ -37,24 +74,30 @@ describe('FSRS-5', () => {
     ]
     const ivl_history: number[] = []
     for (const rating of ratings) {
-      for (const check of Grades) {
-        const rollbackCard = f.rollback(
-          scheduling_cards[check].card,
-          scheduling_cards[check].log
-        )
+      let selectedCard = card
+      for (const schedulingCard of scheduler.preview({ card, now })) {
+        const check = schedulingCard.grade
+        const rollbackCard = scheduler.rollback({
+          card: schedulingCard.card,
+          revlog: schedulingCard.revlog,
+        })
         expect(rollbackCard).toEqual(card)
-        const _f = fsrs({ w })
-        const next = _f.next(card, now, check)
-        expect(scheduling_cards[check]).toEqual(next)
+        const next = scheduler.review({ card, now, grade: check })
+        expect({
+          card: schedulingCard.card,
+          revlog: schedulingCard.revlog,
+        }).toEqual(next)
+        if (check === rating) {
+          selectedCard = schedulingCard.card
+        }
       }
-      card = scheduling_cards[rating].card
-      const ivl = card.scheduled_days
+      card = selectedCard
+      const ivl = card.scheduledDays
       ivl_history.push(ivl)
-      now = card.due
-      scheduling_cards = f.repeat(card, now)
+      now = card.dueAt
     }
     expect(ivl_history).toEqual([
-      0, 4, 14, 44, 125, 328, 0, 0, 6, 14, 31, 65, 130,
+      0, 4, 14, 44, 125, 328, 0, 0, 7, 16, 34, 71, 142,
     ])
   })
 
@@ -69,18 +112,16 @@ describe('FSRS-5', () => {
     ]
     const intervals: number[] = [0, 0, 1, 3, 8, 21]
     function assertMemoryState(
-      f: FSRS,
-      text: string,
+      scheduler: ReturnType<typeof createFSRS5Scheduler>,
       expect_stability: number,
       expect_difficulty: number
     ) {
-      let card = createEmptyCard()
       let now = new Date(2022, 11, 29, 12, 30, 0, 0)
+      let card = scheduler.newCard({ now })
 
       for (const [index, rating] of ratings.entries()) {
         now = new Date(+now + intervals[index] * 24 * 60 * 60 * 1000)
-        card = f.next(card, now, rating).card
-        console.debug(text, index + 1, card.stability, card.difficulty)
+        card = scheduler.review({ card, now, grade: rating }).card
       }
 
       const { stability, difficulty } = card
@@ -88,21 +129,17 @@ describe('FSRS-5', () => {
       expect(difficulty).toBeCloseTo(expect_difficulty, 4)
     }
     it('memory state[short-term]', () => {
-      const f = fsrs({ w, enable_short_term: true })
-      console.debug('memory state[short-term] weight', f.parameters.w)
-      assertMemoryState(f, 'short-term', 48.27115294, 7.10441712)
+      assertMemoryState(createFSRS5Scheduler(true), 48.26549438, 7.10441712)
     })
     it('memory state[long-term]', () => {
-      const f = fsrs({ w, enable_short_term: false })
-      console.debug('memory state[long-term] weight', f.parameters.w)
-      assertMemoryState(f, 'long-term', 48.065163, 7.10441712)
+      assertMemoryState(createFSRS5Scheduler(false), 48.065163, 7.10441712)
     })
   })
 
   it('first repeat', () => {
-    const card = createEmptyCard()
     const now = new Date(2022, 11, 29, 12, 30, 0, 0)
-    const scheduling_cards = f.repeat(card, now)
+    const card = scheduler.newCard({ now })
+    const schedulingCards = scheduler.preview({ card, now })
 
     const stability: number[] = []
     const difficulty: number[] = []
@@ -110,13 +147,13 @@ describe('FSRS-5', () => {
     const reps: number[] = []
     const lapses: number[] = []
     const states: State[] = []
-    for (const item of scheduling_cards) {
+    for (const item of schedulingCards) {
       const first_card = item.card
       stability.push(first_card.stability)
       difficulty.push(first_card.difficulty)
       reps.push(first_card.reps)
       lapses.push(first_card.lapses)
-      scheduled_days.push(first_card.scheduled_days)
+      scheduled_days.push(first_card.scheduledDays)
       states.push(first_card.state)
     }
     expect(stability).toEqual([0.40255, 1.18385, 3.173, 15.69105])

--- a/packages/fsrs/src/legacy/__tests__/FSRS-5.test.ts
+++ b/packages/fsrs/src/legacy/__tests__/FSRS-5.test.ts
@@ -54,7 +54,7 @@ describe('FSRS-5', () => {
       scheduling_cards = f.repeat(card, now)
     }
     expect(ivl_history).toEqual([
-      0, 4, 14, 44, 125, 328, 0, 0, 7, 16, 34, 71, 142,
+      0, 4, 14, 44, 125, 328, 0, 0, 6, 14, 31, 65, 130,
     ])
   })
 
@@ -90,7 +90,7 @@ describe('FSRS-5', () => {
     it('memory state[short-term]', () => {
       const f = fsrs({ w, enable_short_term: true })
       console.debug('memory state[short-term] weight', f.parameters.w)
-      assertMemoryState(f, 'short-term', 48.26549438, 7.10441712)
+      assertMemoryState(f, 'short-term', 48.27115294, 7.10441712)
     })
     it('memory state[long-term]', () => {
       const f = fsrs({ w, enable_short_term: false })

--- a/packages/fsrs/src/legacy/__tests__/fixed/calc-elapsed-days.test.ts
+++ b/packages/fsrs/src/legacy/__tests__/fixed/calc-elapsed-days.test.ts
@@ -21,7 +21,7 @@ test('TS-FSRS-Simulator', () => {
   })
   const rids = [1704468957000, 1704469645000, 1704599572000, 1705509507000]
 
-  const expected = [13.1205, 17.3668145, 21.28550751, 39.63452215]
+  const expected = [13.1205, 16.92546705, 20.85552323, 39.23212599]
   let card = createEmptyCard(new Date(rids[0]))
   const grades: Grade[] = [Rating.Good, Rating.Good, Rating.Good, Rating.Good]
   for (let i = 0; i < rids.length; i++) {
@@ -80,7 +80,7 @@ test('SSE use next_state', () => {
     )
     memoryState = nextStates
   }
-  expect(memoryState?.stability).toBeCloseTo(71.77)
+  expect(memoryState?.stability).toBeCloseTo(66.75687516)
 })
 
 test.skip('SSE 71.77', () => {

--- a/packages/fsrs/src/legacy/__tests__/fixed/calc-elapsed-days.test.ts
+++ b/packages/fsrs/src/legacy/__tests__/fixed/calc-elapsed-days.test.ts
@@ -1,44 +1,55 @@
 import {
-  createEmptyCard,
-  dateDiffInDays,
-  type FSRSState,
-  fsrs,
+  defineScheduler,
   type Grade,
   Rating,
-} from 'ts-fsrs'
+} from '@open-spaced-repetition/srs-kit'
+import { dateChrono } from '@open-spaced-repetition/srs-kit/chrono/date'
+import { FSRS6Model, migrateFSRS6Parameters } from '@/models/fsrs-6/index.js'
+
+const FSRS6Scheduler = defineScheduler({
+  model: FSRS6Model,
+  chrono: dateChrono,
+})
 
 /**
  * @see https://forums.ankiweb.net/t/feature-request-estimated-total-knowledge-over-time/53036/58?u=l.m.sherlock
  * @see https://ankiweb.net/shared/info/1613056169
  */
 test('TS-FSRS-Simulator', () => {
-  const f = fsrs({
-    w: [
-      1.1596, 1.7974, 13.1205, 49.3729, 7.2303, 0.5081, 1.5371, 0.001, 1.5052,
-      0.1261, 0.9735, 1.8924, 0.1486, 0.2407, 2.1937, 0.1518, 3.0699, 0.4636,
-      0.6048,
-    ],
+  const scheduler = FSRS6Scheduler.create({
+    config: {
+      weights: migrateFSRS6Parameters([
+        1.1596, 1.7974, 13.1205, 49.3729, 7.2303, 0.5081, 1.5371, 0.001, 1.5052,
+        0.1261, 0.9735, 1.8924, 0.1486, 0.2407, 2.1937, 0.1518, 3.0699, 0.4636,
+        0.6048,
+      ]),
+      enableShortTerm: true,
+      numRelearningSteps: 1,
+    },
   })
   const rids = [1704468957000, 1704469645000, 1704599572000, 1705509507000]
 
-  const expected = [13.1205, 16.92546705, 20.85552323, 39.23212599]
-  let card = createEmptyCard(new Date(rids[0]))
+  const expected = [13.1205, 17.3668145, 21.28550751, 39.63452215]
+  let card = scheduler.newCard({ now: new Date(rids[0]) })
   const grades: Grade[] = [Rating.Good, Rating.Good, Rating.Good, Rating.Good]
   for (let i = 0; i < rids.length; i++) {
     const now = new Date(rids[i])
-    const log = f.next(card, now, grades[i])
-    card = log.card
+    card = scheduler.review({ card, grade: grades[i], now }).card
     expect(card.stability).toBeCloseTo(expected[i], 4)
   }
 })
 
 test('SSE use next_state', () => {
-  const f = fsrs({
-    w: [
-      0.4911, 4.5674, 24.8836, 77.045, 7.5474, 0.1873, 1.7732, 0.001, 1.1112,
-      0.152, 0.5728, 1.8747, 0.1733, 0.2449, 2.2905, 0.0, 2.9898, 0.0883,
-      0.9033,
-    ],
+  const scheduler = FSRS6Scheduler.create({
+    config: {
+      weights: migrateFSRS6Parameters([
+        0.4911, 4.5674, 24.8836, 77.045, 7.5474, 0.1873, 1.7732, 0.001, 1.1112,
+        0.152, 0.5728, 1.8747, 0.1733, 0.2449, 2.2905, 0.0, 2.9898, 0.0883,
+        0.9033,
+      ]),
+      enableShortTerm: true,
+      numRelearningSteps: 1,
+    },
   })
 
   const rids = [
@@ -55,41 +66,29 @@ test('SSE use next_state', () => {
   ]
   const ratings: Rating[] = [3, 3, 1, 3, 3, 3, 0, 3, 0, 3]
   // 0,0,0,0,0,0,47,119
-  let last = new Date(rids[0])
-  let memoryState: FSRSState | null = null
+  let card = scheduler.newCard({ now: new Date(rids[0]) })
   for (let i = 0; i < rids.length; i++) {
     const current = new Date(rids[i])
     const rating = ratings[i]
-    const delta_t = dateDiffInDays(last, current)
     if (rating === Rating.Manual) {
       continue
     }
-    const nextStates = f.model.step({
-      memoryState,
-      rating,
-      elapsedDays: delta_t,
-    })
-    last = new Date(rids[i])
-
-    console.debug(
-      rids[i + 1],
-      rids[i],
-      delta_t,
-      +nextStates.stability.toFixed(2),
-      +nextStates.difficulty.toFixed(2)
-    )
-    memoryState = nextStates
+    card = scheduler.review({ card, grade: rating, now: current }).card
   }
-  expect(memoryState?.stability).toBeCloseTo(66.75687516)
+  expect(card.stability).toBeCloseTo(71.77)
 })
 
 test.skip('SSE 71.77', () => {
-  const f = fsrs({
-    w: [
-      0.4911, 4.5674, 24.8836, 77.045, 7.5474, 0.1873, 1.7732, 0.001, 1.1112,
-      0.152, 0.5728, 1.8747, 0.1733, 0.2449, 2.2905, 0.0, 2.9898, 0.0883,
-      0.9033,
-    ],
+  const scheduler = FSRS6Scheduler.create({
+    config: {
+      weights: migrateFSRS6Parameters([
+        0.4911, 4.5674, 24.8836, 77.045, 7.5474, 0.1873, 1.7732, 0.001, 1.1112,
+        0.152, 0.5728, 1.8747, 0.1733, 0.2449, 2.2905, 0.0, 2.9898, 0.0883,
+        0.9033,
+      ]),
+      enableShortTerm: true,
+      numRelearningSteps: 1,
+    },
   })
 
   const rids = [
@@ -141,7 +140,7 @@ test.skip('SSE 71.77', () => {
     },
   ]
 
-  let card = createEmptyCard(new Date(rids[0]))
+  let card = scheduler.newCard({ now: new Date(rids[0]) })
 
   for (let i = 0; i < rids.length; i++) {
     const rating = ratings[i]
@@ -150,8 +149,7 @@ test.skip('SSE 71.77', () => {
     }
 
     const now = new Date(rids[i])
-    const log = f.next(card, now, rating)
-    card = log.card
+    card = scheduler.review({ card, grade: rating, now }).card
     console.debug(i + 1)
     expect(card.stability).toBeCloseTo(expected[i].s, 2)
     expect(card.difficulty).toBeCloseTo(expected[i].d, 2)

--- a/packages/fsrs/src/legacy/default.ts
+++ b/packages/fsrs/src/legacy/default.ts
@@ -54,11 +54,7 @@ export const generatorParameters = (
     : defaultRelearningSteps
   const enable_short_term =
     props?.enable_short_term ?? default_enable_short_term
-  const w = migrateFSRS6Parameters(
-    props?.w ? Array.from(props.w) : undefined,
-    relearning_steps.length,
-    enable_short_term
-  )
+  const w = migrateFSRS6Parameters(props?.w ? Array.from(props.w) : undefined)
 
   return {
     request_retention: props?.request_retention || default_request_retention,

--- a/packages/fsrs/src/legacy/fsrs.ts
+++ b/packages/fsrs/src/legacy/fsrs.ts
@@ -1,6 +1,9 @@
 import { FSRSValidationError } from '../error.js'
 import type { IFSRSModel } from '../kit/index.js'
-import { migrateFSRS6Parameters } from '../models/fsrs-6/index.js'
+import {
+  clipFSRS6Parameters,
+  migrateFSRS6Parameters,
+} from '../models/fsrs-6/index.js'
 import { FSRS6Model } from '../models/fsrs-6/model.js'
 import { TypeConvert } from './convert.js'
 import { createEmptyCard, generatorParameters } from './default.js'
@@ -90,12 +93,24 @@ export class FSRS implements IFSRS {
   }
 
   set parameters(parameters: Partial<FSRSParameters>) {
-    const normalized = generatorParameters(parameters)
+    const normalized = this.prepare_parameters(parameters)
     this.#parameters = new Proxy(normalized, this.params_handler_proxy())
     this.rebuildModel()
     this.Scheduler = normalized.enable_short_term
       ? BasicScheduler
       : LongTermScheduler
+  }
+
+  private prepare_parameters = (
+    parameters: Partial<FSRSParameters>
+  ): FSRSParameters => {
+    const generated = generatorParameters(parameters)
+    generated.w = clipFSRS6Parameters(
+      Array.from(generated.w),
+      generated.relearning_steps.length,
+      generated.enable_short_term
+    )
+    return generated
   }
 
   private rebuildModel(): void {
@@ -120,8 +135,8 @@ export class FSRS implements IFSRS {
         if (prop === 'enable_short_term') {
           _this.Scheduler = value === true ? BasicScheduler : LongTermScheduler
         } else if (prop === 'w') {
-          value = migrateFSRS6Parameters(
-            value as number[],
+          value = clipFSRS6Parameters(
+            migrateFSRS6Parameters(value as number[]),
             target.relearning_steps.length,
             target.enable_short_term
           )

--- a/packages/fsrs/src/models/fsrs-3/model.spec.ts
+++ b/packages/fsrs/src/models/fsrs-3/model.spec.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { FSRS3Algorithm } from './algorithm.js'
 import { FSRS3_DEFAULT_WEIGHTS } from './constants.js'
 import { FSRS3Model } from './model.js'
-import { migrateFSRS3Parameters } from './parameters.js'
+import { clipFSRS3Parameters, migrateFSRS3Parameters } from './parameters.js'
 
 describe('FSRS3Model', () => {
   it('returns the default empty memory state', () => {
@@ -75,7 +75,9 @@ describe('FSRS3Model', () => {
       migrate: true,
     })
 
-    expect(model.config.weights).toEqual(migrateFSRS3Parameters(weights))
+    expect(model.config.weights).toEqual(
+      clipFSRS3Parameters(migrateFSRS3Parameters(weights))
+    )
   })
 
   it('bypasses create-time parsing when requested', () => {
@@ -95,6 +97,7 @@ describe('FSRS3Model', () => {
     const model = FSRS3Model.create({
       config: { weights },
       migrate: false,
+      clip: false,
       check: false,
     })
 
@@ -109,6 +112,7 @@ describe('FSRS3Model', () => {
       FSRS3Model.create({
         config: { weights },
         migrate: false,
+        clip: false,
         check: true,
       })
     ).toThrow('Expected FSRS3 weights within model bounds.')

--- a/packages/fsrs/src/models/fsrs-3/model.ts
+++ b/packages/fsrs/src/models/fsrs-3/model.ts
@@ -10,6 +10,7 @@ import { FSRS3Algorithm } from './algorithm.js'
 import { FSRS3_MODEL_BOUNDS } from './constants.js'
 import {
   checkFSRS3Parameters,
+  clipFSRS3Parameters,
   type FSRS3Config,
   fsrs3ConfigSchema,
   migrateFSRS3Parameters,
@@ -87,14 +88,23 @@ export const FSRS3Model = defineModel({
       return { stability: 0, difficulty: 0 }
     },
   },
-  create({ config, migrate = true, check = true, bypass = false }) {
+  create({
+    config,
+    migrate = true,
+    clip = true,
+    check = true,
+    bypass = false,
+  }) {
     if (bypass) {
       return createFSRS3Model(config)
     }
 
-    const weights = migrate
+    let weights = migrate
       ? migrateFSRS3Parameters(config.weights)
       : config.weights
+    if (clip && Array.isArray(weights)) {
+      weights = clipFSRS3Parameters(weights)
+    }
     if (check) {
       checkFSRS3Parameters(weights)
     }

--- a/packages/fsrs/src/models/fsrs-3/parameters.spec.ts
+++ b/packages/fsrs/src/models/fsrs-3/parameters.spec.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import { FSRS3_DEFAULT_WEIGHTS } from './constants.js'
-import { clipFSRS3Parameters, migrateFSRS3Parameters } from './parameters.js'
+import {
+  checkFSRS3Parameters,
+  clipFSRS3Parameters,
+  migrateFSRS3Parameters,
+} from './parameters.js'
 
 describe('FSRS-3 parameters', () => {
   it('returns FSRS-3 default weights when input is missing', () => {
@@ -23,12 +27,19 @@ describe('FSRS-3 parameters', () => {
     ])
   })
 
-  it('fills omitted FSRS-3 weights from defaults when clipping', () => {
-    expect(migrateFSRS3Parameters([1, 2, 3])).toEqual([
-      1,
-      2,
-      3,
-      ...FSRS3_DEFAULT_WEIGHTS.slice(3),
-    ])
+  it('leaves incomplete weights for validation after migration', () => {
+    const weights = migrateFSRS3Parameters([1, 2, 3])
+
+    expect(weights).toEqual([1, 2, 3])
+    expect(() => checkFSRS3Parameters(weights)).toThrow(
+      'Expected FSRS3 weights within model bounds.'
+    )
+  })
+
+  it('migrates without clipping', () => {
+    const weights = Array.from(FSRS3_DEFAULT_WEIGHTS)
+    weights[0] = 0
+
+    expect(migrateFSRS3Parameters(weights)).toEqual(weights)
   })
 })

--- a/packages/fsrs/src/models/fsrs-3/parameters.ts
+++ b/packages/fsrs/src/models/fsrs-3/parameters.ts
@@ -5,9 +5,9 @@ import { isNumberArray } from '@/kit/schema-utils.js'
 import { FSRS3_DEFAULT_WEIGHTS, FSRS3ParameterBounds } from './constants.js'
 
 export const clipFSRS3Parameters = (parameters: number[]): number[] => {
-  const clip = FSRS3ParameterBounds()
+  const clip = FSRS3ParameterBounds().slice(0, parameters.length)
   return clip.map(([min, max], index) =>
-    clamp(parameters[index] ?? FSRS3_DEFAULT_WEIGHTS[index], min, max)
+    clamp(parameters[index] ?? 0, min, max)
   )
 }
 
@@ -30,7 +30,7 @@ export const migrateFSRS3Parameters = (parameters?: number[]): number[] => {
   if (!Array.isArray(parameters) || parameters.length === 0) {
     return [...FSRS3_DEFAULT_WEIGHTS]
   }
-  return clipFSRS3Parameters(parameters)
+  return parameters.slice(0, FSRS3_DEFAULT_WEIGHTS.length)
 }
 
 export type FSRS3Config = {

--- a/packages/fsrs/src/models/fsrs-4/model.spec.ts
+++ b/packages/fsrs/src/models/fsrs-4/model.spec.ts
@@ -46,6 +46,7 @@ describe('FSRS-4 model', () => {
           weights: [0, ...weights.slice(1)],
         },
         migrate: false,
+        clip: false,
         check: true,
       })
     ).toThrow('Expected FSRS4 weights within model bounds.')

--- a/packages/fsrs/src/models/fsrs-4/model.ts
+++ b/packages/fsrs/src/models/fsrs-4/model.ts
@@ -10,6 +10,7 @@ import { FSRS4Algorithm } from './algorithm.js'
 import { FSRS4_MODEL_BOUNDS } from './constants.js'
 import {
   checkFSRS4Parameters,
+  clipFSRS4Parameters,
   type FSRS4Config,
   fsrs4ConfigSchema,
   migrateFSRS4Parameters,
@@ -88,14 +89,23 @@ export const FSRS4Model = defineModel({
       return { stability: 0, difficulty: 0 }
     },
   },
-  create({ config, migrate = true, check = true, bypass = false }) {
+  create({
+    config,
+    migrate = true,
+    clip = true,
+    check = true,
+    bypass = false,
+  }) {
     if (bypass) {
       return createFSRS4Model(config)
     }
 
-    const weights = migrate
+    let weights = migrate
       ? migrateFSRS4Parameters(config.weights)
       : config.weights
+    if (clip && Array.isArray(weights)) {
+      weights = clipFSRS4Parameters(weights)
+    }
     if (check) {
       checkFSRS4Parameters(weights)
     }

--- a/packages/fsrs/src/models/fsrs-4/parameters.spec.ts
+++ b/packages/fsrs/src/models/fsrs-4/parameters.spec.ts
@@ -24,19 +24,20 @@ describe('FSRS-4 parameters', () => {
     ])
   })
 
-  it('migrates FSRS-4 weights while filling missing parameters', () => {
+  it('migrates FSRS-4 weights without filling missing parameters', () => {
     expect(migrateFSRS4Parameters()).toEqual(weights)
     expect(migrateFSRS4Parameters(Array.from(weights))).toEqual(weights)
-    expect(migrateFSRS4Parameters([1, 2, 3])).toEqual([
-      1,
-      2,
-      3,
-      ...weights.slice(3),
-    ])
+    expect(migrateFSRS4Parameters([1, 2, 3])).toEqual([1, 2, 3])
     expect(migrateFSRS4Parameters([...weights, 1, 1])).toEqual(weights)
+
+    const outOfBounds = [0, ...weights.slice(1)]
+    expect(migrateFSRS4Parameters(outOfBounds)).toEqual(outOfBounds)
   })
 
   it('checks parameter bounds after migration', () => {
+    expect(() => checkFSRS4Parameters([1, 2, 3])).toThrow(
+      'Expected FSRS4 weights within model bounds.'
+    )
     expect(() => checkFSRS4Parameters([0, ...weights.slice(1)])).toThrow(
       'Expected FSRS4 weights within model bounds.'
     )

--- a/packages/fsrs/src/models/fsrs-4/parameters.ts
+++ b/packages/fsrs/src/models/fsrs-4/parameters.ts
@@ -5,9 +5,9 @@ import { isNumberArray } from '@/kit/schema-utils.js'
 import { FSRS4_DEFAULT_WEIGHTS, FSRS4ParameterBounds } from './constants.js'
 
 export const clipFSRS4Parameters = (parameters: number[]): number[] => {
-  const clip = FSRS4ParameterBounds()
+  const clip = FSRS4ParameterBounds().slice(0, parameters.length)
   return clip.map(([min, max], index) =>
-    clamp(parameters[index] ?? FSRS4_DEFAULT_WEIGHTS[index], min, max)
+    clamp(parameters[index] ?? 0, min, max)
   )
 }
 
@@ -30,7 +30,7 @@ export const migrateFSRS4Parameters = (parameters?: number[]): number[] => {
   if (!Array.isArray(parameters) || parameters.length === 0) {
     return [...FSRS4_DEFAULT_WEIGHTS]
   }
-  return clipFSRS4Parameters(parameters)
+  return parameters.slice(0, FSRS4_DEFAULT_WEIGHTS.length)
 }
 
 export type FSRS4Config = {

--- a/packages/fsrs/src/models/fsrs-4dot5/model.spec.ts
+++ b/packages/fsrs/src/models/fsrs-4dot5/model.spec.ts
@@ -40,6 +40,7 @@ describe('FSRS-4.5 model', () => {
           weights: [0, ...weights.slice(1)],
         },
         migrate: false,
+        clip: false,
         check: true,
       })
     ).toThrow('Expected FSRS4.5 weights within model bounds.')

--- a/packages/fsrs/src/models/fsrs-4dot5/model.ts
+++ b/packages/fsrs/src/models/fsrs-4dot5/model.ts
@@ -11,6 +11,7 @@ import { FSRS4Dot5_MODEL_BOUNDS } from './constants.js'
 import type { FSRS4Dot5Config } from './parameters.js'
 import {
   checkFSRS4Dot5Parameters,
+  clipFSRS4Dot5Parameters,
   fsrs4Dot5ConfigSchema,
   migrateFSRS4Dot5Parameters,
 } from './parameters.js'
@@ -88,14 +89,23 @@ export const FSRS4Dot5Model = defineModel({
       return { stability: 0, difficulty: 0 }
     },
   },
-  create({ config, migrate = true, check = true, bypass = false }) {
+  create({
+    config,
+    migrate = true,
+    clip = true,
+    check = true,
+    bypass = false,
+  }) {
     if (bypass) {
       return createFSRS4Dot5Model(config)
     }
 
-    const weights = migrate
+    let weights = migrate
       ? migrateFSRS4Dot5Parameters(config.weights)
       : config.weights
+    if (clip && Array.isArray(weights)) {
+      weights = clipFSRS4Dot5Parameters(weights)
+    }
     if (check) {
       checkFSRS4Dot5Parameters(weights)
     }

--- a/packages/fsrs/src/models/fsrs-4dot5/parameters.spec.ts
+++ b/packages/fsrs/src/models/fsrs-4dot5/parameters.spec.ts
@@ -19,10 +19,17 @@ describe('FSRS-4.5 parameters', () => {
 
   it('migrates FSRS-4.5 weights without rejecting longer parameter arrays', () => {
     expect(migrateFSRS4Dot5Parameters()).toEqual(weights)
+    expect(migrateFSRS4Dot5Parameters([1, 2, 3])).toEqual([1, 2, 3])
     expect(migrateFSRS4Dot5Parameters([...weights, 1, 1])).toEqual(weights)
+
+    const outOfBounds = [0, ...weights.slice(1)]
+    expect(migrateFSRS4Dot5Parameters(outOfBounds)).toEqual(outOfBounds)
   })
 
   it('checks parameter bounds after migration', () => {
+    expect(() => checkFSRS4Dot5Parameters([1, 2, 3])).toThrow(
+      'Expected FSRS4.5 weights within model bounds.'
+    )
     expect(() => checkFSRS4Dot5Parameters([0, ...weights.slice(1)])).toThrow(
       'Expected FSRS4.5 weights within model bounds.'
     )

--- a/packages/fsrs/src/models/fsrs-4dot5/parameters.ts
+++ b/packages/fsrs/src/models/fsrs-4dot5/parameters.ts
@@ -35,7 +35,7 @@ export const migrateFSRS4Dot5Parameters = (parameters?: number[]): number[] => {
   if (!Array.isArray(parameters) || parameters.length === 0) {
     return [...FSRS4Dot5_DEFAULT_WEIGHTS]
   }
-  return clipFSRS4Dot5Parameters(parameters)
+  return parameters.slice(0, FSRS4Dot5_DEFAULT_WEIGHTS.length)
 }
 
 export type FSRS4Dot5Config = {

--- a/packages/fsrs/src/models/fsrs-5/model.spec.ts
+++ b/packages/fsrs/src/models/fsrs-5/model.spec.ts
@@ -108,6 +108,7 @@ describe('FSRS5Model', () => {
     const model = FSRS5Model.create({
       config: { weights, enableShortTerm: true },
       migrate: false,
+      clip: false,
       check: false,
     })
 
@@ -122,6 +123,7 @@ describe('FSRS5Model', () => {
       FSRS5Model.create({
         config: { weights, enableShortTerm: true },
         migrate: false,
+        clip: false,
         check: true,
       })
     ).toThrow('Expected FSRS5 weights within model bounds.')

--- a/packages/fsrs/src/models/fsrs-5/model.ts
+++ b/packages/fsrs/src/models/fsrs-5/model.ts
@@ -10,6 +10,7 @@ import { FSRS5Algorithm } from './algorithm.js'
 import { FSRS5_MODEL_BOUNDS } from './constants.js'
 import {
   checkFSRS5Parameters,
+  clipFSRS5Parameters,
   type FSRS5Config,
   fsrs5ConfigSchema,
   migrateFSRS5Parameters,
@@ -92,14 +93,23 @@ export const FSRS5Model = defineModel({
       return { stability: 0, difficulty: 0 }
     },
   },
-  create({ config, migrate = true, check = true, bypass = false }) {
+  create({
+    config,
+    migrate = true,
+    clip = true,
+    check = true,
+    bypass = false,
+  }) {
     if (bypass) {
       return createFSRS5Model(config)
     }
 
-    const weights = migrate
+    let weights = migrate
       ? migrateFSRS5Parameters(config.weights)
       : config.weights
+    if (clip && Array.isArray(weights)) {
+      weights = clipFSRS5Parameters(weights)
+    }
     if (check) {
       checkFSRS5Parameters(weights)
     }

--- a/packages/fsrs/src/models/fsrs-5/parameters.spec.ts
+++ b/packages/fsrs/src/models/fsrs-5/parameters.spec.ts
@@ -56,7 +56,7 @@ describe('FSRS-5 parameters', () => {
     expect(migrateFSRS5Parameters(params)).toEqual(FSRS5_DEFAULT_WEIGHTS)
   })
 
-  it('clips truncated parameters longer than FSRS-5 weights', () => {
+  it('truncates parameters without clipping', () => {
     const params = [
       Number.POSITIVE_INFINITY,
       ...FSRS5_DEFAULT_WEIGHTS.slice(1),
@@ -64,10 +64,13 @@ describe('FSRS-5 parameters', () => {
       0.1542,
     ]
 
-    expect(migrateFSRS5Parameters(params)).toEqual([
-      100,
+    const migrated = migrateFSRS5Parameters(params)
+
+    expect(migrated).toEqual([
+      Number.POSITIVE_INFINITY,
       ...FSRS5_DEFAULT_WEIGHTS.slice(1),
     ])
+    expect(clipFSRS5Parameters(migrated)[0]).toBe(100)
   })
 
   it('rejects parameter lengths outside FSRS-4.5 and FSRS-5', () => {

--- a/packages/fsrs/src/models/fsrs-5/parameters.ts
+++ b/packages/fsrs/src/models/fsrs-5/parameters.ts
@@ -31,17 +31,17 @@ export const migrateFSRS5Parameters = (parameters?: number[]): number[] => {
     return [...FSRS5_DEFAULT_WEIGHTS]
   }
   if (parameters.length > 19) {
-    return clipFSRS5Parameters(parameters)
+    return parameters.slice(0, 19)
   }
   switch (parameters.length) {
     case 19:
-      return clipFSRS5Parameters(parameters)
+      return Array.from(parameters)
     case 17: {
-      const weights = clipFSRS5Parameters(parameters)
+      const weights = Array.from(parameters)
       weights[4] = roundTo(weights[5] * 2.0 + weights[4], 8)
       weights[5] = roundTo(Math.log(weights[5] * 3.0 + 1.0) / 3.0, 8)
       weights[6] = roundTo(weights[6] + 0.5, 8)
-      return clipFSRS5Parameters(weights.concat([0.0, 0.0]))
+      return weights.concat([0.0, 0.0])
     }
     default:
       throw new FSRSValidationError(

--- a/packages/fsrs/src/models/fsrs-6/model.spec.ts
+++ b/packages/fsrs/src/models/fsrs-6/model.spec.ts
@@ -30,21 +30,48 @@ describe('FSRS6Model', () => {
     ).toThrow()
   })
 
-  it('migrates FSRS-5 weights when requested', () => {
+  it.each([
+    [true, 0.01],
+    [false, 0],
+  ])('clips migrated FSRS-5 weights when enableShortTerm=%s', (enableShortTerm, expectedW19) => {
     const weights = Array.from(FSRS5_DEFAULT_WEIGHTS)
     const model = FSRS6Model.create({
       config: {
         weights,
+        enableShortTerm,
+        numRelearningSteps: 0,
+      },
+    })
+
+    expect(model.config.weights[19]).toBe(expectedW19)
+  })
+
+  it('bypasses parameter clipping when requested', () => {
+    const config = {
+      weights: migrateFSRS6Parameters(FSRS5_DEFAULT_WEIGHTS),
+      enableShortTerm: true,
+      numRelearningSteps: 0,
+    }
+
+    const model = FSRS6Model.create({ config, bypass: true })
+
+    expect(model.config).toBe(config)
+    expect(model.config.weights[19]).toBe(0)
+  })
+
+  it('can migrate without clipping or checking', () => {
+    const model = FSRS6Model.create({
+      config: {
+        weights: FSRS5_DEFAULT_WEIGHTS,
         enableShortTerm: true,
         numRelearningSteps: 0,
       },
-      migrate: true,
+      clip: false,
       check: false,
     })
 
-    expect(model.config.weights).toEqual(
-      migrateFSRS6Parameters(weights, 0, true)
-    )
+    expect(model.config.weights).toHaveLength(21)
+    expect(model.config.weights[19]).toBe(0)
   })
 
   it('checks parameter bounds when requested', () => {
@@ -59,6 +86,7 @@ describe('FSRS6Model', () => {
           numRelearningSteps: 0,
         },
         migrate: false,
+        clip: false,
         check: true,
       })
     ).toThrow('Expected FSRS6 weights within model bounds.')

--- a/packages/fsrs/src/models/fsrs-6/model.ts
+++ b/packages/fsrs/src/models/fsrs-6/model.ts
@@ -10,6 +10,7 @@ import { FSRS6Algorithm } from './algorithm.js'
 import { FSRS6_MODEL_BOUNDS } from './constants.js'
 import {
   checkFSRS6Parameters,
+  clipFSRS6Parameters,
   type FSRS6Config,
   fsrs6ConfigSchema,
   migrateFSRS6Parameters,
@@ -92,18 +93,27 @@ export const FSRS6Model = defineModel({
       return { stability: 0, difficulty: 0 }
     },
   },
-  create({ config, migrate = true, check = true, bypass = false }) {
+  create({
+    config,
+    migrate = true,
+    clip = true,
+    check = true,
+    bypass = false,
+  }) {
     if (bypass) {
       return createFSRS6Model(config)
     }
 
-    const weights = migrate
-      ? migrateFSRS6Parameters(
-          config.weights,
-          config.numRelearningSteps,
-          config.enableShortTerm
-        )
+    let weights = migrate
+      ? migrateFSRS6Parameters(config.weights)
       : config.weights
+    if (clip && Array.isArray(weights)) {
+      weights = clipFSRS6Parameters(
+        weights,
+        config.numRelearningSteps,
+        config.enableShortTerm
+      )
+    }
     if (check) {
       checkFSRS6Parameters(
         weights,

--- a/packages/fsrs/src/models/fsrs-6/parameters.spec.ts
+++ b/packages/fsrs/src/models/fsrs-6/parameters.spec.ts
@@ -4,6 +4,7 @@ import {
   checkFSRS6Parameters,
   clipFSRS6Parameters,
   decaySchema,
+  migrateFSRS6Parameters,
 } from './parameters.js'
 
 describe('FSRS-6 parameters', () => {
@@ -28,5 +29,15 @@ describe('FSRS-6 parameters', () => {
     expect(() =>
       checkFSRS6Parameters(FSRS6_DEFAULT_WEIGHTS.slice(0, 20))
     ).toThrow('Expected FSRS6 weights within model bounds.')
+  })
+
+  it('migrates without clipping', () => {
+    const weights = Array.from(FSRS6_DEFAULT_WEIGHTS)
+    weights[0] = 0
+
+    expect(migrateFSRS6Parameters(weights)).toEqual(weights)
+    expect(() => checkFSRS6Parameters(weights)).toThrow(
+      'Expected FSRS6 weights within model bounds.'
+    )
   })
 })

--- a/packages/fsrs/src/models/fsrs-6/parameters.ts
+++ b/packages/fsrs/src/models/fsrs-6/parameters.ts
@@ -77,33 +77,17 @@ export const checkFSRS6Parameters = (
   return parameters
 }
 
-export const migrateFSRS6Parameters = (
-  parameters?: number[],
-  numRelearningSteps = 0,
-  enableShortTerm = true
-): number[] => {
+export const migrateFSRS6Parameters = (parameters?: number[]): number[] => {
   if (!Array.isArray(parameters) || parameters.length === 0) {
     return [...FSRS6_DEFAULT_WEIGHTS]
   }
   switch (parameters.length) {
     case 21:
-      return clipFSRS6Parameters(
-        Array.from(parameters),
-        numRelearningSteps,
-        enableShortTerm
-      )
+      return Array.from(parameters)
     case 19:
-      return clipFSRS6Parameters(
-        Array.from(parameters),
-        numRelearningSteps,
-        enableShortTerm
-      ).concat([0.0, FSRS5_DECAY])
+      return Array.from(parameters).concat([0.0, FSRS5_DECAY])
     case 17: {
-      const weights = clipFSRS6Parameters(
-        Array.from(parameters),
-        numRelearningSteps,
-        enableShortTerm
-      )
+      const weights = Array.from(parameters)
       weights[4] = +(weights[5] * 2.0 + weights[4]).toFixed(8)
       weights[5] = +(Math.log(weights[5] * 3.0 + 1.0) / 3.0).toFixed(8)
       weights[6] = +(weights[6] + 0.5).toFixed(8)

--- a/packages/srs-kit/src/model/model.ts
+++ b/packages/srs-kit/src/model/model.ts
@@ -99,11 +99,12 @@ export type ModelCreate<
     | SchemaInput<Schema['config']>
     | SchemaOutput<Schema['config']>
   readonly migrate?: boolean
+  readonly clip?: boolean
   readonly check?: boolean
   /**
    * The config has already been parsed by the composed scheduler schema.
    * Model implementations should use it directly and skip create-time
-   * validation, migration, range checks, and freezing.
+   * validation, migration, clipping, range checks, and freezing.
    */
   readonly bypass?: boolean
 }) => ModelCore<{


### PR DESCRIPTION
## Summary

- Separate model parameter migration, clipping, and validation.
- Allow clipping to be disabled or bypassed during model creation.
- Keep legacy FSRS parameter preparation responsible for clipping migrated weights.

## Compatibility

In the preview branch (ts-fsrs v6), this PR reverts the result changes introduced by #486 for `packages/fsrs/src/legacy/__tests__/fixed/calc-elapsed-days.test.ts` and `packages/fsrs/src/legacy/__tests__/FSRS-5.test.ts`. Both tests now use `defineScheduler` while preserving their original expected results; the FSRS-5 test uses `FSRS5Model`.

## Tests

- `CI=true ./node_modules/.bin/turbo run test --concurrency=1`
- `./node_modules/.bin/biome check packages/fsrs/src packages/srs-kit/src`
- TypeScript checks for `packages/fsrs` and `packages/srs-kit`