### PR TITLE
feat(kit): share fractional-day config across scheduling

### DIFF
--- a/.changeset/shared-chrono-config.md
+++ b/.changeset/shared-chrono-config.md
@@ -1,0 +1,5 @@
+---
+"@open-spaced-repetition/srs-kit": minor
+---
+
+refactor(kit): simplify chrono config to share options with middleware.

--- a/packages/fsrs/src/middlewares/fuzzing/core.spec.ts
+++ b/packages/fsrs/src/middlewares/fuzzing/core.spec.ts
@@ -14,6 +14,40 @@ describe('fuzzing core', () => {
     expect(withFuzzing(2.4, 1, config, 'seed')).toBe(2)
   })
 
+  it.each([
+    undefined,
+    false,
+    true,
+  ])('honors fractionalDays=%s for short or disabled-fuzz intervals', (fractionalDays) => {
+    for (const enableFuzz of [false, true]) {
+      for (const interval of [0, 1 / 86400, 10 / 1440, 1, 2.4, 2.5, 3.4]) {
+        if (enableFuzz && interval >= 2.5) continue
+        expect(
+          withFuzzing(
+            interval,
+            0,
+            { ...config, enableFuzz, fractionalDays },
+            'seed'
+          )
+        ).toBe(fractionalDays ? interval : Math.round(interval))
+      }
+    }
+  })
+
+  it('still produces the same integer fuzz result at and above 2.5 days', () => {
+    for (const interval of [2.5, 2.6, 10.25]) {
+      const integer = withFuzzing(interval, 0, config, 'boundary-seed')
+      const fractional = withFuzzing(
+        interval,
+        0,
+        { ...config, fractionalDays: true },
+        'boundary-seed'
+      )
+      expect(fractional).toBe(integer)
+      expect(Number.isInteger(fractional)).toBe(true)
+    }
+  })
+
   it('fuzzes the 2.5 interval boundary inside its range', () => {
     const range = getFuzzRange(2.5, 0, config.maximumInterval)
     const interval = withFuzzing(2.5, 0, config, 'boundary-seed')

--- a/packages/fsrs/src/middlewares/fuzzing/core.ts
+++ b/packages/fsrs/src/middlewares/fuzzing/core.ts
@@ -1,4 +1,4 @@
-import type { FuzzingConfig } from './schema.js'
+import type { FuzzingConfigInput } from './schema.js'
 
 export type FuzzRange = {
   readonly start: number
@@ -66,15 +66,17 @@ export const fnv1aMulberry32Rng: FuzzingRng = (seed) =>
   mulberry32(fnv1a32(seed))
 
 /**
- * Returns an integer interval with optional deterministic fuzzing applied.
+ * Applies deterministic fuzzing, preserving unfuzzed fractional intervals when configured.
  */
 export function withFuzzing(
   interval: number,
   elapsedDays: number,
-  config: FuzzingConfig,
+  config: FuzzingConfigInput,
   seed?: string
 ) {
-  if (!config.enableFuzz || interval < 2.5) return Math.round(interval)
+  if (!config.enableFuzz || interval < 2.5) {
+    return config.fractionalDays ? interval : Math.round(interval)
+  }
 
   const { minInterval, maxInterval } = getFuzzRange(
     interval,

--- a/packages/fsrs/src/middlewares/fuzzing/middleware.spec.ts
+++ b/packages/fsrs/src/middlewares/fuzzing/middleware.spec.ts
@@ -2,12 +2,17 @@ import {
   defineMiddleware,
   defineScheduler,
   Rating,
+  State,
   schedulerStatsMiddleware,
 } from '@open-spaced-repetition/srs-kit'
 import { dateChrono } from '@open-spaced-repetition/srs-kit/chrono/date'
 import { describe, expect, it, vi } from 'vitest'
 import { FSRS6_DEFAULT_WEIGHTS } from '@/models/fsrs-6/constants.js'
 import { FSRS6Model } from '@/models/fsrs-6/model.js'
+import { FSRS7_DEFAULT_WEIGHTS, FSRS7Model } from '@/models/fsrs-7/index.js'
+import { schedulerLearningStepsMiddleware } from '../learning-steps/middleware.js'
+import type { StepUnit } from '../learning-steps/types.js'
+import { schedulerScheduledDaysMiddleware } from '../scheduled-days/middleware.js'
 import { withFuzzing } from './core.js'
 import {
   createSchedulerFuzzingMiddleware,
@@ -25,6 +30,109 @@ const config = {
   enableFuzz: true,
   maximumInterval: 36_500,
 }
+
+describe('fuzzing with explicit learning steps', () => {
+  const FSRS7SchedulerDefinition = defineScheduler({
+    model: FSRS7Model,
+    chrono: dateChrono,
+  }).use(
+    schedulerFuzzingMiddleware,
+    schedulerScheduledDaysMiddleware,
+    schedulerLearningStepsMiddleware
+  )
+  function createCore(fractionalDays: boolean, step: StepUnit) {
+    return FSRS7SchedulerDefinition.create({
+      config: {
+        weights: FSRS7_DEFAULT_WEIGHTS,
+        enableFuzz: true,
+        maximumInterval: 36500,
+        fractionalDays,
+        enableShortTerm: true,
+        learningSteps: [step],
+        relearningSteps: [],
+      },
+    })
+  }
+
+  it.each([
+    false,
+    true,
+  ])('preserves a positive step at learningStep=0 with fractionalDays=%s', (fractionalDays) => {
+    for (const [step, minutes] of [
+      ['0.01m', 1 / 60],
+      ['10m', 10],
+      ['1d', 1440],
+      ['2.4d', 3456],
+    ] as const) {
+      const core = createCore(fractionalDays, step)
+      const card = core.newCard({ now })
+      expect(card.learningStep).toBe(0)
+      const result = core.review({ card, now, grade: Rating.Again })
+      expect(result.card.dueAt.getTime() - now.getTime()).toBe(minutes * 60000)
+      expect(result.card.scheduledDays).toBe(
+        fractionalDays ? minutes / 1440 : Math.floor(minutes / 1440)
+      )
+      expect(result.card.learningStep).toBe(0)
+      expect(result.card.state).toBe(
+        minutes < 1440 ? State.Learning : State.Review
+      )
+      expect(core.rollback(result)).toEqual(card)
+    }
+  })
+
+  it.each([
+    false,
+    true,
+  ])('uses the configured rounding for zero steps and graduation with fractionalDays=%s', (fractionalDays) => {
+    for (const step of ['0m', '0.001m', '1m'] as const) {
+      const core = createCore(fractionalDays, step)
+      const card = core.newCard({ now })
+      const first = core.review({ card, now, grade: Rating.Again })
+      const result =
+        step === '1m'
+          ? core.review({ card: first.card, now, grade: Rating.Good })
+          : first
+      const interval = core.model.nextInterval(result.card, 0.9)
+      expect(interval).toBeGreaterThan(0)
+      expect(interval).toBeLessThan(0.5)
+      expect(result.card.dueAt.getTime() - now.getTime()).toBe(
+        fractionalDays ? Math.trunc(interval * DAY) : 0
+      )
+      expect(result.card.scheduledDays).toBe(fractionalDays ? interval : 0)
+      expect(result.card.state).toBe(State.Review)
+      expect(result.card.learningStep).toBe(0)
+    }
+  })
+})
+
+it.each([
+  undefined,
+  false,
+  true,
+])('shares fractionalDays config between fuzzing and scheduled days (%s)', (fractionalDays) => {
+  const scheduler = defineScheduler({ model: FSRS7Model, chrono: dateChrono })
+    .use(schedulerFuzzingMiddleware, schedulerScheduledDaysMiddleware)
+    .create({
+      config: {
+        weights: FSRS7_DEFAULT_WEIGHTS,
+        enableFuzz: true,
+        maximumInterval: 36500,
+        fractionalDays,
+      },
+    })
+  const card = scheduler.newCard({ now, cardId: 'fractional' })
+  const result = scheduler.review({ card, now, grade: Rating.Again })
+  const interval = scheduler.model.nextInterval(result.card, 0.9)
+  expect(withFuzzing(interval, 0, scheduler.config, 'fractional1')).toBe(
+    fractionalDays ? interval : 0
+  )
+  expect(scheduler.config.fractionalDays).toBe(fractionalDays ?? false)
+  expect(result.card.scheduledDays).toBe(fractionalDays ? interval : 0)
+  expect(result.card.dueAt.getTime() - now.getTime()).toBe(
+    fractionalDays ? Math.trunc(interval * DAY) : 0
+  )
+  expect(scheduler.rollback(result)).toEqual(card)
+})
 
 const fuzzFirstCore = defineScheduler({ model: FSRS6Model, chrono: dateChrono })
   .use(schedulerFuzzingMiddleware, schedulerStatsMiddleware)

--- a/packages/fsrs/src/middlewares/fuzzing/middleware.spec.ts
+++ b/packages/fsrs/src/middlewares/fuzzing/middleware.spec.ts
@@ -9,7 +9,6 @@ import { dateChrono } from '@open-spaced-repetition/srs-kit/chrono/date'
 import { describe, expect, it, vi } from 'vitest'
 import { FSRS6_DEFAULT_WEIGHTS } from '@/models/fsrs-6/constants.js'
 import { FSRS6Model } from '@/models/fsrs-6/model.js'
-import { FSRS7_DEFAULT_WEIGHTS, FSRS7Model } from '@/models/fsrs-7/index.js'
 import { schedulerLearningStepsMiddleware } from '../learning-steps/middleware.js'
 import type { StepUnit } from '../learning-steps/types.js'
 import { schedulerScheduledDaysMiddleware } from '../scheduled-days/middleware.js'
@@ -32,8 +31,8 @@ const config = {
 }
 
 describe('fuzzing with explicit learning steps', () => {
-  const FSRS7SchedulerDefinition = defineScheduler({
-    model: FSRS7Model,
+  const schedulerDefinition = defineScheduler({
+    model: FSRS6Model,
     chrono: dateChrono,
   }).use(
     schedulerFuzzingMiddleware,
@@ -41,9 +40,10 @@ describe('fuzzing with explicit learning steps', () => {
     schedulerLearningStepsMiddleware
   )
   function createCore(fractionalDays: boolean, step: StepUnit) {
-    return FSRS7SchedulerDefinition.create({
+    const core = schedulerDefinition.create({
       config: {
-        weights: FSRS7_DEFAULT_WEIGHTS,
+        weights: FSRS6_DEFAULT_WEIGHTS,
+        numRelearningSteps: 0,
         enableFuzz: true,
         maximumInterval: 36500,
         fractionalDays,
@@ -52,6 +52,8 @@ describe('fuzzing with explicit learning steps', () => {
         relearningSteps: [],
       },
     })
+    vi.spyOn(core.model, 'nextInterval').mockReturnValue(0.25)
+    return core
   }
 
   it.each([
@@ -113,16 +115,19 @@ it.each([
   false,
   true,
 ])('shares fractionalDays config between fuzzing and scheduled days (%s)', (fractionalDays) => {
-  const scheduler = defineScheduler({ model: FSRS7Model, chrono: dateChrono })
+  const scheduler = defineScheduler({ model: FSRS6Model, chrono: dateChrono })
     .use(schedulerFuzzingMiddleware, schedulerScheduledDaysMiddleware)
     .create({
       config: {
-        weights: FSRS7_DEFAULT_WEIGHTS,
+        weights: FSRS6_DEFAULT_WEIGHTS,
+        enableShortTerm: false,
+        numRelearningSteps: 0,
         enableFuzz: true,
         maximumInterval: 36500,
         fractionalDays,
       },
     })
+  vi.spyOn(scheduler.model, 'nextInterval').mockReturnValue(0.25)
   const card = scheduler.newCard({ now, cardId: 'fractional' })
   const result = scheduler.review({ card, now, grade: Rating.Again })
   const interval = scheduler.model.nextInterval(result.card, 0.9)

--- a/packages/fsrs/src/middlewares/fuzzing/middleware.spec.ts
+++ b/packages/fsrs/src/middlewares/fuzzing/middleware.spec.ts
@@ -65,6 +65,9 @@ describe('fuzzing with explicit learning steps', () => {
       ['2.4d', 3456],
     ] as const) {
       const core = createCore(fractionalDays, step)
+      expect(
+        core.chrono.difference(now, new Date(now.getTime() + DAY / 2))
+      ).toBe(fractionalDays ? 0.5 : 0)
       const card = core.newCard({ now })
       expect(card.learningStep).toBe(0)
       const result = core.review({ card, now, grade: Rating.Again })

--- a/packages/fsrs/src/middlewares/fuzzing/middleware.ts
+++ b/packages/fsrs/src/middlewares/fuzzing/middleware.ts
@@ -74,7 +74,8 @@ export function createSchedulerFuzzingMiddleware(
           const seed = `${card.cardId}${reps}`
           candidate.nextInterval = (memoryState, desiredRetention) => {
             const interval = nextInterval(memoryState, desiredRetention)
-            if (interval < 2.5) return Math.round(interval)
+            if (interval < 2.5)
+              return ctx.config.fractionalDays ? interval : Math.round(interval)
 
             const { minInterval, maxInterval } = getFuzzRange(
               interval,

--- a/packages/fsrs/src/middlewares/fuzzing/schema.spec.ts
+++ b/packages/fsrs/src/middlewares/fuzzing/schema.spec.ts
@@ -13,7 +13,7 @@ describe('fuzzingConfigSchema', () => {
         enableFuzz: true,
         maximumInterval: 365,
       })
-    ).toEqual({ enableFuzz: true, maximumInterval: 365 })
+    ).toEqual({ enableFuzz: true, maximumInterval: 365, fractionalDays: false })
   })
 
   it.each([
@@ -23,6 +23,9 @@ describe('fuzzingConfigSchema', () => {
     { enableFuzz: true, maximumInterval: 0 },
     { enableFuzz: true, maximumInterval: 1.5 },
     { enableFuzz: true, maximumInterval: Number.NaN },
+    { enableFuzz: true, maximumInterval: 365, fractionalDays: null },
+    { enableFuzz: true, maximumInterval: 365, fractionalDays: 1 },
+    { enableFuzz: true, maximumInterval: 365, fractionalDays: 'true' },
   ])('rejects invalid config %#', (value) => {
     expect(() => fuzzingConfigSchema.parse(value)).toThrow()
   })

--- a/packages/fsrs/src/middlewares/fuzzing/schema.ts
+++ b/packages/fsrs/src/middlewares/fuzzing/schema.ts
@@ -1,8 +1,19 @@
-import { defineSchema, isObject } from '@open-spaced-repetition/srs-kit'
+import {
+  defineSchema,
+  fractionalDaysConfigSchema,
+  isObject,
+} from '@open-spaced-repetition/srs-kit'
+
+export type FuzzingConfigInput = {
+  readonly enableFuzz: boolean
+  readonly maximumInterval: number
+  readonly fractionalDays?: boolean
+}
 
 export type FuzzingConfig = {
   readonly enableFuzz: boolean
   readonly maximumInterval: number
+  readonly fractionalDays: boolean
 }
 
 export type FuzzingCardFields = {
@@ -24,7 +35,10 @@ function parseCardId(value: unknown): string | number | undefined {
   return undefined
 }
 
-export const fuzzingConfigSchema = defineSchema<FuzzingConfig>((value) => {
+export const fuzzingConfigSchema = defineSchema<
+  FuzzingConfigInput,
+  FuzzingConfig
+>((value) => {
   if (!isObject(value)) {
     return { issues: [{ message: 'Expected fuzzing config object' }] }
   }
@@ -43,7 +57,15 @@ export const fuzzingConfigSchema = defineSchema<FuzzingConfig>((value) => {
     }
   }
 
-  return { value: { enableFuzz, maximumInterval } }
+  const fractional = fractionalDaysConfigSchema['~standard'].validate(value)
+  if (fractional.issues) return fractional
+  return {
+    value: {
+      enableFuzz,
+      maximumInterval,
+      fractionalDays: fractional.value.fractionalDays,
+    },
+  }
 })
 
 export const fuzzingCardInitInputSchema = defineSchema<FuzzingCardInitInput>(

--- a/packages/fsrs/src/middlewares/scheduled-days/middleware.spec.ts
+++ b/packages/fsrs/src/middlewares/scheduled-days/middleware.spec.ts
@@ -1,6 +1,7 @@
 import {
   defineMiddleware,
   defineScheduler,
+  fractionalDaysConfigSchema,
   Rating,
   State,
 } from '@open-spaced-repetition/srs-kit'
@@ -36,6 +37,25 @@ function createCore(scheduledDays = 2.9) {
 }
 
 describe('schedulerScheduledDaysMiddleware', () => {
+  it.each([
+    0,
+    1 / 86400,
+    0.5,
+    2.9,
+    -1,
+  ])('preserves fractional intervals with parsed config (%s)', (days) => {
+    const ctx = {
+      config: fractionalDaysConfigSchema.parse({
+        fractionalDays: true,
+      }),
+      input: { card: { scheduledDays: 0.25 } },
+      result: { card: { scheduledDays: 0 }, revlog: { scheduledDays: 0 } },
+      scheduledDays: days,
+    }
+    schedulerScheduledDaysMiddleware.handlers!.review!(ctx as never, () => {})
+    expect(ctx.result.card.scheduledDays).toBe(Math.max(0, days))
+    expect(ctx.result.revlog.scheduledDays).toBe(0.25)
+  })
   it('defaults a new card scheduledDays to zero', () => {
     expect(createCore().newCard({ now }).scheduledDays).toBe(0)
   })
@@ -52,6 +72,7 @@ describe('schedulerScheduledDaysMiddleware', () => {
 
   it('defaults a missing scheduled interval to zero', () => {
     const ctx = {
+      config: fractionalDaysConfigSchema.parse({}),
       input: { card: { scheduledDays: 7 } },
       result: {
         card: { scheduledDays: -1 },

--- a/packages/fsrs/src/middlewares/scheduled-days/middleware.ts
+++ b/packages/fsrs/src/middlewares/scheduled-days/middleware.ts
@@ -1,10 +1,14 @@
-import { defineMiddleware } from '@open-spaced-repetition/srs-kit'
+import {
+  defineMiddleware,
+  fractionalDaysConfigSchema,
+} from '@open-spaced-repetition/srs-kit'
 import { scheduledDaysFieldsSchema } from './schema.js'
 
 /** Register before interval middleware so it records their final value on unwind. */
 export const schedulerScheduledDaysMiddleware = defineMiddleware({
   name: Symbol('ts-fsrs.scheduled-days'),
   schema: {
+    config: fractionalDaysConfigSchema,
     card: scheduledDaysFieldsSchema,
     revlog: scheduledDaysFieldsSchema,
   },
@@ -18,10 +22,10 @@ export const schedulerScheduledDaysMiddleware = defineMiddleware({
       const previousScheduledDays = ctx.input.card.scheduledDays
       next()
 
-      ctx.result.card.scheduledDays = Math.max(
-        0,
-        Math.floor(ctx.scheduledDays ?? 0)
-      )
+      const days = Math.max(0, ctx.scheduledDays ?? 0)
+      ctx.result.card.scheduledDays = ctx.config.fractionalDays
+        ? days
+        : Math.floor(days)
       ctx.result.revlog.scheduledDays = previousScheduledDays
     },
 

--- a/packages/fsrs/src/reschedule/reschedule.spec.ts
+++ b/packages/fsrs/src/reschedule/reschedule.spec.ts
@@ -47,7 +47,8 @@ const createTemporalFixture = () => {
   }).create({
     config: {
       ...modelConfig,
-      chrono: { timezone: 'UTC', fractionalDays: false },
+      timezone: 'UTC',
+      fractionalDays: false,
     },
   })
 

--- a/packages/srs-kit/bench/chrono.bench.ts
+++ b/packages/srs-kit/bench/chrono.bench.ts
@@ -1,5 +1,5 @@
 import { bench, describe } from 'vitest'
-import { dateChrono } from '@/chrono/presets/date/index.js'
+import { dateChrono, dateConfigSchema } from '@/chrono/presets/date/index.js'
 import { numericChrono } from '@/chrono/presets/numeric/index.js'
 import { temporalInstantChrono } from '@/chrono/presets/temporal-instant/index.js'
 
@@ -76,12 +76,13 @@ describe('numericChrono preset', () => {
 describe('dateChrono preset', () => {
   const now = new Date('2026-06-20T00:00:00.000Z')
   const later = new Date('2026-06-21T12:00:00.000Z')
-  const core = dateChrono.create()
+  const config = dateConfigSchema.parse(undefined)
+  const core = dateChrono.create({ config })
   const card = { dueAt: now, lastReviewAt: now }
   const previous = { previous: now, current: later }
 
   bench('create', () => {
-    dateChrono.create()
+    dateChrono.create({ config })
   })
   bench('now', () => {
     core.now()
@@ -90,10 +91,18 @@ describe('dateChrono preset', () => {
     dateChrono.projection['~standard'].validate({ card, time: later })
   })
   bench('default card', () => {
-    dateChrono.defaultValue.card?.({ config: {}, previous, time: now })
+    dateChrono.defaultValue.card?.({
+      config: { fractionalDays: false },
+      previous,
+      time: now,
+    })
   })
   bench('default revlog', () => {
-    dateChrono.defaultValue.revlog?.({ config: {}, previous, time: now })
+    dateChrono.defaultValue.revlog?.({
+      config: { fractionalDays: false },
+      previous,
+      time: now,
+    })
   })
   bench('difference', () => {
     core.difference(now, later)

--- a/packages/srs-kit/bench/chrono.bench.ts
+++ b/packages/srs-kit/bench/chrono.bench.ts
@@ -1,7 +1,8 @@
 import { bench, describe } from 'vitest'
-import { dateChrono, dateConfigSchema } from '@/chrono/presets/date/index.js'
+import { dateChrono } from '@/chrono/presets/date/index.js'
 import { numericChrono } from '@/chrono/presets/numeric/index.js'
 import { temporalInstantChrono } from '@/chrono/presets/temporal-instant/index.js'
+import { fractionalDaysConfigSchema } from '@/schema/fractional-days.js'
 
 const NS_PER_DAY = 86_400_000_000_000n
 const temporalImplementations = ['native', 'polyfill'] as const
@@ -76,7 +77,7 @@ describe('numericChrono preset', () => {
 describe('dateChrono preset', () => {
   const now = new Date('2026-06-20T00:00:00.000Z')
   const later = new Date('2026-06-21T12:00:00.000Z')
-  const config = dateConfigSchema.parse(undefined)
+  const config = fractionalDaysConfigSchema.parse({})
   const core = dateChrono.create({ config })
   const card = { dueAt: now, lastReviewAt: now }
   const previous = { previous: now, current: later }

--- a/packages/srs-kit/src/chrono/define-chrono.type-display.spec.ts
+++ b/packages/srs-kit/src/chrono/define-chrono.type-display.spec.ts
@@ -1,6 +1,7 @@
 /** biome-ignore-all lint/correctness/noUnusedVariables: type-display fixtures read by LanguageService */
 import { describe, expect, it } from 'vitest'
 import { dateChrono } from './presets/date/chrono.js'
+import { dateConfigSchema } from './presets/date/schema.js'
 import { numericChrono } from './presets/numeric/chrono.js'
 import { temporalInstantChrono } from './presets/temporal-instant/chrono.js'
 
@@ -10,7 +11,9 @@ const chronoNumeric = numericChrono
 const chronoDate = dateChrono
 const chronoTemporalInstant = temporalInstantChrono
 const coreNumeric = numericChrono.create()
-const coreDate = dateChrono.create()
+const coreDate = dateChrono.create({
+  config: dateConfigSchema.parse(undefined),
+})
 const coreTemporalInstant = temporalInstantChrono.create({
   config: { timezone: 'UTC', fractionalDays: false },
 })
@@ -32,6 +35,14 @@ describe('defineChrono type display', () => {
     readonly time: SRSSchema<{
         input: Date;
         output: Date;
+    }>;
+    readonly config: SRSSchema<{
+        input: {
+            readonly fractionalDays?: boolean | undefined;
+        } | undefined;
+        output: {
+            readonly fractionalDays: boolean;
+        };
     }>;
     readonly fields: {
         readonly card: SRSSchema<{

--- a/packages/srs-kit/src/chrono/define-chrono.type-display.spec.ts
+++ b/packages/srs-kit/src/chrono/define-chrono.type-display.spec.ts
@@ -1,7 +1,7 @@
 /** biome-ignore-all lint/correctness/noUnusedVariables: type-display fixtures read by LanguageService */
 import { describe, expect, it } from 'vitest'
+import { fractionalDaysConfigSchema } from '@/schema/fractional-days.js'
 import { dateChrono } from './presets/date/chrono.js'
-import { dateConfigSchema } from './presets/date/schema.js'
 import { numericChrono } from './presets/numeric/chrono.js'
 import { temporalInstantChrono } from './presets/temporal-instant/chrono.js'
 
@@ -12,7 +12,7 @@ const chronoDate = dateChrono
 const chronoTemporalInstant = temporalInstantChrono
 const coreNumeric = numericChrono.create()
 const coreDate = dateChrono.create({
-  config: dateConfigSchema.parse(undefined),
+  config: fractionalDaysConfigSchema.parse({}),
 })
 const coreTemporalInstant = temporalInstantChrono.create({
   config: { timezone: 'UTC', fractionalDays: false },
@@ -39,7 +39,7 @@ describe('defineChrono type display', () => {
     readonly config: SRSSchema<{
         input: {
             readonly fractionalDays?: boolean | undefined;
-        } | undefined;
+        };
         output: {
             readonly fractionalDays: boolean;
         };

--- a/packages/srs-kit/src/chrono/infer.ts
+++ b/packages/srs-kit/src/chrono/infer.ts
@@ -16,11 +16,7 @@ export type ChronoConfigPart<
   T extends AnyChrono,
   Mode extends 'input' | 'output',
 > = [SchemaOf<T, 'config'>] extends [never]
-  ? Mode extends 'input'
-    ? EmptyPart
-    : { readonly chrono: Record<string, never> }
+  ? EmptyPart
   : Mode extends 'input'
-    ? undefined extends SchemaInputOf<T, 'config'>
-      ? { readonly chrono?: SchemaInputOf<T, 'config'> }
-      : { readonly chrono: SchemaInputOf<T, 'config'> }
-    : { readonly chrono: SchemaOutputOf<T, 'config'> }
+    ? Exclude<SchemaInputOf<T, 'config'>, undefined>
+    : SchemaOutputOf<T, 'config'>

--- a/packages/srs-kit/src/chrono/infer.ts
+++ b/packages/srs-kit/src/chrono/infer.ts
@@ -20,5 +20,7 @@ export type ChronoConfigPart<
     ? EmptyPart
     : { readonly chrono: Record<string, never> }
   : Mode extends 'input'
-    ? { readonly chrono: SchemaInputOf<T, 'config'> }
+    ? undefined extends SchemaInputOf<T, 'config'>
+      ? { readonly chrono?: SchemaInputOf<T, 'config'> }
+      : { readonly chrono: SchemaInputOf<T, 'config'> }
     : { readonly chrono: SchemaOutputOf<T, 'config'> }

--- a/packages/srs-kit/src/chrono/presets/date/chrono.spec.ts
+++ b/packages/srs-kit/src/chrono/presets/date/chrono.spec.ts
@@ -4,27 +4,32 @@ import type {
   ChronoRevlogOf,
   ChronoTimeOf,
 } from '@/chrono/infer.js'
+import { fractionalDaysConfigSchema } from '@/schema/fractional-days.js'
 import { parse } from '@/schema/index.js'
-import { dateChrono, dateConfigSchema, dateDiffInDays } from './index.js'
+import { dateChrono, dateDiffInDays } from './index.js'
 
 describe('dateChrono', () => {
-  it('validates fractionalDays and defaults omitted configuration', () => {
-    for (const input of [undefined, {}, { fractionalDays: undefined }]) {
-      expect(dateConfigSchema.parse(input)).toEqual({ fractionalDays: false })
+  it('reuses the shared schema and defaults omitted fractionalDays', () => {
+    expect(dateChrono.schema.config).toBe(fractionalDaysConfigSchema)
+    for (const input of [{}, { fractionalDays: undefined }]) {
+      expect(fractionalDaysConfigSchema.parse(input)).toEqual({
+        fractionalDays: false,
+      })
     }
     for (const fractionalDays of [false, true]) {
-      expect(dateConfigSchema.parse({ fractionalDays })).toEqual({
+      expect(fractionalDaysConfigSchema.parse({ fractionalDays })).toEqual({
         fractionalDays,
       })
     }
     for (const input of [
+      undefined,
       null,
       'UTC',
       { fractionalDays: 1 },
       { fractionalDays: 'true' },
       { fractionalDays: null },
     ]) {
-      expect(() => dateConfigSchema.parse(input)).toThrow()
+      expect(() => fractionalDaysConfigSchema.parse(input)).toThrow()
     }
   })
   it('can preserve elapsed fractional days without changing the default', () => {
@@ -42,7 +47,7 @@ describe('dateChrono', () => {
     ).toBe(1)
     expect(
       dateChrono
-        .create({ config: dateConfigSchema.parse(undefined) })
+        .create({ config: fractionalDaysConfigSchema.parse({}) })
         .difference(from, to)
     ).toBe(1)
   })
@@ -65,7 +70,7 @@ describe('dateChrono', () => {
       compare,
       difference,
       now: getCurrent,
-    } = dateChrono.create({ config: dateConfigSchema.parse(undefined) })
+    } = dateChrono.create({ config: fractionalDaysConfigSchema.parse({}) })
     const current = getCurrent()
 
     expect(current).toBeInstanceOf(Date)

--- a/packages/srs-kit/src/chrono/presets/date/chrono.spec.ts
+++ b/packages/srs-kit/src/chrono/presets/date/chrono.spec.ts
@@ -5,9 +5,47 @@ import type {
   ChronoTimeOf,
 } from '@/chrono/infer.js'
 import { parse } from '@/schema/index.js'
-import { dateChrono, dateDiffInDays } from './index.js'
+import { dateChrono, dateConfigSchema, dateDiffInDays } from './index.js'
 
 describe('dateChrono', () => {
+  it('validates fractionalDays and defaults omitted configuration', () => {
+    for (const input of [undefined, {}, { fractionalDays: undefined }]) {
+      expect(dateConfigSchema.parse(input)).toEqual({ fractionalDays: false })
+    }
+    for (const fractionalDays of [false, true]) {
+      expect(dateConfigSchema.parse({ fractionalDays })).toEqual({
+        fractionalDays,
+      })
+    }
+    for (const input of [
+      null,
+      'UTC',
+      { fractionalDays: 1 },
+      { fractionalDays: 'true' },
+      { fractionalDays: null },
+    ]) {
+      expect(() => dateConfigSchema.parse(input)).toThrow()
+    }
+  })
+  it('can preserve elapsed fractional days without changing the default', () => {
+    const from = new Date('2026-06-20T23:59:00Z')
+    const to = new Date('2026-06-21T00:01:00Z')
+    const fractional = dateChrono.create({ config: { fractionalDays: true } })
+    expect(fractional.difference(from, to)).toBe(2 / 1440)
+    expect(fractional.difference(to, from)).toBe(-2 / 1440)
+    expect(fractional.difference(from, from)).toBe(0)
+    expect(fractional.add(from, 2 / 1440)).toEqual(to)
+    expect(
+      dateChrono
+        .create({ config: { fractionalDays: false } })
+        .difference(from, to)
+    ).toBe(1)
+    expect(
+      dateChrono
+        .create({ config: dateConfigSchema.parse(undefined) })
+        .difference(from, to)
+    ).toBe(1)
+  })
   it('provides a Date adapter with due and last-review fields', () => {
     expectTypeOf<ChronoTimeOf<typeof dateChrono>>().toEqualTypeOf<Date>()
     expectTypeOf<ChronoCardOf<typeof dateChrono>>().toEqualTypeOf<{
@@ -22,7 +60,12 @@ describe('dateChrono', () => {
     const now = new Date('2026-06-20T00:00:00.000Z')
     const later = new Date('2026-06-21T12:00:00.000Z')
     const epoch = new Date(0)
-    const { add, compare, difference, now: getCurrent } = dateChrono.create()
+    const {
+      add,
+      compare,
+      difference,
+      now: getCurrent,
+    } = dateChrono.create({ config: dateConfigSchema.parse(undefined) })
     const current = getCurrent()
 
     expect(current).toBeInstanceOf(Date)
@@ -198,7 +241,7 @@ describe('dateChrono', () => {
     expect(add(now, 2.25)).toEqual(new Date('2026-06-22T06:00:00.000Z'))
     expect(
       dateChrono.defaultValue.card!({
-        config: {},
+        config: { fractionalDays: false },
         time: now,
         previous: {
           previous: now,
@@ -208,13 +251,13 @@ describe('dateChrono', () => {
     ).toEqual({ dueAt: now, lastReviewAt: later })
     expect(
       dateChrono.defaultValue.card!({
-        config: {},
+        config: { fractionalDays: false },
         time: now,
       })
     ).toEqual({ dueAt: now, lastReviewAt: null })
     expect(
       dateChrono.defaultValue.revlog!({
-        config: {},
+        config: { fractionalDays: false },
         time: now,
         previous: {
           previous: now,
@@ -224,7 +267,7 @@ describe('dateChrono', () => {
     ).toEqual({ dueAt: now, reviewTime: later })
     expect(
       dateChrono.defaultValue.revlog!({
-        config: {},
+        config: { fractionalDays: false },
         time: now,
       })
     ).toEqual({ dueAt: now, reviewTime: now })

--- a/packages/srs-kit/src/chrono/presets/date/chrono.ts
+++ b/packages/srs-kit/src/chrono/presets/date/chrono.ts
@@ -1,9 +1,9 @@
 import { defineChrono } from '@/chrono/define-chrono.js'
 import { dateSchema } from '@/schema/field.js'
+import { fractionalDaysConfigSchema } from '@/schema/fractional-days.js'
 import { isObject } from '@/schema/index.js'
 import {
   dateCardFieldsSchema,
-  dateConfigSchema,
   dateRevlogFieldsSchema,
   MS_PER_DAY,
 } from './schema.js'
@@ -15,7 +15,7 @@ const differenceByMode = {
 
 export const dateChrono = defineChrono({
   schema: {
-    config: dateConfigSchema,
+    config: fractionalDaysConfigSchema,
     card: dateCardFieldsSchema,
     revlog: dateRevlogFieldsSchema,
     time: dateSchema,

--- a/packages/srs-kit/src/chrono/presets/date/chrono.ts
+++ b/packages/srs-kit/src/chrono/presets/date/chrono.ts
@@ -3,12 +3,19 @@ import { dateSchema } from '@/schema/field.js'
 import { isObject } from '@/schema/index.js'
 import {
   dateCardFieldsSchema,
+  dateConfigSchema,
   dateRevlogFieldsSchema,
   MS_PER_DAY,
 } from './schema.js'
 
+const differenceByMode = {
+  elapsed: elapsedUtcDays,
+  calendar: dateDiffInDays,
+}
+
 export const dateChrono = defineChrono({
   schema: {
+    config: dateConfigSchema,
     card: dateCardFieldsSchema,
     revlog: dateRevlogFieldsSchema,
     time: dateSchema,
@@ -63,7 +70,10 @@ export const dateChrono = defineChrono({
       }
     },
   },
-  create() {
+  create({ config }) {
+    const differenceMode = config.fractionalDays ? 'elapsed' : 'calendar'
+    const difference = differenceByMode[differenceMode]
+
     return {
       now,
       compare,
@@ -79,9 +89,13 @@ const compare = (left: Date, right: Date): number => {
   const rightTime = right.getTime()
   return leftTime < rightTime ? -1 : leftTime > rightTime ? 1 : 0
 }
-const difference = (from: Date, to: Date): number => dateDiffInDays(from, to)
 const add = (from: Date, days: number): Date =>
   new Date(from.getTime() + days * MS_PER_DAY)
+
+/** Elapsed UTC time in fixed 24-hour days, independent of calendar boundaries. */
+function elapsedUtcDays(from: Date, to: Date): number {
+  return (to.getTime() - from.getTime()) / MS_PER_DAY
+}
 
 export function dateDiffInDays(last: Date, cur: Date): number {
   const utc1 = Date.UTC(

--- a/packages/srs-kit/src/chrono/presets/date/schema.ts
+++ b/packages/srs-kit/src/chrono/presets/date/schema.ts
@@ -3,26 +3,6 @@ import { defineSchema, isObject } from '@/schema/index.js'
 
 export const MS_PER_DAY = 86_400_000
 
-export type DateConfig = {
-  readonly fractionalDays: boolean
-}
-
-export const dateConfigSchema = defineSchema<
-  Partial<DateConfig> | undefined,
-  DateConfig
->((value) => {
-  if (value === undefined) return { value: { fractionalDays: false } }
-  if (!isObject(value)) {
-    return { issues: [{ message: 'Expected date config' }] }
-  }
-  const fractionalDays =
-    value.fractionalDays === undefined ? false : value.fractionalDays
-  if (typeof fractionalDays !== 'boolean') {
-    return { issues: [{ message: 'Expected fractionalDays to be a boolean' }] }
-  }
-  return { value: { fractionalDays } }
-})
-
 export type DateCardInputFields = {
   dueAt: Date
   lastReviewAt?: Date | null

--- a/packages/srs-kit/src/chrono/presets/date/schema.ts
+++ b/packages/srs-kit/src/chrono/presets/date/schema.ts
@@ -3,6 +3,26 @@ import { defineSchema, isObject } from '@/schema/index.js'
 
 export const MS_PER_DAY = 86_400_000
 
+export type DateConfig = {
+  readonly fractionalDays: boolean
+}
+
+export const dateConfigSchema = defineSchema<
+  Partial<DateConfig> | undefined,
+  DateConfig
+>((value) => {
+  if (value === undefined) return { value: { fractionalDays: false } }
+  if (!isObject(value)) {
+    return { issues: [{ message: 'Expected date config' }] }
+  }
+  const fractionalDays =
+    value.fractionalDays === undefined ? false : value.fractionalDays
+  if (typeof fractionalDays !== 'boolean') {
+    return { issues: [{ message: 'Expected fractionalDays to be a boolean' }] }
+  }
+  return { value: { fractionalDays } }
+})
+
 export type DateCardInputFields = {
   dueAt: Date
   lastReviewAt?: Date | null

--- a/packages/srs-kit/src/chrono/presets/temporal-instant/schema.ts
+++ b/packages/srs-kit/src/chrono/presets/temporal-instant/schema.ts
@@ -1,3 +1,4 @@
+import { fractionalDaysConfigSchema } from '@/schema/fractional-days.js'
 import { defineSchema, isObject } from '@/schema/index.js'
 
 export type TemporalInstantConfig = {
@@ -65,13 +66,14 @@ export const temporalInstantConfigSchema = defineSchema<
     return { issues: [{ message: 'Expected valid timezone' }] }
   }
 
-  const fractionalDays =
-    value.fractionalDays === undefined ? false : value.fractionalDays
-  if (typeof fractionalDays !== 'boolean') {
-    return { issues: [{ message: 'Expected fractionalDays to be a boolean' }] }
+  const fractional = fractionalDaysConfigSchema['~standard'].validate(value)
+  if (fractional.issues) return fractional
+  return {
+    value: {
+      timezone: timezoneId,
+      fractionalDays: fractional.value.fractionalDays,
+    },
   }
-
-  return { value: { timezone: timezoneId, fractionalDays } }
 })
 
 export const temporalInstantSchema = defineSchema<Temporal.Instant>((value) => {

--- a/packages/srs-kit/src/scheduler/base.spec.ts
+++ b/packages/srs-kit/src/scheduler/base.spec.ts
@@ -59,7 +59,6 @@ describe('SchedulerCore.create', () => {
   it('validates config and returns core', () => {
     expect(core.config).toEqual({
       ...config,
-      chrono: {},
       clearStatsOnForget: true,
     })
     expect(core.model).not.toBe(SM2Model)
@@ -84,7 +83,6 @@ describe('SchedulerCore.create', () => {
 
     expect(c.config).toEqual({
       weights: SM2_DEFAULT_WEIGHTS,
-      chrono: {},
       clearStatsOnForget: true,
     })
     expect(c.config).not.toHaveProperty('desiredRetention')
@@ -1658,7 +1656,8 @@ describe('SchedulerCore.rollback', () => {
     }).create({
       config: {
         ...config,
-        chrono: { timezone: 'UTC', fractionalDays: false },
+        timezone: 'UTC',
+        fractionalDays: false,
       },
     })
     const dueAt = Temporal.Instant.from('2026-06-28T00:00:00Z')

--- a/packages/srs-kit/src/scheduler/base.ts
+++ b/packages/srs-kit/src/scheduler/base.ts
@@ -190,7 +190,7 @@ export class BaseScheduler<
       bypass: true,
     }) as ReturnType<M['create']>
     this.chrono = Reflect.apply(chrono.create, chrono, [
-      { config: config.chrono },
+      { config },
     ]) as ReturnType<C['create']>
     this.reviewHandlers = middlewares.map(
       (middleware) => middleware.handlers?.review
@@ -576,7 +576,7 @@ export class BaseScheduler<
       Object.assign(
         result.card,
         chronoCardDefault({
-          config: this.config.chrono,
+          config: this.config,
           time: this.chrono.add(prepared.time.current, scheduledDays),
           previous: prepared.time,
         })
@@ -589,7 +589,7 @@ export class BaseScheduler<
       Object.assign(
         result.revlog,
         chronoRevlogDefault({
-          config: this.config.chrono,
+          config: this.config,
           time: prepared.time.current,
           previous: prepared.time,
         })
@@ -613,7 +613,7 @@ export class BaseScheduler<
     )
     const isNew = revlog.state === State.New
     const cardFields = this.schedulerDefinition.chrono.defaultValue?.card?.({
-      config: this.config.chrono,
+      config: this.config,
       previous: isNew
         ? undefined
         : {

--- a/packages/srs-kit/src/scheduler/compose-schema.ts
+++ b/packages/srs-kit/src/scheduler/compose-schema.ts
@@ -108,15 +108,13 @@ export function composeSchema(ctx: {
     const modelResult = validateSync(modelConfigSchema, value)
     if (modelResult.issues) return modelResult
 
-    let chronoValue: unknown = {}
-    if (chronoConfigSchema) {
-      const chronoResult = validateSync(chronoConfigSchema, value.chrono)
-      if (chronoResult.issues) return chronoResult
-      chronoValue = chronoResult.value
-    }
-
-    const result: Record<PropertyKey, unknown> = { chrono: chronoValue }
+    const result: Record<PropertyKey, unknown> = {}
     assignObjectFields(result, modelResult.value)
+    if (chronoConfigSchema) {
+      const chronoResult = validateSync(chronoConfigSchema, value)
+      if (chronoResult.issues) return chronoResult
+      assignObjectFields(result, chronoResult.value)
+    }
 
     for (const schema of middlewareConfigSchemas) {
       const middlewareResult = validateSync(schema, value)

--- a/packages/srs-kit/src/scheduler/default-value.ts
+++ b/packages/srs-kit/src/scheduler/default-value.ts
@@ -48,7 +48,7 @@ function applyNewCardDefaults(ctx: {
     Object.assign(
       target,
       chronoDefault({
-        config: defaultValue.config.chrono as Readonly<unknown>,
+        config: defaultValue.config,
         time,
       })
     )

--- a/packages/srs-kit/src/scheduler/scheduler.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.spec.ts
@@ -1,12 +1,14 @@
 import { describe, expect, expectTypeOf, it } from 'vitest'
 import { defineChrono } from '@/chrono/define-chrono.js'
 import { dateChrono } from '@/chrono/presets/date/chrono.js'
+import { temporalInstantChrono } from '@/chrono/presets/temporal-instant/chrono.js'
 import { defineMiddleware } from '@/middleware/index.js'
 import { schedulerStatsMiddleware } from '@/middleware/stats/index.js'
 import { SM2Model } from '@/model/sm2.test.js'
 import { type Grade, Rating, State } from '@/primitives/index.js'
 import {
   defineSchema,
+  fractionalDaysConfigSchema,
   isObject,
   numberSchema,
   type StandardSchemaV1,
@@ -56,6 +58,88 @@ const usedCore = usedScheduler.create({
 })
 
 describe('defineScheduler', () => {
+  it.each([
+    undefined,
+    false,
+    true,
+  ])('shares flat fractionalDays config with Date chrono and middleware (%s)', (fractionalDays) => {
+    const capture = defineMiddleware({
+      name: 'test.shared-fractional-days',
+      schema: { config: fractionalDaysConfigSchema },
+      handlers: {
+        review(ctx, next) {
+          expect(ctx.config.fractionalDays).toBe(fractionalDays ?? false)
+          expect(ctx.elapsedDays).toBe(fractionalDays ? 2 / 1440 : 1)
+          next()
+        },
+      },
+    })
+    const definition = defineScheduler({
+      model: SM2Model,
+      chrono: dateChrono,
+    }).use(capture)
+    const shared = definition.create({ config: { ...config, fractionalDays } })
+    expect(shared.config.fractionalDays).toBe(fractionalDays ?? false)
+    const from = new Date('2026-09-08T23:59:00Z')
+    const to = new Date('2026-09-09T00:01:00Z')
+    const card = {
+      ...shared.newCard({ now: from }),
+      state: State.Review,
+      lastReviewAt: from,
+    }
+    const result = shared.review({ card, now: to, grade: Rating.Good })
+    expect(shared.rollback(result).lastReviewAt).toEqual(from)
+    // A parsed config can be reused without introducing a nested chrono config.
+    expect(definition.create({ config: shared.config }).config).toEqual(
+      shared.config
+    )
+    expect(() =>
+      definition.create({
+        config: { ...config, fractionalDays: 'true' } as never,
+      })
+    ).toThrow('fractionalDays')
+  })
+
+  it('accepts Temporal timezone and fractionalDays in the same flat config', () => {
+    const capture = defineMiddleware({
+      name: 'test.shared-temporal-fractional-days',
+      schema: { config: fractionalDaysConfigSchema },
+      handlers: {
+        review(ctx, next) {
+          expect(ctx.config.fractionalDays).toBe(true)
+          expect(ctx.elapsedDays).toBe(2 / 1440)
+          next()
+        },
+      },
+    })
+    const definition = defineScheduler({
+      model: SM2Model,
+      chrono: temporalInstantChrono,
+    }).use(capture)
+    const shared = definition.create({
+      config: { ...config, timezone: 'Asia/Tokyo', fractionalDays: true },
+    })
+    expect(shared.config).toMatchObject({
+      timezone: 'Asia/Tokyo',
+      fractionalDays: true,
+    })
+    const from = Temporal.Instant.from('2026-09-08T14:59:00Z')
+    const to = Temporal.Instant.from('2026-09-08T15:01:00Z')
+    const card = {
+      ...shared.newCard({ now: from }),
+      state: State.Review,
+      lastReviewAt: from,
+    }
+    const result = shared.review({ card, now: to, grade: Rating.Good })
+    expect(shared.rollback(result).lastReviewAt).toBe(from)
+    expect(definition.create({ config }).config).toMatchObject({
+      timezone: 'UTC',
+      fractionalDays: false,
+    })
+    expect(() =>
+      definition.create({ config: { ...config, timezone: 'not-a-timezone' } })
+    ).toThrow('timezone')
+  })
   it('preserves model name', () => {
     expect(scheduler.name).toBe('sm2')
     expectTypeOf(scheduler.name).toEqualTypeOf<'sm2'>()
@@ -335,13 +419,13 @@ describe('defineScheduler', () => {
     expect(
       chronoScheduler.schema.config.parse({
         ...config,
-        chrono: { offset: 9 },
-      }).chrono
-    ).toEqual({ offset: 9 })
+        offset: 9,
+      }).offset
+    ).toBe(9)
     expect(() =>
       chronoScheduler.schema.config.parse({
         ...config,
-        chrono: { offset: 'bad' },
+        offset: 'bad',
       })
     ).toThrow('Expected offset config')
   })
@@ -459,7 +543,6 @@ describe('defineScheduler', () => {
   it('infers composed config type', () => {
     expectTypeOf<SchedulerConfigOf<typeof scheduler>>().toEqualTypeOf<{
       readonly weights: readonly number[]
-      readonly chrono: Record<string, never>
       readonly clearStatsOnForget: boolean
     }>()
   })
@@ -469,7 +552,6 @@ describe('defineScheduler', () => {
       SchedulerConfigOf<typeof middlewareScheduler>
     >().toEqualTypeOf<{
       readonly weights: readonly number[]
-      readonly chrono: Record<string, never>
       readonly source: string
       readonly clearStatsOnForget: boolean
     }>()
@@ -478,7 +560,6 @@ describe('defineScheduler', () => {
   it('preserves middleware config type through use()', () => {
     expectTypeOf<SchedulerConfigOf<typeof usedScheduler>>().toEqualTypeOf<{
       readonly weights: readonly number[]
-      readonly chrono: Record<string, never>
       readonly source: string
       readonly clearStatsOnForget: boolean
     }>()
@@ -487,7 +568,6 @@ describe('defineScheduler', () => {
   it('preserves prior config type through chained use()', () => {
     expectTypeOf<SchedulerConfigOf<typeof chainedScheduler>>().toEqualTypeOf<{
       readonly weights: readonly number[]
-      readonly chrono: Record<string, never>
       readonly source: string
       readonly clearStatsOnForget: boolean
     }>()

--- a/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
+++ b/packages/srs-kit/src/scheduler/scheduler.type-display.spec.ts
@@ -284,7 +284,6 @@ describe('defineScheduler type display', () => {
         };
         output: {
             readonly weights: readonly number[];
-            readonly chrono: Record<string, never>;
         };
     }>;
     readonly cardInitInput: SchedulerCardInitSchema<number>;
@@ -362,7 +361,6 @@ describe('defineScheduler type display', () => {
         };
         output: {
             readonly weights: readonly number[];
-            readonly chrono: Record<string, never>;
             readonly clearStatsOnForget: boolean;
         };
     }>;
@@ -445,7 +443,6 @@ describe('defineScheduler type display', () => {
         };
         output: {
             readonly weights: readonly number[];
-            readonly chrono: Record<string, never>;
             readonly clearStatsOnForget: boolean;
         };
     }>;
@@ -528,7 +525,6 @@ describe('defineScheduler type display', () => {
     sm2NumericCoreWithMiddleware: `const sm2NumericCoreWithMiddleware: SchedulerCore<{
     readonly config: {
         readonly weights: readonly number[];
-        readonly chrono: Record<string, never>;
         readonly clearStatsOnForget: boolean;
     };
     readonly cardInitInput: {
@@ -592,7 +588,6 @@ describe('defineScheduler type display', () => {
     sm2NumericCore: `const sm2NumericCore: SchedulerCore<{
     readonly config: {
         readonly weights: readonly number[];
-        readonly chrono: Record<string, never>;
         readonly clearStatsOnForget: boolean;
     };
     readonly cardInitInput: {
@@ -756,7 +751,6 @@ describe('defineScheduler type display', () => {
         };
         output: {
             readonly weights: readonly number[];
-            readonly chrono: Record<string, never>;
         };
     }>;
     readonly cardInitInput: SchedulerCardInitSchema<number>;
@@ -827,7 +821,6 @@ describe('defineScheduler type display', () => {
     sm2WithSuspendCore: `const sm2WithSuspendCore: SchedulerCore<{
     readonly config: {
         readonly weights: readonly number[];
-        readonly chrono: Record<string, never>;
     };
     readonly cardInitInput: {
         readonly now?: number | undefined;
@@ -905,7 +898,6 @@ describe('defineScheduler type display', () => {
 }`,
     SM2NumericSchedulerConfigOutput: `type SM2NumericSchedulerConfigOutput = {
     readonly weights: readonly number[];
-    readonly chrono: Record<string, never>;
     readonly clearStatsOnForget: boolean;
 }`,
   }

--- a/packages/srs-kit/src/schema/fractional-days.spec.ts
+++ b/packages/srs-kit/src/schema/fractional-days.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, expectTypeOf, it } from 'vitest'
+import { fractionalDaysConfigSchema } from './fractional-days.js'
+import type { SchemaInput } from './standard.js'
+
+describe('shared fractionalDays config', () => {
+  it('accepts an omitted input field and produces a boolean output', () => {
+    expectTypeOf<
+      SchemaInput<typeof fractionalDaysConfigSchema>
+    >().toEqualTypeOf<{ readonly fractionalDays?: boolean }>()
+    for (const input of [
+      {},
+      { fractionalDays: undefined },
+      { fractionalDays: false },
+    ]) {
+      const config = fractionalDaysConfigSchema.parse(input)
+      expectTypeOf(config.fractionalDays).toEqualTypeOf<boolean>()
+      expect(config).toEqual({ fractionalDays: false })
+    }
+    expect(fractionalDaysConfigSchema.parse({ fractionalDays: true })).toEqual({
+      fractionalDays: true,
+    })
+    for (const value of [null, 1, 'true']) {
+      expect(() =>
+        fractionalDaysConfigSchema.parse({ fractionalDays: value })
+      ).toThrow()
+    }
+    expect(() => fractionalDaysConfigSchema.parse(null)).toThrow()
+  })
+})

--- a/packages/srs-kit/src/schema/fractional-days.ts
+++ b/packages/srs-kit/src/schema/fractional-days.ts
@@ -1,0 +1,21 @@
+import { isObject } from './utils.js'
+import { defineSchema } from './validators.js'
+
+export type FractionalDaysConfig = {
+  readonly fractionalDays: boolean
+}
+
+export const fractionalDaysConfigSchema = defineSchema<
+  Partial<FractionalDaysConfig>,
+  FractionalDaysConfig
+>((value) => {
+  if (!isObject(value)) {
+    return { issues: [{ message: 'Expected fractional days config' }] }
+  }
+  const fractionalDays =
+    value.fractionalDays === undefined ? false : value.fractionalDays
+  if (typeof fractionalDays !== 'boolean') {
+    return { issues: [{ message: 'Expected fractionalDays to be a boolean' }] }
+  }
+  return { value: { fractionalDays } }
+})

--- a/packages/srs-kit/src/schema/index.ts
+++ b/packages/srs-kit/src/schema/index.ts
@@ -4,6 +4,7 @@ export type {
 } from '@vendor/standard-schema.js'
 export * from './cache.js'
 export * from './field.js'
+export * from './fractional-days.js'
 export * from './infer.js'
 export * from './iterable.js'
 export * from './middleware.js'


### PR DESCRIPTION
Share `fractionalDays` through the scheduler's top-level config so Date/Temporal chronos, fuzzing, and scheduled-day middleware use the same option. It defaults to `false`; enabling it preserves fractional intervals and elapsed 24-hour days while learning-step durations stay exact.

Chrono options now belong directly in scheduler config instead of nested `config.chrono`.

Validation: 228 srs-kit tests and 573 ts-fsrs tests passed (1 skipped); package build, lint, and TypeScript checks with a 512 MiB heap passed.
