### PR TITLE
fix(kit): flatten newCard return types

### DIFF
--- a/.changeset/flatten-new-card-types.md
+++ b/.changeset/flatten-new-card-types.md
@@ -1,0 +1,5 @@
+---
+"@open-spaced-repetition/srs-kit": patch
+---
+
+fix(kit): flatten composed `newCard` return type displays.

--- a/packages/srs-kit/src/scheduler/base.ts
+++ b/packages/srs-kit/src/scheduler/base.ts
@@ -204,9 +204,9 @@ export class BaseScheduler<
     return this.schedulerDefinition
   }
 
-  newCard: SchedulerNewCardFn<SchedulerCoreEnv<Env>> = (
+  private readonly createNewCard = (
     options?: SchedulerNewCardOptions<SchedulerCoreEnv<Env>>
-  ): SchedulerCoreEnv<Env>['card']['output'] => {
+  ) => {
     const { now, input } = parse<Env['cardInitInput']>(
       this.schema.cardInitInput,
       options === undefined ? {} : options
@@ -224,6 +224,8 @@ export class BaseScheduler<
       this.parseNow(now)
     )
   }
+
+  newCard = this.createNewCard as SchedulerNewCardFn<SchedulerCoreEnv<Env>>
 
   /**
    * Replays a review history and returns the card and revlog produced by each
@@ -256,7 +258,7 @@ export class BaseScheduler<
     const results: ForwardResult[] = new Array(history.length)
     const initialCard =
       input.initialCard == null
-        ? this.newCard({
+        ? this.createNewCard({
             now: history[0].reviewTime,
           } as SchedulerNewCardOptions<SchedulerCoreEnv<Env>>)
         : (input.initialCard as SchedulerNewCardOptions<SchedulerCoreEnv<Env>>)

--- a/packages/srs-kit/src/scheduler/scheduler.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.ts
@@ -71,8 +71,10 @@ export type SchedulerNewCardOptions<Env extends BlankSchedulerCoreEnv> =
 
 export type SchedulerNewCardFn<Env extends BlankSchedulerCoreEnv> =
   EmptyPart extends SchedulerNewCardOptions<Env>
-    ? (options?: SchedulerNewCardOptions<Env>) => Env['card']['output']
-    : (options: SchedulerNewCardOptions<Env>) => Env['card']['output']
+    ? (
+        options?: SchedulerNewCardOptions<Env>
+      ) => Prettify<Env['card']['output']>
+    : (options: SchedulerNewCardOptions<Env>) => Prettify<Env['card']['output']>
 
 export interface ForwardItem<Time> {
   readonly rating: Grade

--- a/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
@@ -12,7 +12,11 @@ import type {
   SchedulerConfigInputOf,
   SchedulerConfigOutputOf,
 } from './infer.js'
-import type { PreviewResult, ScheduleResult } from './scheduler.js'
+import type {
+  PreviewResult,
+  ScheduleResult,
+  SchedulerNewCardFn,
+} from './scheduler.js'
 
 const sm2NumericScheduler = defineScheduler({
   model: SM2Model,
@@ -135,6 +139,32 @@ type ComposedRevlogForDisplay = Mutable<
     readonly rating: Grade
   }
 >
+type NewCardEnvForDisplay = {
+  readonly config: object
+  readonly cardInitInput: { readonly now?: Date }
+  readonly card: {
+    readonly input: ComposedCardForDisplay
+    readonly output: ComposedCardForDisplay
+  }
+  readonly revlog: {
+    readonly input: ComposedRevlogForDisplay
+    readonly output: ComposedRevlogForDisplay
+  }
+  readonly chrono: Date
+  readonly scheduleStatus: 'new' | 'learning' | 'review'
+}
+
+declare const newCardForDisplay: SchedulerNewCardFn<NewCardEnvForDisplay>
+function displayNewCard(card: ReturnType<typeof newCardForDisplay>) {
+  return card
+}
+
+const composedNewCardForDisplay = displayNewCard({
+  stability: 1,
+  dueAt: new Date(0),
+  reps: 0,
+  learningStep: 0,
+})
 
 interface FSRSSchedulerForDisplay {
   readonly preview: () => PreviewResult<
@@ -599,6 +629,12 @@ describe('defineScheduler type display', () => {
   }
 
   const expectedDefaultValues = {
+    composedNewCardForDisplay: `const composedNewCardForDisplay: {
+    reps: number;
+    stability: number;
+    dueAt: Date;
+    learningStep: number;
+}`,
     defaultNewCard: `const defaultNewCard: {
     source: string;
     interval: number;
@@ -793,7 +829,7 @@ describe('defineScheduler type display', () => {
     }
   })
 
-  it('shows the composed card type for defaultValue.newCard()', () => {
+  it('shows flattened card types for newCard()', () => {
     for (const [marker, expected] of Object.entries(expectedDefaultValues)) {
       expect(quickInfoAt(service, SELF, marker)).toBe(expected)
     }


### PR DESCRIPTION
## Summary
- flatten composed `newCard` return types in IDE displays
- keep internal card creation isolated to avoid TypeScript type expansion
- add type-display regression coverage and a patch changeset

## Testing
- `pnpm --filter @open-spaced-repetition/srs-kit check`
- `pnpm --filter @open-spaced-repetition/srs-kit test`
- `pnpm --filter @open-spaced-repetition/srs-kit build`
- `pnpm --filter ts-fsrs typecheck`
- 512 MiB TypeScript heap smoke