### PR TITLE
fix(build): fail fast instead of auto-installing deps before scripts

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,8 @@ overrides:
   '@napi-rs/cli@3.8.0>emnapi': 2.0.0-alpha.4
   '@rolldown/binding-wasm32-wasi>@napi-rs/wasm-runtime': 1.1.4
 
+verifyDepsBeforeRun: error
+
 allowBuilds:
   esbuild: true
   unrs-resolver: false


### PR DESCRIPTION
## Problem

`turbo run build` intermittently dies on a fresh checkout or right after switching
branches:

```
@open-spaced-repetition/srs-kit:build:     at execaCoreSync (.../pnpm.mjs:40384:23)
@open-spaced-repetition/srs-kit:build:     at runPnpmCli (.../pnpm.mjs:247810:5)
@open-spaced-repetition/srs-kit:build:     at runDepsStatusCheck (.../pnpm.mjs:249560:7)
@open-spaced-repetition/binding:build: [ELIFECYCLE] Command failed.
 ERROR  @open-spaced-repetition/srs-kit#build: ... exited (1)
```

## Root cause

pnpm 11 defaults `verify-deps-before-run` to `"install"`. Every `pnpm run <script>`
therefore checks whether `node_modules` still matches the lockfile, and when it
does not, it *synchronously* shells out to `pnpm install` before running the
script — that is exactly the `install2()` call at `runDepsStatusCheck`, the last
frame in the trace above.

Turbo runs one such script per package concurrently. Once the lockfile drifts —
a branch switch, a pull, a rebase across a dependency bump — several tasks each
launch a real `pnpm install` and write `node_modules` at the same time. Note that
the stack trace above is attributed to `srs-kit:build` while the `ELIFECYCLE`
belongs to `binding:build`: two tasks racing.

## Fix

Set `verifyDepsBeforeRun: error` in `pnpm-workspace.yaml`. Scripts now stop with
an actionable message instead of repairing the workspace behind Turbo's back:

```
[ERR_PNPM_VERIFY_DEPS_BEFORE_RUN] The lockfile in <root> does not satisfy project of id packages/srs-kit
Run "pnpm install"
```

Concurrent tasks throwing is safe; concurrent installs are not.

`false` was the other candidate, but it would silently build against a stale tree
and surface later as unrelated compile errors. `error` keeps the diagnostic.

## Verification

- **Deps in sync:** `turbo run build --force` → 3/3 tasks succeed, behaviour unchanged.
- **Genuine drift** (injected an uninstalled `devDependency` into `packages/srs-kit`):
  exit code 1, both tasks print the message above, and `pnpm-lock.yaml` is left
  untouched — no install is attempted. Injected dependency reverted afterwards.

## CI impact

None. Every workflow that invokes pnpm runs `./.github/actions/setup-node-pnpm`
first, which ends in `pnpm install --frozen-lockfile`, so deps are always in sync
before Turbo starts. Checked the ordering in `build-napi.yml`, `check.yml`,
`docs-preview.yml`, `preview-package.yml`, `release.yml` and `test.yml`.

## Contributor impact

After a branch switch or pull that changes the lockfile, `pnpm run …` and
`turbo run …` now fail until `pnpm install` is run, rather than installing on
your behalf.
