### PR TITLE
allow readonly to be passed to migrateFSRSXParameters

### DIFF
--- a/.changeset/readonly-model-parameters.md
+++ b/.changeset/readonly-model-parameters.md
@@ -1,0 +1,5 @@
+---
+"ts-fsrs": patch
+---
+
+fix: accept `readonly number[]` in model parameter helpers

--- a/packages/fsrs/src/models/fsrs-3/parameters.ts
+++ b/packages/fsrs/src/models/fsrs-3/parameters.ts
@@ -26,7 +26,7 @@ export const checkFSRS3Parameters = (
   return parameters
 }
 
-export const migrateFSRS3Parameters = (parameters?: number[]): number[] => {
+export const migrateFSRS3Parameters = (parameters?: readonly number[]): number[] => {
   if (!Array.isArray(parameters) || parameters.length === 0) {
     return [...FSRS3_DEFAULT_WEIGHTS]
   }

--- a/packages/fsrs/src/models/fsrs-3/parameters.ts
+++ b/packages/fsrs/src/models/fsrs-3/parameters.ts
@@ -4,16 +4,16 @@ import { clamp } from '@/help.js'
 import { isNumberArray } from '@/kit/schema-utils.js'
 import { FSRS3_DEFAULT_WEIGHTS, FSRS3ParameterBounds } from './constants.js'
 
-export const clipFSRS3Parameters = (parameters: number[]): number[] => {
+export const clipFSRS3Parameters = (
+  parameters: readonly number[]
+): number[] => {
   const clip = FSRS3ParameterBounds().slice(0, parameters.length)
   return clip.map(([min, max], index) =>
     clamp(parameters[index] ?? 0, min, max)
   )
 }
 
-export const checkFSRS3Parameters = (
-  parameters: number[] | readonly number[]
-) => {
+export const checkFSRS3Parameters = (parameters: readonly number[]) => {
   const clipped = clipFSRS3Parameters(Array.from(parameters))
   const isValid =
     parameters.length === FSRS3_DEFAULT_WEIGHTS.length &&

--- a/packages/fsrs/src/models/fsrs-3/parameters.ts
+++ b/packages/fsrs/src/models/fsrs-3/parameters.ts
@@ -26,7 +26,9 @@ export const checkFSRS3Parameters = (
   return parameters
 }
 
-export const migrateFSRS3Parameters = (parameters?: readonly number[]): number[] => {
+export const migrateFSRS3Parameters = (
+  parameters?: readonly number[]
+): number[] => {
   if (!Array.isArray(parameters) || parameters.length === 0) {
     return [...FSRS3_DEFAULT_WEIGHTS]
   }

--- a/packages/fsrs/src/models/fsrs-4/parameters.ts
+++ b/packages/fsrs/src/models/fsrs-4/parameters.ts
@@ -4,16 +4,16 @@ import { clamp } from '@/help.js'
 import { isNumberArray } from '@/kit/schema-utils.js'
 import { FSRS4_DEFAULT_WEIGHTS, FSRS4ParameterBounds } from './constants.js'
 
-export const clipFSRS4Parameters = (parameters: number[]): number[] => {
+export const clipFSRS4Parameters = (
+  parameters: readonly number[]
+): number[] => {
   const clip = FSRS4ParameterBounds().slice(0, parameters.length)
   return clip.map(([min, max], index) =>
     clamp(parameters[index] ?? 0, min, max)
   )
 }
 
-export const checkFSRS4Parameters = (
-  parameters: number[] | readonly number[]
-) => {
+export const checkFSRS4Parameters = (parameters: readonly number[]) => {
   const clipped = clipFSRS4Parameters(Array.from(parameters))
   const isValid =
     parameters.length === FSRS4_DEFAULT_WEIGHTS.length &&

--- a/packages/fsrs/src/models/fsrs-4/parameters.ts
+++ b/packages/fsrs/src/models/fsrs-4/parameters.ts
@@ -26,7 +26,9 @@ export const checkFSRS4Parameters = (
   return parameters
 }
 
-export const migrateFSRS4Parameters = (parameters?: readonly number[]): number[] => {
+export const migrateFSRS4Parameters = (
+  parameters?: readonly number[]
+): number[] => {
   if (!Array.isArray(parameters) || parameters.length === 0) {
     return [...FSRS4_DEFAULT_WEIGHTS]
   }

--- a/packages/fsrs/src/models/fsrs-4/parameters.ts
+++ b/packages/fsrs/src/models/fsrs-4/parameters.ts
@@ -26,7 +26,7 @@ export const checkFSRS4Parameters = (
   return parameters
 }
 
-export const migrateFSRS4Parameters = (parameters?: number[]): number[] => {
+export const migrateFSRS4Parameters = (parameters?: readonly number[]): number[] => {
   if (!Array.isArray(parameters) || parameters.length === 0) {
     return [...FSRS4_DEFAULT_WEIGHTS]
   }

--- a/packages/fsrs/src/models/fsrs-4dot5/parameters.ts
+++ b/packages/fsrs/src/models/fsrs-4dot5/parameters.ts
@@ -31,7 +31,9 @@ export const checkFSRS4Dot5Parameters = (
   return parameters
 }
 
-export const migrateFSRS4Dot5Parameters = (parameters?: readonly number[]): number[] => {
+export const migrateFSRS4Dot5Parameters = (
+  parameters?: readonly number[]
+): number[] => {
   if (!Array.isArray(parameters) || parameters.length === 0) {
     return [...FSRS4Dot5_DEFAULT_WEIGHTS]
   }

--- a/packages/fsrs/src/models/fsrs-4dot5/parameters.ts
+++ b/packages/fsrs/src/models/fsrs-4dot5/parameters.ts
@@ -7,16 +7,16 @@ import {
   FSRS4Dot5ParameterBounds,
 } from './constants.js'
 
-export const clipFSRS4Dot5Parameters = (parameters: number[]): number[] => {
+export const clipFSRS4Dot5Parameters = (
+  parameters: readonly number[]
+): number[] => {
   const clip = FSRS4Dot5ParameterBounds().slice(0, parameters.length)
   return clip.map(([min, max], index) =>
     clamp(parameters[index] || 0, min, max)
   )
 }
 
-export const checkFSRS4Dot5Parameters = (
-  parameters: number[] | readonly number[]
-) => {
+export const checkFSRS4Dot5Parameters = (parameters: readonly number[]) => {
   const clipped = clipFSRS4Dot5Parameters(Array.from(parameters))
   const isValid =
     parameters.length === FSRS4Dot5_DEFAULT_WEIGHTS.length &&

--- a/packages/fsrs/src/models/fsrs-4dot5/parameters.ts
+++ b/packages/fsrs/src/models/fsrs-4dot5/parameters.ts
@@ -31,7 +31,7 @@ export const checkFSRS4Dot5Parameters = (
   return parameters
 }
 
-export const migrateFSRS4Dot5Parameters = (parameters?: number[]): number[] => {
+export const migrateFSRS4Dot5Parameters = (parameters?: readonly number[]): number[] => {
   if (!Array.isArray(parameters) || parameters.length === 0) {
     return [...FSRS4Dot5_DEFAULT_WEIGHTS]
   }

--- a/packages/fsrs/src/models/fsrs-5/parameters.ts
+++ b/packages/fsrs/src/models/fsrs-5/parameters.ts
@@ -26,7 +26,9 @@ export const checkFSRS5Parameters = (
   return parameters
 }
 
-export const migrateFSRS5Parameters = (parameters?: readonly number[]): number[] => {
+export const migrateFSRS5Parameters = (
+  parameters?: readonly number[]
+): number[] => {
   if (!Array.isArray(parameters) || parameters.length === 0) {
     return [...FSRS5_DEFAULT_WEIGHTS]
   }

--- a/packages/fsrs/src/models/fsrs-5/parameters.ts
+++ b/packages/fsrs/src/models/fsrs-5/parameters.ts
@@ -4,16 +4,16 @@ import { clamp, roundTo } from '@/help.js'
 import { isNumberArray } from '@/kit/schema-utils.js'
 import { FSRS5_DEFAULT_WEIGHTS, FSRS5ParameterBounds } from './constants.js'
 
-export const clipFSRS5Parameters = (parameters: number[]): number[] => {
+export const clipFSRS5Parameters = (
+  parameters: readonly number[]
+): number[] => {
   const clip = FSRS5ParameterBounds().slice(0, parameters.length)
   return clip.map(([min, max], index) =>
     clamp(parameters[index] || 0, min, max)
   )
 }
 
-export const checkFSRS5Parameters = (
-  parameters: number[] | readonly number[]
-) => {
+export const checkFSRS5Parameters = (parameters: readonly number[]) => {
   const clipped = clipFSRS5Parameters(Array.from(parameters))
   const isValid =
     parameters.length === FSRS5_DEFAULT_WEIGHTS.length &&

--- a/packages/fsrs/src/models/fsrs-5/parameters.ts
+++ b/packages/fsrs/src/models/fsrs-5/parameters.ts
@@ -26,7 +26,7 @@ export const checkFSRS5Parameters = (
   return parameters
 }
 
-export const migrateFSRS5Parameters = (parameters?: number[]): number[] => {
+export const migrateFSRS5Parameters = (parameters?: readonly number[]): number[] => {
   if (!Array.isArray(parameters) || parameters.length === 0) {
     return [...FSRS5_DEFAULT_WEIGHTS]
   }

--- a/packages/fsrs/src/models/fsrs-6/parameters.ts
+++ b/packages/fsrs/src/models/fsrs-6/parameters.ts
@@ -77,7 +77,9 @@ export const checkFSRS6Parameters = (
   return parameters
 }
 
-export const migrateFSRS6Parameters = (parameters?: readonly number[]): number[] => {
+export const migrateFSRS6Parameters = (
+  parameters?: readonly number[]
+): number[] => {
   if (!Array.isArray(parameters) || parameters.length === 0) {
     return [...FSRS6_DEFAULT_WEIGHTS]
   }

--- a/packages/fsrs/src/models/fsrs-6/parameters.ts
+++ b/packages/fsrs/src/models/fsrs-6/parameters.ts
@@ -77,7 +77,7 @@ export const checkFSRS6Parameters = (
   return parameters
 }
 
-export const migrateFSRS6Parameters = (parameters?: number[]): number[] => {
+export const migrateFSRS6Parameters = (parameters?: readonly number[]): number[] => {
   if (!Array.isArray(parameters) || parameters.length === 0) {
     return [...FSRS6_DEFAULT_WEIGHTS]
   }

--- a/packages/fsrs/src/models/fsrs-6/parameters.ts
+++ b/packages/fsrs/src/models/fsrs-6/parameters.ts
@@ -57,7 +57,7 @@ export const clipFSRS6Parameters = (
 }
 
 export const checkFSRS6Parameters = (
-  parameters: number[] | readonly number[],
+  parameters: readonly number[],
   numRelearningSteps = 0,
   enableShortTerm = true
 ) => {


### PR DESCRIPTION
This way you don't have to cast it

maybe it would be better using 
```ts
number[] | readonly number[]
```
but `number[]` satisfies `readonly number[]` so it should be fine.

ref: https://github.com/Luc-Mcgrady/Anki-Search-Stats-Extended/pull/117/changes#diff-09ba28996b8078022c08755aed565f70c519b47151fa061571c599fe72b28e3cR172
