### PR TITLE
docs: add a runnable defineScheduler guide

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -28,8 +28,9 @@
     "@rsbuild/plugin-tailwindcss": "^2.0.3",
     "@rspress/core": "2.0.19",
     "@rspress/plugin-rss": "2.0.19",
+    "@rspress/plugin-twoslash": "2.0.19",
     "@types/react": "19.2.18",
     "tailwindcss": "^4.3.3",
-    "typescript-compiler": "npm:typescript@6.0.3"
+    "typescript": "6.0.3"
   }
 }

--- a/docs/rspress.config.ts
+++ b/docs/rspress.config.ts
@@ -4,8 +4,13 @@ import path from 'node:path'
 import { pluginTailwindcss } from '@rsbuild/plugin-tailwindcss'
 import { defineConfig } from '@rspress/core'
 import { pluginRss } from '@rspress/plugin-rss'
+import { pluginTwoslash } from '@rspress/plugin-twoslash'
 import { adaptI18nSource } from './src/i18n'
 import { collectPlaygroundDeclarations } from './src/playground/editor/collect-declarations'
+import {
+  collectHighlightedExportNames,
+  keepTsFsrsTypeHover,
+} from './src/playground/highlight/twoslash'
 
 const siteOrigin = process.env.DOCS_SITE_ORIGIN
 const repository =
@@ -16,6 +21,9 @@ const repositoryRef = (process.env.DOCS_REPO_REF ?? 'main')
   .join('/')
 const workspaceRoot = path.resolve(import.meta.dirname, '..')
 const playgroundDeclarations = collectPlaygroundDeclarations(workspaceRoot)
+const highlightedExportNames = collectHighlightedExportNames(
+  playgroundDeclarations
+)
 // Any module whose path ends in `.css` is pulled into the site-wide stylesheet,
 // so the editor styles are inlined as a string that only the playground's async
 // chunk references. Monaco's icon font is a data URI, so no asset rewriting is
@@ -94,6 +102,11 @@ export default defineConfig({
     },
   },
   plugins: [
+    pluginTwoslash({
+      twoslashOptions: {
+        filterNode: (node) => keepTsFsrsTypeHover(node, highlightedExportNames),
+      },
+    }),
     pluginRss({
       feed: [
         {

--- a/docs/src/components/RunCode.tsx
+++ b/docs/src/components/RunCode.tsx
@@ -1,0 +1,58 @@
+import { useI18n } from '@rspress/core/runtime'
+import WorkerLogLine from '@/components/WorkerLogLine'
+import { usePlaygroundRunner } from '@/playground/runner/use-playground-runner'
+import * as styles from '@/playground/shared/styles'
+import { cn } from '@/utils/cn'
+
+type Props = {
+  readonly code: string
+}
+
+export default function RunCode({ code }: Props) {
+  const t = useI18n<typeof import('i18n')>()
+  const runner = usePlaygroundRunner()
+  const hasOutput = runner.logs.length > 0 || runner.error
+
+  return (
+    <div className="rp-not-doc my-3">
+      <button
+        className={cn(styles.button, styles.primaryButton)}
+        data-testid="run-code-button"
+        disabled={runner.state !== 'idle'}
+        onClick={() => void runner.run(code)}
+        type="button"
+      >
+        {runner.state === 'idle'
+          ? `▶ ${t('playground.run')}`
+          : t('playground.runBusy')}
+      </button>
+      {hasOutput && (
+        <div
+          aria-live="polite"
+          className="mt-3 overflow-auto rounded-[10px] border border-line bg-output"
+          data-testid="run-code-output"
+        >
+          {runner.logs.map((line, index) => (
+            <WorkerLogLine
+              className={cn(styles.logLine, index > 0 && styles.logDivider)}
+              // biome-ignore lint/suspicious/noArrayIndexKey: duplicate transcript lines need their position.
+              key={`${line.level}-${index}`}
+              line={line}
+            />
+          ))}
+          {runner.error && (
+            <pre
+              className={cn(
+                styles.logLine,
+                'text-danger',
+                runner.logs.length > 0 && styles.logDivider
+              )}
+            >
+              {runner.error}
+            </pre>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/docs/src/en-US/_nav.json
+++ b/docs/src/en-US/_nav.json
@@ -1,6 +1,5 @@
 [
-  { "text": "Home", "link": "/" },
-  { "text": "Installation", "link": "/installation/" },
+  { "text": "Guide", "link": "/guide/", "activeMatch": "/guide/" },
   { "text": "Playground", "link": "/playground" },
   { "text": "Updates", "link": "/updates/" }
 ]

--- a/docs/src/en-US/guide/index.mdx
+++ b/docs/src/en-US/guide/index.mdx
@@ -1,0 +1,46 @@
+---
+title: Getting Started
+description: Install ts-fsrs, understand its scheduler building blocks, and run a complete defineScheduler quick start in the browser
+---
+
+import { PackageManagerTabs, Prompt } from '@rspress/core/theme'
+import RunCode from '../../components/RunCode'
+import code from '@/snippets/run-code/define-scheduler.ts?raw'
+
+# Getting Started
+
+`ts-fsrs` is a TypeScript toolkit for building spaced repetition systems with FSRS. Its declarative API composes a model, a chronology, and optional middleware into a reusable scheduler definition.
+
+<Prompt
+  title="Integrate ts-fsrs into a TypeScript application"
+  description="Copy this prompt and send it to your AI agent to install ts-fsrs and create a working FSRS-6 scheduler."
+  prompt={`Integrate ts-fsrs into my TypeScript application.
+
+1. Install the \`ts-fsrs\` package.
+2. Create an FSRS-6 scheduler with \`defineScheduler\`, \`FSRS6Model\`, and \`dateChrono\`.
+3. Create a new card and review it with \`Rating.Good\`.
+4. Keep the implementation minimal and use the current ts-fsrs public API.`}
+/>
+
+## Installation
+
+`ts-fsrs` requires Node.js 20 or later.
+
+<PackageManagerTabs command="install ts-fsrs" />
+
+Install `@open-spaced-repetition/binding` separately only when you need to train FSRS parameters or convert review-log CSV files.
+
+## Quick start
+
+`defineScheduler` creates a reusable definition from the FSRS-6 model and a date-based chronology. Calling `.create()` validates the configuration and returns an independent scheduler.
+
+```ts twoslash file="../../snippets/run-code/define-scheduler.ts"
+```
+
+<RunCode code={code} />
+
+Use the code block's copy button to copy the original source, or run it directly in the dedicated Worker. The fixed `now` value keeps the output reproducible.
+
+- `newCard()` creates the scheduler's default card shape.
+- `review()` returns a new card and revlog without mutating the input card.
+- Keep the definition when you need multiple schedulers; add policy middleware with `.use(...)` before `.create()`.

--- a/docs/src/en-US/installation/index.mdx
+++ b/docs/src/en-US/installation/index.mdx
@@ -1,8 +1,0 @@
----
-title: Installation
-description: Install ts-fsrs and the FSRS optimizer binding with npm, pnpm, Yarn, Bun, or Deno
----
-
-import { PackageManagerTabs } from '@rspress/core/theme';
-
-<PackageManagerTabs command="install ts-fsrs @open-spaced-repetition/binding" />

--- a/docs/src/ja-JP/_nav.json
+++ b/docs/src/ja-JP/_nav.json
@@ -1,6 +1,5 @@
 [
-  { "text": "ホーム", "link": "/" },
-  { "text": "インストール", "link": "/installation/" },
+  { "text": "ガイド", "link": "/guide/", "activeMatch": "/guide/" },
   { "text": "Playground", "link": "/playground" },
   { "text": "更新情報", "link": "/updates/" }
 ]

--- a/docs/src/ja-JP/guide/index.mdx
+++ b/docs/src/ja-JP/guide/index.mdx
@@ -1,0 +1,46 @@
+---
+title: はじめに
+description: ts-fsrs をインストールし、スケジューラーの構成を理解して、defineScheduler の完全なクイックスタートをブラウザーで実行します
+---
+
+import { PackageManagerTabs, Prompt } from '@rspress/core/theme'
+import RunCode from '../../components/RunCode'
+import code from '@/snippets/run-code/define-scheduler.ts?raw'
+
+# はじめに
+
+`ts-fsrs` は、FSRS を使用した間隔反復システムを構築するための TypeScript ツールキットです。宣言的 API はモデル、時刻体系、任意の middleware を再利用可能なスケジューラー定義に組み合わせます。
+
+<Prompt
+  title="TypeScript アプリに ts-fsrs を組み込む"
+  description="このプロンプトをコピーして AI Agent に送り、ts-fsrs のインストールと動作する FSRS-6 スケジューラーの作成を依頼できます。"
+  prompt={`私の TypeScript アプリに ts-fsrs を組み込んでください。
+
+1. \`ts-fsrs\` package をインストールする。
+2. \`defineScheduler\`、\`FSRS6Model\`、\`dateChrono\` で FSRS-6 スケジューラーを作成する。
+3. 新しいカードを作成し、\`Rating.Good\` で復習する。
+4. 実装を最小限に保ち、現在の ts-fsrs public API を使用する。`}
+/>
+
+## インストール
+
+`ts-fsrs` には Node.js 20 以降が必要です。
+
+<PackageManagerTabs command="install ts-fsrs" />
+
+FSRS パラメーターの学習や復習ログ CSV の変換が必要な場合にのみ、`@open-spaced-repetition/binding` を追加でインストールします。
+
+## Quick start
+
+`defineScheduler` は FSRS-6 モデルと日付ベースの時刻体系から再利用可能な定義を作成します。`.create()` は設定を検証し、独立したスケジューラーを返します。
+
+```ts twoslash file="../../snippets/run-code/define-scheduler.ts"
+```
+
+<RunCode code={code} />
+
+コードブロックのコピーボタンは元のソースをコピーします。専用 Worker でそのまま実行することもできます。固定した `now` により出力を再現できます。
+
+- `newCard()` はスケジューラー既定のカードを作成します。
+- `review()` は新しいカードと復習ログを返し、入力カードを変更しません。
+- 複数のスケジューラーを作る場合は definition を保持し、ポリシーが必要な場合は `.create()` の前に `.use(...)` で middleware を追加します。

--- a/docs/src/ja-JP/installation/index.mdx
+++ b/docs/src/ja-JP/installation/index.mdx
@@ -1,8 +1,0 @@
----
-title: インストール
-description: npm、pnpm、Yarn、Bun、Deno を使用して ts-fsrs と FSRS パラメータ最適化 binding をインストールする手順
----
-
-import { PackageManagerTabs } from '@rspress/core/theme';
-
-<PackageManagerTabs command="install ts-fsrs @open-spaced-repetition/binding" />

--- a/docs/src/playground/examples/examples.test.ts
+++ b/docs/src/playground/examples/examples.test.ts
@@ -1,6 +1,6 @@
 import { readdirSync, readFileSync } from 'node:fs'
 import path from 'node:path'
-import ts from 'typescript-compiler'
+import ts from 'typescript'
 import { describe, expect, it } from 'vitest'
 import { PLAYGROUND_SCENARIOS } from '../shared/scenarios'
 

--- a/docs/src/playground/highlight/run-code-source.test.ts
+++ b/docs/src/playground/highlight/run-code-source.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const root = dirname(fileURLToPath(import.meta.url))
+const snippetPath = '../../snippets/run-code/define-scheduler.ts'
+const snippetImport = '@/snippets/run-code/define-scheduler.ts?raw'
+
+describe('defineScheduler guide source', () => {
+  it('uses one file for the Markdown code block and Worker input', () => {
+    const snippet = readFileSync(join(root, snippetPath), 'utf8')
+    expect(snippet).toContain('defineScheduler({')
+
+    for (const locale of ['en-US', 'zh-CN', 'ja-JP']) {
+      const page = readFileSync(
+        join(root, '../..', locale, 'guide/index.mdx'),
+        'utf8'
+      )
+      expect(page).toContain(`from '${snippetImport}'`)
+      expect(page).toContain(`\`\`\`ts twoslash file="${snippetPath}"`)
+      expect(page).toContain('PackageManagerTabs')
+      expect(page).toContain('<Prompt')
+
+      const nav = readFileSync(join(root, '../..', locale, '_nav.json'), 'utf8')
+      expect(nav).toContain('"link": "/guide/"')
+      expect(nav).not.toMatch(/installation|define-scheduler/)
+      expect(JSON.parse(nav)).not.toContainEqual(
+        expect.objectContaining({ link: '/' })
+      )
+    }
+  })
+})

--- a/docs/src/playground/highlight/twoslash.test.ts
+++ b/docs/src/playground/highlight/twoslash.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { collectHighlightedExportNames, keepTsFsrsTypeHover } from './twoslash'
+
+describe('Twoslash package hover filter', () => {
+  const exportNames = collectHighlightedExportNames([
+    {
+      content:
+        'declare class SchedulerCore {}\ndeclare const FSRS6Model: unknown\nexport { SchedulerCore, FSRS6Model }',
+      filePath: 'file:///node_modules/ts-fsrs/index.d.ts',
+    },
+    {
+      content:
+        'export declare function computeOptimalSteps(): void\nexport interface StepStatsResult {}',
+      filePath:
+        'file:///node_modules/@open-spaced-repetition/binding/index.d.ts',
+    },
+    {
+      content: 'export { SomethingElse }',
+      filePath: 'file:///node_modules/other/index.d.ts',
+    },
+  ])
+
+  it('collects exports only from highlighted package declarations', () => {
+    expect([...exportNames]).toEqual([
+      'SchedulerCore',
+      'FSRS6Model',
+      'computeOptimalSteps',
+      'StepStatsResult',
+    ])
+  })
+
+  it('keeps hovers backed by ts-fsrs exports', () => {
+    expect(
+      keepTsFsrsTypeHover(
+        { type: 'hover', text: 'const scheduler: SchedulerCore' },
+        exportNames
+      )
+    ).toBe(true)
+    expect(
+      keepTsFsrsTypeHover(
+        { type: 'hover', text: 'JSON.stringify(value: any): string' },
+        exportNames
+      )
+    ).toBe(false)
+    expect(
+      keepTsFsrsTypeHover(
+        { type: 'hover', text: 'function computeOptimalSteps(): void' },
+        exportNames
+      )
+    ).toBe(true)
+    expect(keepTsFsrsTypeHover({ type: 'error' }, exportNames)).toBe(true)
+  })
+})

--- a/docs/src/playground/highlight/twoslash.ts
+++ b/docs/src/playground/highlight/twoslash.ts
@@ -1,0 +1,79 @@
+import ts from 'typescript'
+import type { PlaygroundDeclaration } from '../editor/declarations'
+
+type TwoslashNode = {
+  readonly type: string
+  readonly text?: string
+}
+
+const highlightedPackageRoots = [
+  'file:///node_modules/ts-fsrs/',
+  'file:///node_modules/@open-spaced-repetition/binding/',
+]
+
+export function collectHighlightedExportNames(
+  declarations: readonly PlaygroundDeclaration[]
+): ReadonlySet<string> {
+  const names = new Set<string>()
+
+  for (const declaration of declarations) {
+    if (
+      !highlightedPackageRoots.some((root) =>
+        declaration.filePath.startsWith(root)
+      )
+    ) {
+      continue
+    }
+    const source = ts.createSourceFile(
+      declaration.filePath,
+      declaration.content,
+      ts.ScriptTarget.Latest,
+      false,
+      ts.ScriptKind.TS
+    )
+    for (const statement of source.statements) {
+      if (ts.isExportDeclaration(statement)) {
+        if (
+          statement.exportClause &&
+          ts.isNamedExports(statement.exportClause)
+        ) {
+          for (const element of statement.exportClause.elements) {
+            names.add(element.name.text)
+          }
+        }
+        continue
+      }
+
+      if (
+        !ts.canHaveModifiers(statement) ||
+        !ts
+          .getModifiers(statement)
+          ?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword)
+      ) {
+        continue
+      }
+
+      if (ts.isVariableStatement(statement)) {
+        for (const declaration of statement.declarationList.declarations) {
+          if (ts.isIdentifier(declaration.name))
+            names.add(declaration.name.text)
+        }
+      } else {
+        const name = 'name' in statement ? statement.name : undefined
+        if (name && ts.isIdentifier(name)) names.add(name.text)
+      }
+    }
+  }
+
+  return names
+}
+
+export function keepTsFsrsTypeHover(
+  node: TwoslashNode,
+  exportNames: ReadonlySet<string>
+): boolean {
+  if (node.type !== 'hover') return true
+  return (node.text?.match(/[A-Za-z_$][\w$]*/g) ?? []).some((name) =>
+    exportNames.has(name)
+  )
+}

--- a/docs/src/snippets/run-code/define-scheduler.ts
+++ b/docs/src/snippets/run-code/define-scheduler.ts
@@ -1,0 +1,30 @@
+import { dateChrono, defineScheduler, Rating } from 'ts-fsrs'
+import { FSRS6_DEFAULT_WEIGHTS, FSRS6Model } from 'ts-fsrs/models/fsrs-6'
+
+const scheduler = defineScheduler({
+  model: FSRS6Model,
+  chrono: dateChrono,
+}).create({
+  config: {
+    weights: FSRS6_DEFAULT_WEIGHTS,
+    enableShortTerm: true,
+    numRelearningSteps: 1,
+  },
+})
+
+const now = new Date('2026-01-01T00:00:00.000Z')
+const card = scheduler.newCard({ now })
+const result = scheduler.review({ card, grade: Rating.Good, now })
+
+console.log(
+  JSON.stringify(
+    {
+      state: result.card.state,
+      dueAt: result.card.dueAt,
+      stability: result.card.stability,
+      rating: result.revlog.rating,
+    },
+    null,
+    2
+  )
+)

--- a/docs/src/zh-CN/_nav.json
+++ b/docs/src/zh-CN/_nav.json
@@ -1,6 +1,5 @@
 [
-  { "text": "首页", "link": "/" },
-  { "text": "安装", "link": "/installation/" },
+  { "text": "指南", "link": "/guide/", "activeMatch": "/guide/" },
   { "text": "Playground", "link": "/playground" },
   { "text": "更新", "link": "/updates/" }
 ]

--- a/docs/src/zh-CN/guide/index.mdx
+++ b/docs/src/zh-CN/guide/index.mdx
@@ -1,0 +1,46 @@
+---
+title: 快速开始
+description: 安装 ts-fsrs，了解调度器的模型与时间系统组成，并在浏览器中运行完整的 defineScheduler 快速开始示例
+---
+
+import { PackageManagerTabs, Prompt } from '@rspress/core/theme'
+import RunCode from '../../components/RunCode'
+import code from '@/snippets/run-code/define-scheduler.ts?raw'
+
+# 快速开始
+
+`ts-fsrs` 是用于构建 FSRS 间隔重复系统的 TypeScript 工具包。声明式 API 将模型、时间系统和可选 middleware 组合成可复用的调度器定义。
+
+<Prompt
+  title="在 TypeScript 应用中集成 ts-fsrs"
+  description="复制这段提示词并发送给 AI Agent，让它安装 ts-fsrs 并创建可运行的 FSRS-6 调度器。"
+  prompt={`在我的 TypeScript 应用中集成 ts-fsrs。
+
+1. 安装 \`ts-fsrs\` package。
+2. 使用 \`defineScheduler\`、\`FSRS6Model\` 和 \`dateChrono\` 创建 FSRS-6 调度器。
+3. 创建一张新卡片，并使用 \`Rating.Good\` 完成一次复习。
+4. 保持实现最小化，并使用当前 ts-fsrs 公共 API。`}
+/>
+
+## 安装
+
+`ts-fsrs` 需要 Node.js 20 或更高版本。
+
+<PackageManagerTabs command="install ts-fsrs" />
+
+只有在训练 FSRS 参数或转换复习日志 CSV 时，才需要额外安装 `@open-spaced-repetition/binding`。
+
+## Quick start
+
+`defineScheduler` 使用 FSRS-6 模型和基于日期的时间系统创建可复用定义。`.create()` 会校验配置并返回独立的调度器。
+
+```ts twoslash file="../../snippets/run-code/define-scheduler.ts"
+```
+
+<RunCode code={code} />
+
+代码块自带的复制按钮会复制原始源码；也可以直接在专用 Worker 中运行。固定的 `now` 让输出保持可复现。
+
+- `newCard()` 创建符合该调度器默认结构的新卡片。
+- `review()` 返回新的卡片和复习日志，不会修改输入卡片。
+- 需要多个调度器时保留 definition；需要策略时，在 `.create()` 前通过 `.use(...)` 组合 middleware。

--- a/docs/src/zh-CN/installation/index.mdx
+++ b/docs/src/zh-CN/installation/index.mdx
@@ -1,8 +1,0 @@
----
-title: 安装
-description: 使用 npm、pnpm、Yarn、Bun 或 Deno 安装 ts-fsrs 与 FSRS 参数优化 binding
----
-
-import { PackageManagerTabs } from '@rspress/core/theme';
-
-<PackageManagerTabs command="install ts-fsrs @open-spaced-repetition/binding" />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,22 +68,25 @@ importers:
     devDependencies:
       '@rsbuild/plugin-tailwindcss':
         specifier: ^2.0.3
-        version: 2.0.3(@rsbuild/core@2.2.1)(@rspack/core@2.2.1(@swc/helpers@0.5.23))
+        version: 2.0.3(@rsbuild/core@2.1.13)(@rspack/core@2.1.10(@swc/helpers@0.5.23))
       '@rspress/core':
         specifier: 2.0.19
-        version: 2.0.19(@rspack/core@2.2.1(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.2)
+        version: 2.0.19(@rspack/core@2.1.10(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.2)
       '@rspress/plugin-rss':
         specifier: 2.0.19
-        version: 2.0.19(@rspress/core@2.0.19(@rspack/core@2.2.1(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.2))
+        version: 2.0.19(@rspress/core@2.0.19(@rspack/core@2.1.10(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.2))
+      '@rspress/plugin-twoslash':
+        specifier: 2.0.19
+        version: 2.0.19(@rspress/core@2.0.19(@rspack/core@2.1.10(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.2))(react@19.2.8)(typescript@6.0.3)
       '@types/react':
         specifier: 19.2.18
         version: 19.2.18
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3
-      typescript-compiler:
-        specifier: npm:typescript@6.0.3
-        version: typescript@6.0.3
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
 
   packages/binding:
     devDependencies:
@@ -261,8 +264,8 @@ importers:
 
 packages:
 
-  '@alloc/quick-lru@5.3.0':
-    resolution: {integrity: sha512-U4+70Pc5ZS9osnCBCE5Jha/ciHM+Yp+CNMNC/7HvYbNRk1Ldd+f7qO65W5qfhu/TCv+/ozljlXXe9Nj8419DMA==}
+  '@alloc/quick-lru@5.2.0':
+    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
   '@babel/code-frame@7.29.0':
@@ -645,6 +648,15 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@floating-ui/core@1.8.0':
+    resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
+
+  '@floating-ui/dom@1.8.0':
+    resolution: {integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==}
+
+  '@floating-ui/utils@0.2.12':
+    resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
 
   '@inquirer/ansi@2.0.7':
     resolution: {integrity: sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==}
@@ -1557,8 +1569,8 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
-  '@rsbuild/core@2.2.1':
-    resolution: {integrity: sha512-JcGtG4bo7PBihj6fBL6gaxaJihqLf7nGWW/t4zEmXpMJkV6XNdr1jAo9B0xI4mLAOmtFeva8cUbn9SE2ZEmAIw==}
+  '@rsbuild/core@2.1.13':
+    resolution: {integrity: sha512-Z+6MzmjOio4+bFZQ24k+7ge/oNCOdXIunAssrswTNE8AIf6mcyXpJZevRXRiOEMZasRPA8VNyh+9JngQLg729Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -1583,88 +1595,88 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  '@rspack/binding-darwin-arm64@2.2.1':
-    resolution: {integrity: sha512-Y/Naw/7V76QiUYdYRuBzBZtzRjt/3fjDUuF8GK0+/BO7BP1RrpY4tk1ln+iiqegRUD8u9uGn08fi8No1rwfyUg==}
+  '@rspack/binding-darwin-arm64@2.1.10':
+    resolution: {integrity: sha512-DZlcTpbIb2mjeS1aSG4k01UH33Zj7T+k8ZylPK6HmsKs4JvK4wgpWFC78WVv3p/Aj3MZS6DwtDLwpZ2Ihj/fpg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@2.2.1':
-    resolution: {integrity: sha512-rTIG/xZIW7RbEEuMR9hnNn5dv3fDBpX0N4FAQUwfhUYy3tN2+3vibTTq/Nj1Sd9Vn4yWydbWIEwBX6m/aGejig==}
+  '@rspack/binding-darwin-x64@2.1.10':
+    resolution: {integrity: sha512-my/0h2LwxCRT6cg3oDDC2e0ZOxQLVajAdIcv0fqnQk5JRNvVuL89PuTutitnSqie1A0/JSL8OQz5XHwmoS3kow==}
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-linux-arm64-gnu@2.2.1':
-    resolution: {integrity: sha512-53rAMU6Hqiat21IMU1hTt4Si2F33h+ZbXOt+Y18W39AFjcwmleIBId2u7beqJeGXLJuBgIAm31jcbJj/PN7mWQ==}
+  '@rspack/binding-linux-arm64-gnu@2.1.10':
+    resolution: {integrity: sha512-laevn9g+E5PAUEGqiKe6Ju5KApsuQYp+bPI17XS3Lkl8eqL5pS/BmHYU7QMlst4GzV8+wlruVTMh//+st6Vqzg==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-arm64-musl@2.2.1':
-    resolution: {integrity: sha512-o7zFiWkt4MqSfSdTbxUdF27fcrWKpRizcuVB8H3yd2G6xW9V2OfYbhVGQnOlbKi+GK74RkCmoJtANB+QboIqKQ==}
+  '@rspack/binding-linux-arm64-musl@2.1.10':
+    resolution: {integrity: sha512-V71+Qz5G72+ROZXrJn5zxOszdG1AEbO8pcC/itXXtf4yRR6a3bVHKNKGhipBNxb8eI6cnD/01FH1h3ZG655jLw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-ppc64-gnu@2.2.1':
-    resolution: {integrity: sha512-pvx1oeg1z7cr8OcNt7PAt1SJTHzdsN/pvu7HkGnfks2fWE7GDs9DLL2KvN7tUkzQvJm6bGgUwqSCOrqV4uSwAg==}
+  '@rspack/binding-linux-ppc64-gnu@2.1.10':
+    resolution: {integrity: sha512-U7HlNzHcDtZ+LYOtOJmtx67kHEybZzUUAaP7aEXjGYO5WTCgh/176sW2UYP0rmZLrgUNFUuzn+B98RLaClNaVg==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-riscv64-gnu@2.2.1':
-    resolution: {integrity: sha512-WQ6P94Wz2tgwOsgifTWP2/bV63iZH5+rkxngQwF22FC8KmIXXy/Yug7lyMH1ld8Hzg4p1qXjBBr4i1cCyJTR+w==}
+  '@rspack/binding-linux-riscv64-gnu@2.1.10':
+    resolution: {integrity: sha512-GMGTJpy9/ecE+5F5IfxZH4bXv0Wx/b2TiehTlCbTksbL+pKpLHYy0rwGdjWDKbmBkhxMMqPiC7PDnn9LbdnnLA==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-riscv64-musl@2.2.1':
-    resolution: {integrity: sha512-GEFUFHQkjKU7OYyHXnrIo8wWcUHM7jeKov5z6Lxd3i+3hKo11yBOgb7b+uD94Rx2tPuWF4jyFdWmcNu46Njb/A==}
+  '@rspack/binding-linux-riscv64-musl@2.1.10':
+    resolution: {integrity: sha512-rkurnAWc04vIbzG1QCrPBWSJadZvaOt1mazFH3EdiJO8VUiu0I1T9zdiwuDOPrd50lOKIZlcTXbd5aaAkWEnvQ==}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-s390x-gnu@2.2.1':
-    resolution: {integrity: sha512-Cqw2UjSmFGZaw1EjQXClKDud86ThynGEEIazy2PZfPzZG4WjICK1WjdeFCJd7xWsSbUQ3jGyzb7/EHiDVa+sKA==}
+  '@rspack/binding-linux-s390x-gnu@2.1.10':
+    resolution: {integrity: sha512-X+DyxkriZEAF/wihI7ERDv+CAS0mbMv36aEuQ+vXzTlvS6cSmpou/r29AHbvIF3NlG1UeAbDVlOs9QrMBZjpUQ==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-x64-gnu@2.2.1':
-    resolution: {integrity: sha512-QX+gRxg2CS9ri2fUG5eNurdsrOCWoJ56SsD2O7kcVGiRm+S2+muNb/QhkdkAdt/u/m++7Ve5TMIpHTnaKYCpCw==}
+  '@rspack/binding-linux-x64-gnu@2.1.10':
+    resolution: {integrity: sha512-Fat09V6jUuyo9qG7Wyj9cQ31VDfLmokXyBtGqKxY5OvSWHereB7QUub5btbPXHwbp6Iq4aAQyUbbLTzvR1YaBw==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-x64-musl@2.2.1':
-    resolution: {integrity: sha512-mBZQl1NdGbEB3y5M9d0tkuF7RL1GLz3Hb3gqFa3QRZBymP9PCV83Jiji8s2PJimNUJIVcdZRIw8+VGYs/35c2A==}
+  '@rspack/binding-linux-x64-musl@2.1.10':
+    resolution: {integrity: sha512-lhHOnIJ4ClpIlA1f1L8aoxEZivYLjnjq5A6jKKz7BKsm+cHK8kqqEm6lO5KqA5xQT0Lonq1o28bmKHEj6JHInw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-wasm32-wasi@2.2.1':
-    resolution: {integrity: sha512-/d2ImKDS+lT+FJ07MxKBeUkTat84tr2Nm2+nIRt8HmZK7/N8odkQml9vb4MHr8E7oYOp4B+jm6W5frdRzKrkJQ==}
+  '@rspack/binding-wasm32-wasi@2.1.10':
+    resolution: {integrity: sha512-KY5YbWbuvYcoaLXnV+vzZOvGRCeb6jt4EpVpKdph1h1IJjwX/ju15EQ+GOe3iecZEdf0OttQcNVcwBkLkFT9ag==}
     cpu: [wasm32]
 
-  '@rspack/binding-win32-arm64-msvc@2.2.1':
-    resolution: {integrity: sha512-TfmaKPF3KC7uoZb6A+8ZUbLS8g8P5EdeXFGLCaJ+UgdkJ20TsapcfJXZXWNnKzFEkV8dUO/t5oNxNLYy2URusw==}
+  '@rspack/binding-win32-arm64-msvc@2.1.10':
+    resolution: {integrity: sha512-z4GWzMLofaDGpAt9Z+MlN88LlUBDm+zM6R2GdOOPM6/4g/h3/+47OP7casmSL3AwTGYBEJqogwt08sRSosB6Cg==}
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@2.2.1':
-    resolution: {integrity: sha512-rdBXayngvpQFMSUIC4b71FDZrSBJszSHNEkln/Nis3a17DMAE7IkgJcqe7SqLWbk2OPF/N920AOWmBEDQQCaMg==}
+  '@rspack/binding-win32-ia32-msvc@2.1.10':
+    resolution: {integrity: sha512-7qcWdsZ+GuGtzKjqgy7wTN7Dso/ezIY8yhx1r2yIbcczdmXj4FhaEampMDp/25HwtKwIGBBoh6HHSt3JWxpTUg==}
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@2.2.1':
-    resolution: {integrity: sha512-l3K4s7nrQJc+3LacPFjZGjX8Jk1sf8Q4TK6IXAsdSucOjTqYSpD8PMl2NUXCBDXOl8T2V4v323z1LfxwW8BPmA==}
+  '@rspack/binding-win32-x64-msvc@2.1.10':
+    resolution: {integrity: sha512-pgp23pLrzfhGnKycxzr7ifP17lAbWZEfnx1bX8gXtYrnpJ66DRNyTKSzxB6sa/HBWjS1L8PX5TjMZ44WfPydqQ==}
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding@2.2.1':
-    resolution: {integrity: sha512-56TqztuEMd+aHGv1jDXnkJQGSLTb4NoO146flFxJqPG8931UdXPO2pNR9M0Q2Pz+GvmO0fLHGPLYBHoRVrRlHw==}
+  '@rspack/binding@2.1.10':
+    resolution: {integrity: sha512-vnu/UP5HnrND15lO9+VeG6eUrbTyycHNQNQ3XEiRiFojuoiGZkIZC3Hbzr8qQH44C6vScPODEPvvIVvLcO2LpQ==}
 
-  '@rspack/core@2.2.1':
-    resolution: {integrity: sha512-EHFX2oWCY1HkHJkG/Ev8HXCcl4gQzgETyairdIlBkKaypuW8i7kowBxUFzpHHg/ObF70vB3focToel9Wwg4MRA==}
+  '@rspack/core@2.1.10':
+    resolution: {integrity: sha512-YSS2/Xxz8uiG/KXDkqOoA3dTetNo/vysk7bAexQOrU8iuq7JuzDTTAwLKvWZnwmvME8M8m5wcM4YvfIwYmidHA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
@@ -1694,6 +1706,14 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@rspress/core': ^2.0.10
+
+  '@rspress/plugin-twoslash@2.0.19':
+    resolution: {integrity: sha512-ggS9NayRg23hNmlhji7F4RkOGkLWV0FzktundSr41rivvaT6GhogPEsoAzQoE4b+HrTiWORs7sPWIZrsdS8Izg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@rspress/core': ^2.0.10
+      react: '>=18.0.0'
+      typescript: ^6.0.3
 
   '@rspress/shared@2.0.19':
     resolution: {integrity: sha512-INrETllWuR49lksqCz+xeLSO6rKtHA+5Ix2YQWcP9nerCuTSyGYwH8eBC0HrIacJkGHxB8wkkbV99tyzGtY8Wg==}
@@ -1725,6 +1745,12 @@ packages:
   '@shikijs/themes@4.4.3':
     resolution: {integrity: sha512-w8UHjeUnIR965KMWJHUPXOc2mNJUnK3vpVLYLvw5IYU2mnTTJ89E24OrJDBNiJDQ0qzb0tc4l7mrIXx5cFeIyw==}
     engines: {node: '>=20'}
+
+  '@shikijs/twoslash@4.4.3':
+    resolution: {integrity: sha512-m7HNzunEIHRk1jCya3ngGsO3+8pYxrPIIxtdJewg/W8ceW/+m/mSsm4jM3L9DvYYNa8Rvbu7Dabt3BOpCclz8Q==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      typescript: '>=5.5.0'
 
   '@shikijs/types@4.4.3':
     resolution: {integrity: sha512-UEJxmRR++MAGR6hugn0vgVS2W/6lWAts84FFSrnlH9sP0LNol7E5+NQ792pH8liWUhyMyjhTgSUH3k7iD7tc5g==}
@@ -2044,8 +2070,13 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@ungap/structured-clone@1.4.0':
-    resolution: {integrity: sha512-1mEZtMKPM09vDmQt5y7YvmN2+DFTP7Tg0EWXdic8/C6VRnpb33e4ghisCIE3WZjsE2N8mf+QV1Zqh7ZFYLWInQ==}
+  '@typescript/vfs@1.6.4':
+    resolution: {integrity: sha512-PJFXFS4ZJKiJ9Qiuix6Dz/OwEIqHD7Dme1UwZhTK11vR+5dqW2ACbdndWQexBzCx+CPuMe5WBYQWCsFyGlQLlQ==}
+    peerDependencies:
+      typescript: '*'
+
+  '@ungap/structured-clone@1.3.3':
+    resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
 
   '@unhead/react@2.1.17':
     resolution: {integrity: sha512-KmcYksDjlLozL0fxUjIDwH/0k6+Lg2HWHLUPlkRW8Gl08hdB1AbLB5iU9QxFvkaT8p0Q4dFEqZWnz3g6RMeiRA==}
@@ -2483,8 +2514,8 @@ packages:
   estree-util-is-identifier-name@3.0.0:
     resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
 
-  estree-util-scope@1.0.1:
-    resolution: {integrity: sha512-B0np3dcdxqILX5e9nEi5/Fr4K7gL4oYFVPV1zRa2e9wRCbQoZZNWOZFYyoInvXUPJXBXjss+QXlWLJChDEHDkA==}
+  estree-util-scope@1.0.0:
+    resolution: {integrity: sha512-2CAASclonf+JFWBNJPndcOpA8EMJwa0Q8LUFJEKqXLW6+qBvbFZuF5gItbQOs/umBUkjviCSDCbBwU2cXbmrhQ==}
 
   estree-util-to-js@2.0.0:
     resolution: {integrity: sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==}
@@ -3088,8 +3119,8 @@ packages:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3208,8 +3239,8 @@ packages:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
 
-  postcss@8.5.14:
-    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prettier@2.8.8:
@@ -3258,15 +3289,15 @@ packages:
     peerDependencies:
       react: '>=19'
 
-  react-router-dom@7.18.3:
-    resolution: {integrity: sha512-ytVbyBBM7vMfRCam25r0WMhSVSom909A8p+8m0/f1w853dz/xfFu6etAT2SEbVoSnI+ZoPRDqIsQXVT89gp7kg==}
+  react-router-dom@7.18.2:
+    resolution: {integrity: sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
       react-dom: '>=18'
 
-  react-router@7.18.3:
-    resolution: {integrity: sha512-gyXgtdr5uACJ5b1Q4udzjVV+tb/rlHIMJKuJ0e89R4Kzgz47z/rgP0dIKxktqIEUhDHluGTPJJH/wRha7CyqsA==}
+  react-router@7.18.2:
+    resolution: {integrity: sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -3616,6 +3647,14 @@ packages:
     resolution: {integrity: sha512-lCPgus1NuTiBdaITWqzSH/Ff6HVL8HHGBtOXHg1dHRfcshN79XkygSdh0M6g8b0td91ILLG5MTkLOkp5UvyPJw==}
     hasBin: true
 
+  twoslash-protocol@0.3.9:
+    resolution: {integrity: sha512-9/iwp+CXOnjFMPQuPL5PkuRbZnDoNpBvtJCLs9t8kDYkL3YHujbvnHfZA1i5fApDftVEdBw+T/4F+dH5kIzpYQ==}
+
+  twoslash@0.3.9:
+    resolution: {integrity: sha512-rDclk+OtzuTX+tnea7DYLCkqGQ3eP0IyfD+kzUJ7t46X/NzlaxwrhecmEBNuSCuEn3V+n1PhcjUUQQ7gUJzX5Q==}
+    peerDependencies:
+      typescript: ^5.5.0 || ^6.0.0
+
   typanion@3.14.0:
     resolution: {integrity: sha512-ZW/lVMRabETuYCd9O9ZvMhAh8GslSqaUjxmK/JLPCh6l73CvLBiuXswj/+7LdnWOgYsQ130FqLzFz5aGT4I3Ug==}
 
@@ -3831,7 +3870,7 @@ packages:
 
 snapshots:
 
-  '@alloc/quick-lru@5.3.0': {}
+  '@alloc/quick-lru@5.2.0': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -4267,6 +4306,17 @@ snapshots:
   '@esbuild/win32-x64@0.27.2':
     optional: true
 
+  '@floating-ui/core@1.8.0':
+    dependencies:
+      '@floating-ui/utils': 0.2.12
+
+  '@floating-ui/dom@1.8.0':
+    dependencies:
+      '@floating-ui/core': 1.8.0
+      '@floating-ui/utils': 0.2.12
+
+  '@floating-ui/utils@0.2.12': {}
+
   '@inquirer/ansi@2.0.7': {}
 
   '@inquirer/checkbox@5.2.1(@types/node@25.6.2)':
@@ -4440,7 +4490,7 @@ snapshots:
       collapse-white-space: 2.1.0
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
-      estree-util-scope: 1.0.1
+      estree-util-scope: 1.0.0
       estree-walker: 3.0.3
       hast-util-to-jsx-runtime: 2.3.6
       markdown-extensions: 2.0.0
@@ -4989,112 +5039,112 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@rsbuild/core@2.2.1':
+  '@rsbuild/core@2.1.13':
     dependencies:
-      '@rspack/core': 2.2.1(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.10(@swc/helpers@0.5.23)
       '@swc/helpers': 0.5.23
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.1(@swc/helpers@0.5.23))':
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.13)(@rspack/core@2.1.10(@swc/helpers@0.5.23))':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.2.1(@swc/helpers@0.5.23))(react-refresh@0.18.0)
+      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.10(@swc/helpers@0.5.23))(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rsbuild/core': 2.2.1
+      '@rsbuild/core': 2.1.13
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-tailwindcss@2.0.3(@rsbuild/core@2.2.1)(@rspack/core@2.2.1(@swc/helpers@0.5.23))':
+  '@rsbuild/plugin-tailwindcss@2.0.3(@rsbuild/core@2.1.13)(@rspack/core@2.1.10(@swc/helpers@0.5.23))':
     dependencies:
-      '@tailwindcss/webpack': 4.3.3(@rspack/core@2.2.1(@swc/helpers@0.5.23))
+      '@tailwindcss/webpack': 4.3.3(@rspack/core@2.1.10(@swc/helpers@0.5.23))
     optionalDependencies:
-      '@rsbuild/core': 2.2.1
+      '@rsbuild/core': 2.1.13
     transitivePeerDependencies:
       - '@rspack/core'
       - webpack
 
-  '@rspack/binding-darwin-arm64@2.2.1':
+  '@rspack/binding-darwin-arm64@2.1.10':
     optional: true
 
-  '@rspack/binding-darwin-x64@2.2.1':
+  '@rspack/binding-darwin-x64@2.1.10':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@2.2.1':
+  '@rspack/binding-linux-arm64-gnu@2.1.10':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@2.2.1':
+  '@rspack/binding-linux-arm64-musl@2.1.10':
     optional: true
 
-  '@rspack/binding-linux-ppc64-gnu@2.2.1':
+  '@rspack/binding-linux-ppc64-gnu@2.1.10':
     optional: true
 
-  '@rspack/binding-linux-riscv64-gnu@2.2.1':
+  '@rspack/binding-linux-riscv64-gnu@2.1.10':
     optional: true
 
-  '@rspack/binding-linux-riscv64-musl@2.2.1':
+  '@rspack/binding-linux-riscv64-musl@2.1.10':
     optional: true
 
-  '@rspack/binding-linux-s390x-gnu@2.2.1':
+  '@rspack/binding-linux-s390x-gnu@2.1.10':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@2.2.1':
+  '@rspack/binding-linux-x64-gnu@2.1.10':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@2.2.1':
+  '@rspack/binding-linux-x64-musl@2.1.10':
     optional: true
 
-  '@rspack/binding-wasm32-wasi@2.2.1':
+  '@rspack/binding-wasm32-wasi@2.1.10':
     dependencies:
       '@emnapi/core': 1.11.3
       '@emnapi/runtime': 1.11.3
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@2.2.1':
+  '@rspack/binding-win32-arm64-msvc@2.1.10':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@2.2.1':
+  '@rspack/binding-win32-ia32-msvc@2.1.10':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@2.2.1':
+  '@rspack/binding-win32-x64-msvc@2.1.10':
     optional: true
 
-  '@rspack/binding@2.2.1':
+  '@rspack/binding@2.1.10':
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': 2.2.1
-      '@rspack/binding-darwin-x64': 2.2.1
-      '@rspack/binding-linux-arm64-gnu': 2.2.1
-      '@rspack/binding-linux-arm64-musl': 2.2.1
-      '@rspack/binding-linux-ppc64-gnu': 2.2.1
-      '@rspack/binding-linux-riscv64-gnu': 2.2.1
-      '@rspack/binding-linux-riscv64-musl': 2.2.1
-      '@rspack/binding-linux-s390x-gnu': 2.2.1
-      '@rspack/binding-linux-x64-gnu': 2.2.1
-      '@rspack/binding-linux-x64-musl': 2.2.1
-      '@rspack/binding-wasm32-wasi': 2.2.1
-      '@rspack/binding-win32-arm64-msvc': 2.2.1
-      '@rspack/binding-win32-ia32-msvc': 2.2.1
-      '@rspack/binding-win32-x64-msvc': 2.2.1
+      '@rspack/binding-darwin-arm64': 2.1.10
+      '@rspack/binding-darwin-x64': 2.1.10
+      '@rspack/binding-linux-arm64-gnu': 2.1.10
+      '@rspack/binding-linux-arm64-musl': 2.1.10
+      '@rspack/binding-linux-ppc64-gnu': 2.1.10
+      '@rspack/binding-linux-riscv64-gnu': 2.1.10
+      '@rspack/binding-linux-riscv64-musl': 2.1.10
+      '@rspack/binding-linux-s390x-gnu': 2.1.10
+      '@rspack/binding-linux-x64-gnu': 2.1.10
+      '@rspack/binding-linux-x64-musl': 2.1.10
+      '@rspack/binding-wasm32-wasi': 2.1.10
+      '@rspack/binding-win32-arm64-msvc': 2.1.10
+      '@rspack/binding-win32-ia32-msvc': 2.1.10
+      '@rspack/binding-win32-x64-msvc': 2.1.10
 
-  '@rspack/core@2.2.1(@swc/helpers@0.5.23)':
+  '@rspack/core@2.1.10(@swc/helpers@0.5.23)':
     dependencies:
-      '@rspack/binding': 2.2.1
+      '@rspack/binding': 2.1.10
     optionalDependencies:
       '@swc/helpers': 0.5.23
 
-  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.2.1(@swc/helpers@0.5.23))(react-refresh@0.18.0)':
+  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.1.10(@swc/helpers@0.5.23))(react-refresh@0.18.0)':
     dependencies:
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rspack/core': 2.2.1(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.10(@swc/helpers@0.5.23)
 
-  '@rspress/core@2.0.19(@rspack/core@2.2.1(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.2)':
+  '@rspress/core@2.0.19(@rspack/core@2.1.10(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.2)':
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@mdx-js/react': 3.1.1(@types/react@19.2.18)(react@19.2.8)
-      '@rsbuild/core': 2.2.1
-      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.2.1)(@rspack/core@2.2.1(@swc/helpers@0.5.23))
+      '@rsbuild/core': 2.1.13
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.13)(@rspack/core@2.1.10(@swc/helpers@0.5.23))
       '@rspress/shared': 2.0.19
       '@shikijs/rehype': 4.4.3
       '@types/mdast': 4.0.4
@@ -5114,7 +5164,7 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
       react-lazy-with-preload: 2.2.1
       react-render-to-markdown: 19.1.0(react@19.2.8)
-      react-router-dom: 7.18.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react-router-dom: 7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       rehype-external-links: 3.0.0
       rehype-raw: 7.0.0
       remark-cjk-friendly: 2.3.1(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2)(unified@11.0.5)
@@ -5137,14 +5187,29 @@ snapshots:
       - micromark-util-types
       - supports-color
 
-  '@rspress/plugin-rss@2.0.19(@rspress/core@2.0.19(@rspack/core@2.2.1(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.2))':
+  '@rspress/plugin-rss@2.0.19(@rspress/core@2.0.19(@rspack/core@2.1.10(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.2))':
     dependencies:
-      '@rspress/core': 2.0.19(@rspack/core@2.2.1(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.19(@rspack/core@2.1.10(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.2)
       feed: 5.2.1
+
+  '@rspress/plugin-twoslash@2.0.19(@rspress/core@2.0.19(@rspack/core@2.1.10(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.2))(react@19.2.8)(typescript@6.0.3)':
+    dependencies:
+      '@floating-ui/dom': 1.8.0
+      '@rspress/core': 2.0.19(@rspack/core@2.1.10(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@shikijs/twoslash': 4.4.3(typescript@6.0.3)
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm: 3.1.0
+      mdast-util-to-hast: 13.2.1
+      picocolors: 1.1.1
+      react: 19.2.8
+      twoslash: 0.3.9(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@rspress/shared@2.0.19':
     dependencies:
-      '@rsbuild/core': 2.2.1
+      '@rsbuild/core': 2.1.13
       '@shikijs/rehype': 4.4.3
       '@types/react': 19.2.18
       mdast-util-mdx-jsx: 3.2.0
@@ -5195,6 +5260,15 @@ snapshots:
   '@shikijs/themes@4.4.3':
     dependencies:
       '@shikijs/types': 4.4.3
+
+  '@shikijs/twoslash@4.4.3(typescript@6.0.3)':
+    dependencies:
+      '@shikijs/core': 4.4.3
+      '@shikijs/types': 4.4.3
+      twoslash: 0.3.9(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@shikijs/types@4.4.3':
     dependencies:
@@ -5270,14 +5344,14 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.3
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.3
 
-  '@tailwindcss/webpack@4.3.3(@rspack/core@2.2.1(@swc/helpers@0.5.23))':
+  '@tailwindcss/webpack@4.3.3(@rspack/core@2.1.10(@swc/helpers@0.5.23))':
     dependencies:
-      '@alloc/quick-lru': 5.3.0
+      '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.3
       '@tailwindcss/oxide': 4.3.3
       tailwindcss: 4.3.3
     optionalDependencies:
-      '@rspack/core': 2.2.1(@swc/helpers@0.5.23)
+      '@rspack/core': 2.1.10(@swc/helpers@0.5.23)
 
   '@taplo/cli@0.7.0': {}
 
@@ -5413,7 +5487,14 @@ snapshots:
   '@typescript/typescript-win32-x64@7.0.2':
     optional: true
 
-  '@ungap/structured-clone@1.4.0': {}
+  '@typescript/vfs@1.6.4(typescript@6.0.3)':
+    dependencies:
+      debug: 4.4.3
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@ungap/structured-clone@1.3.3': {}
 
   '@unhead/react@2.1.17(react@19.2.8)':
     dependencies:
@@ -5770,7 +5851,7 @@ snapshots:
 
   estree-util-is-identifier-name@3.0.0: {}
 
-  estree-util-scope@1.0.1:
+  estree-util-scope@1.0.0:
     dependencies:
       '@types/estree': 1.0.8
       devlop: 1.1.0
@@ -5913,7 +5994,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.5
       '@types/unist': 3.0.3
-      '@ungap/structured-clone': 1.4.0
+      '@ungap/structured-clone': 1.3.3
       hast-util-from-parse5: 8.0.3
       hast-util-to-parse5: 8.0.1
       html-void-elements: 3.0.0
@@ -6319,7 +6400,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
-      '@ungap/structured-clone': 1.4.0
+      '@ungap/structured-clone': 1.3.3
       devlop: 1.1.0
       micromark-util-sanitize-uri: 2.0.1
       trim-lines: 3.0.1
@@ -6683,7 +6764,7 @@ snapshots:
 
   mute-stream@3.0.0: {}
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.18: {}
 
   node-fetch@2.7.0:
     dependencies:
@@ -6778,9 +6859,9 @@ snapshots:
 
   pify@4.0.1: {}
 
-  postcss@8.5.14:
+  postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -6817,13 +6898,13 @@ snapshots:
       react: 19.2.8
       react-reconciler: 0.33.0(react@19.2.8)
 
-  react-router-dom@7.18.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  react-router-dom@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
-      react-router: 7.18.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react-router: 7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
 
-  react-router@7.18.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  react-router@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       cookie: 1.1.1
       react: 19.2.8
@@ -6887,7 +6968,7 @@ snapshots:
   rehype-external-links@3.0.0:
     dependencies:
       '@types/hast': 3.0.5
-      '@ungap/structured-clone': 1.4.0
+      '@ungap/structured-clone': 1.3.3
       hast-util-is-element: 3.0.0
       is-absolute-url: 4.0.1
       space-separated-tokens: 2.0.2
@@ -7236,6 +7317,16 @@ snapshots:
       '@turbo/windows-64': 2.9.12
       '@turbo/windows-arm64': 2.9.12
 
+  twoslash-protocol@0.3.9: {}
+
+  twoslash@0.3.9(typescript@6.0.3):
+    dependencies:
+      '@typescript/vfs': 1.6.4(typescript@6.0.3)
+      twoslash-protocol: 0.3.9
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   typanion@3.14.0: {}
 
   typescript@6.0.3: {}
@@ -7348,7 +7439,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
-      postcss: 8.5.14
+      postcss: 8.5.26
       rolldown: 1.0.0-rc.18
       tinyglobby: 0.2.17
     optionalDependencies:


### PR DESCRIPTION
## Summary

- replace the installation page with a task-oriented Guide and Getting Started page
- add a runnable `defineScheduler` example backed by the existing worker runner
- use one checked-in snippet for rendering, exact code copy, and execution
- add Twoslash hovers derived from exports of `ts-fsrs` and `@open-spaced-repetition/binding`
- remove the redundant Home navigation item and keep the site title as the home link

## Validation

- 73 docs tests
- docs typecheck and Biome check
- frozen lockfile validation
- production Rspress build

## Stack

4 of 4. Base: `docs/preview`.