### PR TITLE
docs: add sitemap, robots.txt, and canonical URLs

### DIFF
--- a/docs/e2e/docs.spec.ts
+++ b/docs/e2e/docs.spec.ts
@@ -16,12 +16,14 @@ function filesIn(directory: string): string[] {
   })
 }
 
+// `cleanUrls` is on, so the site links to `/playground`, not to the
+// `playground.html` file behind it. Visit what a reader would.
 function routeFor(file: string): string {
   const relative = path.relative(buildRoot, file).split(path.sep).join('/')
   if (relative === 'index.html') return '/'
   if (relative.endsWith('/index.html'))
     return `/${relative.slice(0, -'index.html'.length)}`
-  return `/${relative}`
+  return `/${relative.slice(0, -'.html'.length)}`
 }
 
 if (!existsSync(buildRoot)) {
@@ -112,7 +114,7 @@ test('Playground runs its default example', async ({ page }) => {
   const pageErrors: string[] = []
   page.on('pageerror', (error) => pageErrors.push(error.message))
 
-  await page.goto('/playground.html')
+  await page.goto('/playground')
   const run = page.getByTestId('playground-run')
   await expect(run).toBeEnabled()
   await run.click()

--- a/docs/package.json
+++ b/docs/package.json
@@ -33,6 +33,7 @@
     "@rsbuild/plugin-tailwindcss": "^2.0.3",
     "@rspress/core": "2.0.19",
     "@rspress/plugin-rss": "2.0.19",
+    "@rspress/plugin-sitemap": "2.0.19",
     "@rspress/plugin-twoslash": "2.0.19",
     "@types/react": "19.2.18",
     "shiki": "^4.4.3",

--- a/docs/rspress.config.ts
+++ b/docs/rspress.config.ts
@@ -2,8 +2,9 @@ import { readFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import path from 'node:path'
 import { pluginTailwindcss } from '@rsbuild/plugin-tailwindcss'
-import { defineConfig } from '@rspress/core'
+import { defineConfig, withBase, withSiteOrigin } from '@rspress/core'
 import { pluginRss } from '@rspress/plugin-rss'
+import { pluginSitemap } from '@rspress/plugin-sitemap'
 import { pluginTwoslash } from '@rspress/plugin-twoslash'
 import { adaptI18nSource } from './src/i18n'
 import {
@@ -17,8 +18,16 @@ import {
   collectHighlightedExportNames,
   keepTsFsrsTypeHover,
 } from './src/playground/highlight/twoslash'
+import { pluginRobotsTxt } from './src/seo/robots'
 
 const siteOrigin = process.env.DOCS_SITE_ORIGIN
+// Preview deployments serve the site from the root of their own subdomain,
+// while a project page would serve it from a repository sub-path. Leaving this
+// to an env var keeps both correct from one config.
+const base = process.env.DOCS_BASE ?? '/'
+// Preview deployments duplicate the production site, so only the production
+// build asks to be crawled.
+const indexable = process.env.DOCS_INDEXABLE === 'true'
 const repository =
   process.env.DOCS_REPO_SLUG ?? 'open-spaced-repetition/ts-fsrs'
 const repositoryRef = (process.env.DOCS_REPO_REF ?? 'main')
@@ -59,9 +68,14 @@ const landingContributors = readLandingContributors(import.meta.dirname)
 
 export default defineConfig({
   root: path.join(import.meta.dirname, 'src'),
+  base,
   route: {
     extensions: ['.md', '.mdx'],
     localeRedirect: 'never',
+    // Without this every page answers to both `/guide/` and `/guide/index.html`,
+    // and internal links, hreflang, and the sitemap all pick the `.html` form.
+    // One canonical shape per page keeps crawlers from seeing duplicates.
+    cleanUrls: true,
   },
   themeDir: path.join(import.meta.dirname, 'theme'),
   title: 'ts-fsrs',
@@ -89,6 +103,20 @@ export default defineConfig({
   ],
   i18nSource: adaptI18nSource,
   siteOrigin,
+  head: [
+    // Only emitted once the deployment knows its own origin, since a relative
+    // canonical tells a crawler nothing it did not already know.
+    (route) =>
+      siteOrigin
+        ? [
+            'link',
+            {
+              rel: 'canonical',
+              href: withSiteOrigin(withBase(route.routePath, base), siteOrigin),
+            },
+          ]
+        : undefined,
+  ],
   llms: true,
   builderConfig: {
     plugins: [pluginTailwindcss()],
@@ -136,6 +164,20 @@ export default defineConfig({
   },
   plugins: [
     pluginTwoslash({ twoslashOptions }),
+    // `siteUrl` is left out so the plugin composes `siteOrigin` and `base`
+    // itself, which makes a preview deployment map its own host. A sitemap of
+    // relative paths is useless, so it is skipped when no origin is known.
+    ...(siteOrigin
+      ? [
+          pluginSitemap(),
+          pluginRobotsTxt({
+            siteOrigin,
+            base,
+            indexable,
+            outDir: path.join(import.meta.dirname, 'doc_build'),
+          }),
+        ]
+      : []),
     pluginRss({
       feed: [
         {

--- a/docs/rspress.config.ts
+++ b/docs/rspress.config.ts
@@ -219,7 +219,7 @@ export default defineConfig({
         // the per-locale feeds rather than at one locale's `.xml`.
         icon: { svg: rssIcon },
         mode: 'link',
-        content: '/guide/llms#feeds',
+        content: withBase('/guide/llms#feeds', base),
       },
     ],
     editLink: {

--- a/docs/src/seo/robots.ts
+++ b/docs/src/seo/robots.ts
@@ -1,0 +1,73 @@
+import { writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import type { RspressPlugin } from '@rspress/core'
+
+type Options = {
+  readonly siteOrigin: string
+  readonly base: string
+  readonly outDir: string
+  /**
+   * Every deployment other than the production one is a duplicate of it, so
+   * crawling is opt-in rather than the default.
+   */
+  readonly indexable: boolean
+}
+
+// Crawlers that read the site on behalf of an assistant. They are listed
+// explicitly because a bare `User-agent: *` leaves their access to whichever
+// default the operator happens to apply, and this documentation is meant to be
+// quotable: see src/en-US/guide/llms.mdx.
+const AI_CRAWLERS = [
+  'GPTBot',
+  'OAI-SearchBot',
+  'ChatGPT-User',
+  'ClaudeBot',
+  'Claude-User',
+  'Claude-SearchBot',
+  'PerplexityBot',
+  'Google-Extended',
+  'Applebot-Extended',
+]
+
+function render({
+  siteOrigin,
+  base,
+  indexable,
+}: Omit<Options, 'outDir'>): string {
+  if (!indexable) {
+    return `# Preview deployment: a duplicate of the production site.\nUser-agent: *\nDisallow: /\n`
+  }
+
+  const absolute = (file: string) => new URL(base + file, siteOrigin).href
+  const groups = [`User-agent: *\nAllow: /`]
+  for (const crawler of AI_CRAWLERS) {
+    groups.push(`User-agent: ${crawler}\nAllow: /`)
+  }
+
+  return `${groups.join('\n\n')}
+
+Sitemap: ${absolute('sitemap.xml')}
+
+# Documentation index for LLMs: ${absolute('llms.txt')}
+# Full documentation bundle: ${absolute('llms-full.txt')}
+`
+}
+
+// `public/` cannot hold this file: the `Sitemap` directive has to be an
+// absolute URL, and the origin is only known once a deployment sets
+// DOCS_SITE_ORIGIN at build time.
+export function pluginRobotsTxt(options: Options): RspressPlugin {
+  return {
+    name: 'ts-fsrs-robots-txt',
+    async afterBuild(_config, isProd) {
+      if (!isProd) return
+      await writeFile(
+        path.join(options.outDir, 'robots.txt'),
+        render(options),
+        'utf8'
+      )
+    },
+  }
+}
+
+export const renderRobotsTxt = render

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       '@rspress/plugin-rss':
         specifier: 2.0.19
         version: 2.0.19(@rspress/core@2.0.19(@rspack/core@2.1.10(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.2))
+      '@rspress/plugin-sitemap':
+        specifier: 2.0.19
+        version: 2.0.19(@rspress/core@2.0.19(@rspack/core@2.1.10(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.2))
       '@rspress/plugin-twoslash':
         specifier: 2.0.19
         version: 2.0.19(@rspress/core@2.0.19(@rspack/core@2.1.10(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.2))(react@19.2.8)(typescript@6.0.3)
@@ -1882,6 +1885,12 @@ packages:
 
   '@rspress/plugin-rss@2.0.19':
     resolution: {integrity: sha512-PgZzNLfYnDkkxWZYEVvCAt9WtjHl8W6hU/i8nnLaPruIDl+7v56Q2PcqyBz0S+AfstLmDBsAk1rK9FGT68ej2w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@rspress/core': ^2.0.10
+
+  '@rspress/plugin-sitemap@2.0.19':
+    resolution: {integrity: sha512-9ydrpj9hmmXWKWKIXUqJ1UrfxSvfxhHZRBZLb5OkTlOuQBNAg6BpsrW1WHoJqJr7p+3zqlz7S/9HTzSA3+EYcA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@rspress/core': ^2.0.10
@@ -5544,6 +5553,10 @@ snapshots:
     dependencies:
       '@rspress/core': 2.0.19(@rspack/core@2.1.10(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.2)
       feed: 5.2.1
+
+  '@rspress/plugin-sitemap@2.0.19(@rspress/core@2.0.19(@rspack/core@2.1.10(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.2))':
+    dependencies:
+      '@rspress/core': 2.0.19(@rspack/core@2.1.10(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.2)
 
   '@rspress/plugin-twoslash@2.0.19(@rspress/core@2.0.19(@rspack/core@2.1.10(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.2))(react@19.2.8)(typescript@6.0.3)':
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -71,7 +71,13 @@
       ],
       "outputs": ["doc_build/**"],
       "inputs": ["$TURBO_DEFAULT$", ".sponsors.json", ".contributors.json"],
-      "env": ["DOCS_SITE_ORIGIN", "DOCS_REPO_SLUG", "DOCS_REPO_REF"]
+      "env": [
+        "DOCS_SITE_ORIGIN",
+        "DOCS_BASE",
+        "DOCS_INDEXABLE",
+        "DOCS_REPO_SLUG",
+        "DOCS_REPO_REF"
+      ]
     },
     "@ts-fsrs/website#rspress:dev": {
       "dependsOn": [
@@ -82,7 +88,13 @@
       ],
       "cache": false,
       "persistent": true,
-      "env": ["DOCS_SITE_ORIGIN", "DOCS_REPO_SLUG", "DOCS_REPO_REF"]
+      "env": [
+        "DOCS_SITE_ORIGIN",
+        "DOCS_BASE",
+        "DOCS_INDEXABLE",
+        "DOCS_REPO_SLUG",
+        "DOCS_REPO_REF"
+      ]
     },
     "@ts-fsrs/website#preview": {
       "dependsOn": ["@ts-fsrs/website#rspress:build"],


### PR DESCRIPTION
## Summary

- enable `route.cleanUrls` so each page answers to one URL: `/guide/` and `/guide/llms` instead of also `/guide/index.html`, which is what internal links, `hreflang`, and the sitemap were previously pointing at
- add `@rspress/plugin-sitemap`, and write `robots.txt` from a small `afterBuild` plugin — `public/` cannot hold it because the `Sitemap:` directive has to be an absolute URL, which is only known at build time
- emit `<link rel="canonical">` per route through the `head` function form
- thread `DOCS_BASE` (deployment sub-path) and `DOCS_INDEXABLE` (crawling opt-in) through `turbo.json`, alongside the existing `DOCS_SITE_ORIGIN`
- list AI crawlers explicitly in `robots.txt`, since a bare `User-agent: *` leaves their access to whatever default the host applies, and these docs are meant to be quotable

## Notes

- **Nothing changes for existing deployments.** All three SEO outputs are conditional on `DOCS_SITE_ORIGIN`, and crawling requires `DOCS_INDEXABLE=true`. `docs-preview.yml` sets neither of the new vars, so previews keep serving from the root and now ship `Disallow: /` — a preview is a duplicate of production and should not be indexed.
- `DOCS_BASE` implements the deferred TODO from the 2026-08-30 GitHub Pages audit. A future Pages workflow should derive it from `actions/configure-pages` outputs rather than hardcoding `/ts-fsrs/`, so a custom domain keeps working.
- `turbo.json` filters the build environment; a var missing from the `env` array is dropped silently and the build still succeeds. All three are listed for `rspress:build` and `rspress:dev`.
- og:image and twitter:card are still missing and out of scope here — they need a 1200×630 raster that does not exist in the repo yet.
- Not verified: asset loading under a sub-path. `rspress preview` serves from the root, so only the generated URLs were checked. Worth a smoke test before production publishing.

## Testing

- `pnpm --filter @ts-fsrs/website check`
- `pnpm --filter @ts-fsrs/website typecheck`
- `pnpm --filter @ts-fsrs/website test:docs`
- `pnpm --filter @ts-fsrs/website test:e2e` — `routeFor()` and the playground route now drop `.html` to match what the site links to
- built three ways and diffed the output: no origin (no `sitemap.xml`, no `robots.txt`, no canonical), preview origin (`Disallow: /`), and production origin with `DOCS_BASE=/ts-fsrs/` + `DOCS_INDEXABLE=true` (every generated URL carries the prefix)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>