### PR TITLE
test(docs): run browser examples with Playwright

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -71,6 +71,12 @@ jobs:
       - name: Test docs
         run: pnpm --filter @ts-fsrs/website test:docs
 
+      - name: Install Playwright browser
+        run: pnpm --filter @ts-fsrs/website exec playwright install --with-deps --only-shell chromium
+
+      - name: Test docs E2E
+        run: pnpm --filter @ts-fsrs/website test:e2e
+
       - name: Save preview metadata
         env:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,8 @@ docs/src/public/revlog.csv
 # Documentation and coverage
 **/coverage/
 /docs/doc_build/
+/docs/playwright-report/
+/docs/test-results/
 
 # Rust
 target/

--- a/docs/e2e/docs.spec.ts
+++ b/docs/e2e/docs.spec.ts
@@ -1,0 +1,127 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { expect, test } from '@playwright/test'
+import ts from 'typescript'
+import { sourceId } from '../src/playground/shared/source-id'
+
+const docsRoot = path.resolve(import.meta.dirname, '..')
+const buildRoot = path.join(docsRoot, 'doc_build')
+const snippetsRoot = path.join(docsRoot, 'src/snippets')
+
+function filesIn(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const file = path.join(directory, entry.name)
+    return entry.isDirectory() ? filesIn(file) : [file]
+  })
+}
+
+function routeFor(file: string): string {
+  const relative = path.relative(buildRoot, file).split(path.sep).join('/')
+  if (relative === 'index.html') return '/'
+  if (relative.endsWith('/index.html'))
+    return `/${relative.slice(0, -'index.html'.length)}`
+  return `/${relative}`
+}
+
+if (!existsSync(buildRoot)) {
+  throw new Error('Missing docs/doc_build. Run pnpm docs:build first.')
+}
+
+const runCodeRoutes = filesIn(buildRoot)
+  .filter((file) => file.endsWith('.html'))
+  .filter((file) => readFileSync(file, 'utf8').includes('run-code-test'))
+  .map(routeFor)
+
+const snippets = new Map<
+  string,
+  { readonly file: string; readonly outputFile: string }
+>()
+for (const file of filesIn(snippetsRoot)) {
+  if (!file.endsWith('.ts') || file.endsWith('.output.ts')) continue
+  const id = sourceId(readFileSync(file, 'utf8'))
+  const duplicate = snippets.get(id)
+  if (duplicate) {
+    throw new Error(
+      `Duplicate RunCode source id ${id}: ${path.relative(docsRoot, duplicate.file)} and ${path.relative(docsRoot, file)}`
+    )
+  }
+  snippets.set(id, {
+    file,
+    outputFile: file.replace(/\.ts$/, '.output.ts'),
+  })
+}
+
+async function expectedOutput(file: string): Promise<readonly string[]> {
+  const javascript = ts.transpileModule(readFileSync(file, 'utf8'), {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2022,
+    },
+    fileName: file,
+  }).outputText
+  const moduleUrl = `data:text/javascript;base64,${Buffer.from(javascript).toString('base64')}#${encodeURIComponent(pathToFileURL(file).href)}`
+  const value: unknown = (await import(moduleUrl)).default
+  const lines = typeof value === 'string' ? [value] : value
+  if (!Array.isArray(lines) || !lines.every((line) => typeof line === 'string'))
+    throw new Error(`${file} must default-export a string or string array.`)
+  return lines
+}
+
+for (const route of runCodeRoutes) {
+  test(`RunCode succeeds on ${route}`, async ({ page }) => {
+    const pageErrors: string[] = []
+    page.on('pageerror', (error) => pageErrors.push(error.message))
+
+    await page.goto(route)
+    const runners = page.getByTestId('run-code-test')
+    const count = await runners.count()
+    expect(count).toBeGreaterThan(0)
+
+    for (let index = 0; index < count; index += 1) {
+      const runner = runners.nth(index)
+      const id = await runner.getAttribute('data-run-code-source')
+      const snippet = id ? snippets.get(id) : undefined
+      expect(snippet, `Unknown RunCode source id: ${id}`).toBeDefined()
+
+      await runner.getByTestId('run-code-button').click()
+      await expect(runner).toHaveAttribute(
+        'data-run-code-status',
+        /^(success|error)$/
+      )
+      const status = await runner.getAttribute('data-run-code-status')
+      const output = runner.getByTestId('run-code-output')
+      const message = (await output.count()) > 0 ? await output.innerText() : ''
+      expect(status, message).toBe('success')
+
+      if (snippet && existsSync(snippet.outputFile)) {
+        const actual = await runner
+          .getByTestId('worker-log')
+          .evaluateAll((elements) =>
+            elements.map((element) => element.getAttribute('data-log-text'))
+          )
+        expect(actual).toEqual(await expectedOutput(snippet.outputFile))
+      }
+    }
+
+    expect(pageErrors).toEqual([])
+  })
+}
+
+test('Playground runs its default example', async ({ page }) => {
+  const pageErrors: string[] = []
+  page.on('pageerror', (error) => pageErrors.push(error.message))
+
+  await page.goto('/playground.html')
+  const run = page.getByTestId('playground-run')
+  await expect(run).toBeEnabled()
+  await run.click()
+
+  const output = page.getByTestId('playground-output')
+  await expect(output).toHaveAttribute('data-state', /^(success|error)$/)
+  expect(
+    await output.getAttribute('data-state'),
+    await output.innerText()
+  ).toBe('success')
+  expect(pageErrors).toEqual([])
+})

--- a/docs/e2e/docs.spec.ts
+++ b/docs/e2e/docs.spec.ts
@@ -117,6 +117,9 @@ test('Playground runs its default example', async ({ page }) => {
   await expect(run).toBeEnabled()
   await run.click()
 
+  await expect(run).toBeDisabled()
+  await expect(run).toBeEnabled()
+
   const output = page.getByTestId('playground-output')
   await expect(output).toHaveAttribute('data-state', /^(success|error)$/)
   expect(

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,6 +11,7 @@
     "check:fix": "biome check --write .",
     "typecheck": "tsc --noEmit --pretty false",
     "test:docs": "vitest run --config vitest.config.ts",
+    "test:e2e": "playwright test",
     "prepare:packages": "node scripts/prepare-wasm-package.mjs",
     "prepare:revlog": "node scripts/fetch-revlog.mjs",
     "verify:packages": "node scripts/verify-packages.mjs"
@@ -25,6 +26,7 @@
     "ts-fsrs": "workspace:*"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
     "@rsbuild/plugin-tailwindcss": "^2.0.3",
     "@rspress/core": "2.0.19",
     "@rspress/plugin-rss": "2.0.19",

--- a/docs/playwright.config.ts
+++ b/docs/playwright.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  expect: { timeout: 120_000 },
+  testDir: './e2e',
+  timeout: 120_000,
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+    trace: 'retain-on-failure',
+  },
+  webServer: {
+    command: 'pnpm exec rspress preview --host 127.0.0.1 --port 4173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    url: 'http://127.0.0.1:4173',
+  },
+  workers: process.env.CI ? 1 : undefined,
+})

--- a/docs/src/components/RunCode.tsx
+++ b/docs/src/components/RunCode.tsx
@@ -1,20 +1,32 @@
 import { useI18n } from '@rspress/core/runtime'
 import WorkerLogLine from '@/components/WorkerLogLine'
 import { usePlaygroundRunner } from '@/playground/runner/use-playground-runner'
+import { sourceId } from '@/playground/shared/source-id'
 import * as styles from '@/playground/shared/styles'
 import { cn } from '@/utils/cn'
 
 type Props = {
   readonly code: string
+  readonly test?: boolean
 }
 
-export default function RunCode({ code }: Props) {
+export default function RunCode({ code, test = true }: Props) {
   const t = useI18n<typeof import('i18n')>()
   const runner = usePlaygroundRunner()
   const hasOutput = runner.logs.length > 0 || runner.error
+  const testStatus = runner.error
+    ? 'error'
+    : runner.durationMs !== undefined
+      ? 'success'
+      : runner.state
 
   return (
-    <div className="rp-not-doc my-3">
+    <div
+      className="rp-not-doc my-3"
+      data-run-code-source={test ? sourceId(code) : undefined}
+      data-run-code-status={test ? testStatus : undefined}
+      data-testid={test ? 'run-code-test' : undefined}
+    >
       <button
         className={cn(styles.button, styles.primaryButton)}
         data-testid="run-code-button"

--- a/docs/src/components/WorkerLogLine.tsx
+++ b/docs/src/components/WorkerLogLine.tsx
@@ -59,7 +59,12 @@ export default function WorkerLogLine({ className, line }: Props) {
 
   if (!json) {
     return (
-      <div className={row} data-level={line.level}>
+      <div
+        className={row}
+        data-level={line.level}
+        data-log-text={line.text}
+        data-testid="worker-log"
+      >
         <pre className="m-0 min-w-0 border-0 bg-transparent font-[inherit] break-words whitespace-pre-wrap">
           {line.text}
         </pre>
@@ -72,8 +77,10 @@ export default function WorkerLogLine({ className, line }: Props) {
     <div
       // Without `rp-not-doc` the viewer's nested <ul> is laid out as prose.
       className={cn(row, 'rp-not-doc', 'playground-log--json')}
+      data-json="true"
       data-level={line.level}
-      data-testid="worker-json"
+      data-log-text={line.text}
+      data-testid="worker-log"
     >
       {/* The tree is the flexible column: without `min-w-0` a wide value would
           push the timestamp off the edge instead of wrapping. */}

--- a/docs/src/playground/shared/source-id.ts
+++ b/docs/src/playground/shared/source-id.ts
@@ -1,0 +1,8 @@
+export function sourceId(source: string): string {
+  let hash = 0x811c9dc5
+  for (let index = 0; index < source.length; index += 1) {
+    hash ^= source.charCodeAt(index)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return (hash >>> 0).toString(36)
+}

--- a/docs/src/snippets/run-code/define-scheduler.output.ts
+++ b/docs/src/snippets/run-code/define-scheduler.output.ts
@@ -1,0 +1,6 @@
+export default `{
+  "state": 2,
+  "dueAt": "2026-01-03T00:00:00.000Z",
+  "stability": 2.3065,
+  "rating": 3
+}`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
         specifier: workspace:*
         version: link:../packages/fsrs
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.62.1
+        version: 1.62.1
       '@rsbuild/plugin-tailwindcss':
         specifier: ^2.0.3
         version: 2.0.3(@rsbuild/core@2.1.13)(@rspack/core@2.1.10(@swc/helpers@0.5.23))
@@ -1274,6 +1277,11 @@ packages:
 
   '@oxc-project/types@0.139.0':
     resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
+
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
@@ -2584,6 +2592,11 @@ packages:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3238,6 +3251,16 @@ packages:
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   postcss@8.5.26:
     resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
@@ -4884,6 +4907,10 @@ snapshots:
 
   '@oxc-project/types@0.139.0': {}
 
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
+
   '@quansync/fs@1.0.0':
     dependencies:
       quansync: 1.0.0
@@ -5934,6 +5961,9 @@ snapshots:
       jsonfile: 4.0.0
       universalify: 0.1.2
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -6858,6 +6888,14 @@ snapshots:
   pidtree@0.6.0: {}
 
   pify@4.0.1: {}
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.26:
     dependencies:


### PR DESCRIPTION
## Summary

- run every test-enabled RunCode example in Chromium with automatic page and snippet discovery
- compare exact worker logs when a matching `*.output.ts` fixture exists
- add an independent Playground smoke test
- split unit tests into `test:docs` and browser tests into `test:e2e`
- install only Chromium Headless Shell in Docs Preview CI

## Validation

- `test:docs`: 73 tests
- `test:e2e`: 4 tests
- docs typecheck and Biome check
- frozen lockfile validation
- production Rspress build

## Stack

5 of 5. Base: `docs/runcode`.