### PR TITLE
fix(kit): expose flattened scheduler config types

### DIFF
--- a/.changeset/expose-scheduler-config-input.md
+++ b/.changeset/expose-scheduler-config-input.md
@@ -1,0 +1,5 @@
+---
+"@open-spaced-repetition/srs-kit": patch
+---
+
+fix(kit): expose flattened scheduler config input and output types.

--- a/packages/srs-kit/src/scheduler/infer.ts
+++ b/packages/srs-kit/src/scheduler/infer.ts
@@ -44,6 +44,14 @@ export type SchedulerConfigOf<T extends HasSchema<'config'>> = SchemaOutputOf<
   'config'
 >
 
+export type SchedulerConfigInputOf<T extends HasSchema<'config'>> = {
+  [Key in keyof SchemaInputOf<T, 'config'>]: SchemaInputOf<T, 'config'>[Key]
+}
+
+export type SchedulerConfigOutputOf<T extends HasSchema<'config'>> = {
+  [Key in keyof SchemaOutputOf<T, 'config'>]: SchemaOutputOf<T, 'config'>[Key]
+}
+
 export type SchedulerConfigInput<
   M extends AnyModel,
   C extends AnyChrono,

--- a/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
@@ -8,12 +8,23 @@ import type { Grade } from '@/primitives/rating.js'
 import type { Mutable } from '@/schema/index.js'
 import { defineStringFieldOutputSchema } from '@/schema/string-field.test.js'
 import { defineScheduler } from './define-scheduler.js'
+import type {
+  SchedulerConfigInputOf,
+  SchedulerConfigOutputOf,
+} from './infer.js'
 import type { PreviewResult, ScheduleResult } from './scheduler.js'
 
 const sm2NumericScheduler = defineScheduler({
   model: SM2Model,
   chrono: numericChrono,
 }).use(schedulerStatsMiddleware)
+
+type SM2NumericSchedulerConfigInput = SchedulerConfigInputOf<
+  typeof sm2NumericScheduler
+>
+type SM2NumericSchedulerConfigOutput = SchedulerConfigOutputOf<
+  typeof sm2NumericScheduler
+>
 
 const baseSm2NumericScheduler = defineScheduler({
   model: SM2Model,
@@ -752,6 +763,18 @@ describe('defineScheduler type display', () => {
 }>`,
   }
 
+  const expectedConfigs = {
+    SM2NumericSchedulerConfigInput: `type SM2NumericSchedulerConfigInput = {
+    readonly weights: readonly number[];
+    readonly clearStatsOnForget?: boolean | undefined;
+}`,
+    SM2NumericSchedulerConfigOutput: `type SM2NumericSchedulerConfigOutput = {
+    readonly weights: readonly number[];
+    readonly chrono: Record<string, never>;
+    readonly clearStatsOnForget: boolean;
+}`,
+  }
+
   it('keeps scheduler hovers readable with composed env', () => {
     for (const [marker, expected] of Object.entries(expectedSchedulers)) {
       expect(quickInfoAt(service, SELF, marker)).toBe(expected)
@@ -784,6 +807,12 @@ describe('defineScheduler type display', () => {
 
   it('keeps middleware names readable', () => {
     for (const [marker, expected] of Object.entries(expectedMiddlewares)) {
+      expect(quickInfoAt(service, SELF, marker)).toBe(expected)
+    }
+  })
+
+  it('shows the flattened scheduler config input and output', () => {
+    for (const [marker, expected] of Object.entries(expectedConfigs)) {
       expect(quickInfoAt(service, SELF, marker)).toBe(expected)
     }
   })

--- a/packages/srs-kit/vitest.setup.ts
+++ b/packages/srs-kit/vitest.setup.ts
@@ -161,8 +161,19 @@ globalThis.quickInfoAt = (svc, rel, marker) => {
     markerStart + marker.length - 1
   )
 
-  if (!match || !ts.isIdentifier(match.declaration.name)) {
-    throw new Error(`Expected "${marker}" in ${rel} to be a variable name`)
+  if (!match) {
+    const info = svc.getQuickInfoAtPosition(
+      fileName,
+      markerStart + marker.length - 1
+    )
+    if (!info) {
+      throw new Error(`Missing QuickInfo for "${marker}" in ${rel}`)
+    }
+    return ts.displayPartsToString(info.displayParts)
+  }
+
+  if (!ts.isIdentifier(match.declaration.name)) {
+    throw new Error(`Expected "${marker}" in ${rel} to be an identifier`)
   }
 
   const checker = program.getTypeChecker()


### PR DESCRIPTION
## Summary

- Export `SchedulerConfigInputOf` and `SchedulerConfigOutputOf` with flattened IDE hovers.
- Preserve the existing `SchedulerConfigOf` implementation to avoid increasing type-instantiation costs for current consumers.
- Add QuickInfo regression coverage and a patch changeset.

## Validation

- `pnpm --filter @open-spaced-repetition/srs-kit test` (221 tests)
- `pnpm --filter @open-spaced-repetition/srs-kit check`
- `pnpm --filter @open-spaced-repetition/srs-kit build`
- `pnpm exec changeset status`
- `tsc --extendedDiagnostics`: median memory 290505K -> 290606K (+101K, +0.035%); instantiations +157
