### PR TITLE
fix(kit): flatten scheduler card return types in QuickInfo

### DIFF
--- a/.changeset/flatten-named-new-card-types.md
+++ b/.changeset/flatten-named-new-card-types.md
@@ -1,0 +1,5 @@
+---
+"@open-spaced-repetition/srs-kit": patch
+---
+
+fix(kit): flatten named card return type displays across scheduler APIs.

--- a/packages/srs-kit/src/scheduler/base.ts
+++ b/packages/srs-kit/src/scheduler/base.ts
@@ -303,7 +303,7 @@ export class BaseScheduler<
         input: card,
       },
       now
-    )
+    ) as SchedulerCoreEnv<Env>['card']['output']
   }
 
   review = (input: {

--- a/packages/srs-kit/src/scheduler/scheduler.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.ts
@@ -69,12 +69,15 @@ type SchedulerCoreCardInitInput<Env extends BlankSchedulerCoreEnv> =
 export type SchedulerNewCardOptions<Env extends BlankSchedulerCoreEnv> =
   Prettify<SchedulerCoreCardInitInput<Env>>
 
+// Keep the mapped return type inline so QuickInfo expands named card aliases.
 export type SchedulerNewCardFn<Env extends BlankSchedulerCoreEnv> =
   EmptyPart extends SchedulerNewCardOptions<Env>
-    ? (
-        options?: SchedulerNewCardOptions<Env>
-      ) => Prettify<Env['card']['output']>
-    : (options: SchedulerNewCardOptions<Env>) => Prettify<Env['card']['output']>
+    ? (options?: SchedulerNewCardOptions<Env>) => {
+        [Key in keyof Env['card']['output']]: Env['card']['output'][Key]
+      }
+    : (options: SchedulerNewCardOptions<Env>) => {
+        [Key in keyof Env['card']['output']]: Env['card']['output'][Key]
+      }
 
 export interface ForwardItem<Time> {
   readonly rating: Grade
@@ -110,7 +113,9 @@ export interface SchedulerCore<
   readonly forget: (input: {
     readonly card: Env['card']['input']
     readonly now?: Env['chrono']
-  }) => Env['card']['output']
+  }) => {
+    [Key in keyof Env['card']['output']]: Env['card']['output'][Key]
+  }
   readonly review: (input: {
     readonly card: Env['card']['input']
     readonly grade: Grade
@@ -125,7 +130,9 @@ export interface SchedulerCore<
   readonly rollback: (input: {
     readonly card: Env['card']['output']
     readonly revlog: Env['revlog']['output']
-  }) => Env['card']['output']
+  }) => {
+    [Key in keyof Env['card']['output']]: Env['card']['output'][Key]
+  }
 }
 
 export type AnySchedulerCore = SchedulerCore<any>
@@ -242,7 +249,9 @@ export interface SchedulerDefaultValue<Env extends BlankSchedulerEnv> {
   readonly newCard: (
     ctx: SchedulerDefaultValueContext<Env>,
     time: Env['chrono']
-  ) => SchedulerCoreEnv<Env>['card']['output']
+  ) => {
+    [Key in keyof SchedulerCoreEnv<Env>['card']['output']]: SchedulerCoreEnv<Env>['card']['output'][Key]
+  }
 }
 
 export type SchedulerCreate<

--- a/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
@@ -5,7 +5,7 @@ import { defineMiddleware } from '@/middleware/index.js'
 import { schedulerStatsMiddleware } from '@/middleware/stats/index.js'
 import { SM2_DEFAULT_WEIGHTS, SM2Model } from '@/model/sm2.test.js'
 import type { Grade } from '@/primitives/rating.js'
-import type { Mutable } from '@/schema/index.js'
+import type { Mutable, SRSSchema } from '@/schema/index.js'
 import { defineStringFieldOutputSchema } from '@/schema/string-field.test.js'
 import { defineScheduler } from './define-scheduler.js'
 import type {
@@ -15,6 +15,8 @@ import type {
 import type {
   PreviewResult,
   ScheduleResult,
+  SchedulerCore,
+  SchedulerDefaultValue,
   SchedulerNewCardFn,
 } from './scheduler.js'
 
@@ -122,9 +124,14 @@ const mappedPreview = sm2NumericCoreWithMiddleware
   .preview({ card: sm2NumericCoreWithMiddleware.newCard({ now: 0 }), now: 0 })
   .map((item) => item)
 
+interface MemoryStateForDisplay {
+  readonly stability: number
+  readonly difficulty: number
+}
+
 type ComposedCardForDisplay = Mutable<
   Omit<
-    Mutable<{ stability: number; dueAt: Date }> & {
+    Mutable<MemoryStateForDisplay & { dueAt: Date }> & {
       readonly reps: number
     },
     'dueAt'
@@ -161,9 +168,74 @@ function displayNewCard(card: ReturnType<typeof newCardForDisplay>) {
 
 const composedNewCardForDisplay = displayNewCard({
   stability: 1,
+  difficulty: 2,
   dueAt: new Date(0),
   reps: 0,
   learningStep: 0,
+})
+
+declare const coreForDisplay: SchedulerCore<NewCardEnvForDisplay>
+
+function displayForgottenCard(card: ReturnType<typeof coreForDisplay.forget>) {
+  return card
+}
+
+const forgottenCardForDisplay = displayForgottenCard({
+  stability: 1,
+  difficulty: 2,
+  dueAt: new Date(0),
+  reps: 0,
+  learningStep: 0,
+})
+
+function displayRolledBackCard(
+  card: ReturnType<typeof coreForDisplay.rollback>
+) {
+  return card
+}
+
+const rolledBackCardForDisplay = displayRolledBackCard({
+  stability: 1,
+  difficulty: 2,
+  dueAt: new Date(0),
+  reps: 0,
+  learningStep: 0,
+})
+
+type DefaultValueEnvForDisplay = {
+  readonly chrono: Date
+  readonly config: SRSSchema<{ input: object; output: object }>
+  readonly cardInitInput: SRSSchema<{
+    input: { readonly now?: Date }
+    output: { readonly input: object; readonly now?: unknown }
+  }>
+  readonly card: SRSSchema<{
+    input: ComposedCardForDisplay
+    output: ComposedCardForDisplay
+  }>
+  readonly revlog: SRSSchema<{
+    input: ComposedRevlogForDisplay
+    output: ComposedRevlogForDisplay
+  }>
+  readonly scheduleStatus: 'new' | 'learning' | 'review'
+}
+
+declare const defaultValueForDisplay: SchedulerDefaultValue<DefaultValueEnvForDisplay>
+
+function displayDefaultValueCard(
+  card: ReturnType<typeof defaultValueForDisplay.newCard>
+) {
+  return card
+}
+
+const defaultValueCardForDisplay = displayDefaultValueCard({
+  stability: 1,
+  difficulty: 2,
+  dueAt: new Date(0),
+  reps: 0,
+  learningStep: 0,
+  state: 0,
+  scheduleStatus: 'new',
 })
 
 interface FSRSSchedulerForDisplay {
@@ -185,6 +257,7 @@ function displaySchedulerPreview(preview: SchedulerPreview) {
 const inferredSchedulerPreview = displaySchedulerPreview({
   card: {
     stability: 1,
+    difficulty: 2,
     dueAt: new Date(0),
     reps: 0,
     learningStep: 0,
@@ -583,6 +656,7 @@ describe('defineScheduler type display', () => {
     card: {
         reps: number;
         stability: number;
+        difficulty: number;
         dueAt: Date;
         learningStep: number;
     };
@@ -617,6 +691,7 @@ describe('defineScheduler type display', () => {
     card: {
         reps: number;
         stability: number;
+        difficulty: number;
         dueAt: Date;
         learningStep: number;
     };
@@ -632,8 +707,32 @@ describe('defineScheduler type display', () => {
     composedNewCardForDisplay: `const composedNewCardForDisplay: {
     reps: number;
     stability: number;
+    difficulty: number;
     dueAt: Date;
     learningStep: number;
+}`,
+    forgottenCardForDisplay: `const forgottenCardForDisplay: {
+    reps: number;
+    stability: number;
+    difficulty: number;
+    dueAt: Date;
+    learningStep: number;
+}`,
+    rolledBackCardForDisplay: `const rolledBackCardForDisplay: {
+    reps: number;
+    stability: number;
+    difficulty: number;
+    dueAt: Date;
+    learningStep: number;
+}`,
+    defaultValueCardForDisplay: `const defaultValueCardForDisplay: {
+    reps: number;
+    stability: number;
+    difficulty: number;
+    dueAt: Date;
+    learningStep: number;
+    state: State;
+    scheduleStatus: "new" | "learning" | "review";
 }`,
     defaultNewCard: `const defaultNewCard: {
     source: string;
@@ -829,7 +928,7 @@ describe('defineScheduler type display', () => {
     }
   })
 
-  it('shows flattened card types for newCard()', () => {
+  it('shows flattened card types for card-returning APIs', () => {
     for (const [marker, expected] of Object.entries(expectedDefaultValues)) {
       expect(quickInfoAt(service, SELF, marker)).toBe(expected)
     }


### PR DESCRIPTION
## Summary

- expand named card output types inline for `newCard`, `forget`, `rollback`, and `defaultValue.newCard` so TypeScript QuickInfo shows concrete fields
- preserve the internal scheduler output contract while exposing readable public return types
- add LanguageService regression coverage and a patch changeset

## Testing

- srs-kit: 25 test files, 221 tests passed
- ts-fsrs: 58 test files, 553 tests passed, 2 skipped
- srs-kit and ts-fsrs builds passed
- TypeScript 7 extended diagnostics passed without TS2590; median memory changed by +0.10% for srs-kit and +0.59% for ts-fsrs versus `origin/preview`
- built-package consumer QuickInfo verified flat fields for `newCard`, `forget`, and `rollback`