### PR TITLE
refactor(chrono): unify card and revlog time projections

### DIFF
--- a/.changeset/fix-chrono-revlog-due-at.md
+++ b/.changeset/fix-chrono-revlog-due-at.md
@@ -1,0 +1,6 @@
+---
+"@open-spaced-repetition/srs-kit": minor
+"ts-fsrs": minor
+---
+
+refactor(chrono): unify card and revlog time projections so rollback restores the pre-review due date

--- a/packages/fsrs/src/scheduler/default-scheduler.legacy-parity.spec.ts
+++ b/packages/fsrs/src/scheduler/default-scheduler.legacy-parity.spec.ts
@@ -13,7 +13,6 @@ import {
   expectSequenceParity,
   legacyNext,
   legacyReview,
-  legacyRollback,
 } from './default-scheduler.legacy-test-utils.js'
 import {
   createStateCard,
@@ -39,6 +38,7 @@ const revlogKeys = [
   'cardId',
   'difficulty',
   'dueAt',
+  'lastReviewAt',
   'learningStep',
   'rating',
   'reviewTime',
@@ -80,7 +80,8 @@ describe('DefaultScheduler legacy parity', () => {
 
       expect(Object.keys(actual.revlog).sort()).toEqual(revlogKeys)
       expect(actual.revlog.cardId).toBe(card.cardId)
-      expect(actual.revlog.dueAt).toEqual(legacy.log.due)
+      expect(actual.revlog.dueAt).toEqual(card.dueAt)
+      expect(actual.revlog.lastReviewAt).toEqual(card.lastReviewAt)
       expect(actual.revlog.stability).toBe(legacy.log.stability)
       expect(actual.revlog.difficulty).toBe(legacy.log.difficulty)
       expect(actual.revlog.scheduledDays).toBe(legacy.log.scheduled_days)
@@ -183,10 +184,7 @@ describe('DefaultScheduler legacy parity', () => {
         const actual = scheduler.review({ card, grade, now })
 
         expectSequenceParity(actual, expected, card, enableShortTerm)
-        expectRollbackParity(
-          scheduler.rollback(actual),
-          legacyRollback(options, expected)
-        )
+        expectRollbackParity(scheduler.rollback(actual), card)
 
         card = actual.card
         const delay = Math.floor(random() * 15) * DAY
@@ -195,9 +193,7 @@ describe('DefaultScheduler legacy parity', () => {
       }
     })
 
-    it.each(
-      states
-    )('rolls state %s back to the legacy input', async (state) => {
+    it.each(states)('restores the input card for state %s', async (state) => {
       const scheduler = await DefaultScheduler(options)
       const card = createStateCard(state)
 
@@ -328,10 +324,7 @@ describe('DefaultScheduler legacy parity', () => {
       })
 
       expectFullParity(actual, expected)
-      expectRollbackParity(
-        scheduler.rollback(actual),
-        legacyRollback(options, expected)
-      )
+      expectRollbackParity(scheduler.rollback(actual), card)
       expect(scheduler.rollback(actual).scheduledDays).toBe(scheduledDays)
     })
 

--- a/packages/fsrs/src/scheduler/default-scheduler.legacy-test-utils.ts
+++ b/packages/fsrs/src/scheduler/default-scheduler.legacy-test-utils.ts
@@ -69,11 +69,12 @@ function fromLegacyCard(
 
 function fromLegacyRevlog(
   revlog: ReviewLog,
-  cardId: DefaultSchedulerCard['cardId']
+  card: DefaultSchedulerCard
 ): ReviewResult['revlog'] {
   return {
-    cardId,
-    dueAt: revlog.due,
+    cardId: card.cardId,
+    dueAt: card.dueAt,
+    lastReviewAt: card.lastReviewAt,
     stability: revlog.stability,
     difficulty: revlog.difficulty,
     scheduledDays: revlog.scheduled_days,
@@ -82,19 +83,6 @@ function fromLegacyRevlog(
     state: revlog.state,
     scheduleStatus: scheduleStatusByState[revlog.state],
     reviewTime: revlog.review,
-  }
-}
-
-function toLegacyRevlog(revlog: ReviewResult['revlog']): ReviewLog {
-  return {
-    rating: revlog.rating,
-    state: revlog.state,
-    due: revlog.dueAt,
-    stability: revlog.stability,
-    difficulty: revlog.difficulty,
-    scheduled_days: revlog.scheduledDays,
-    learning_steps: revlog.learningStep,
-    review: revlog.reviewTime,
   }
 }
 
@@ -107,7 +95,7 @@ export function legacyReview(
   const result = legacyNext(options, card, now, grade)
   return {
     card: fromLegacyCard(result.card, card.cardId),
-    revlog: fromLegacyRevlog(result.log, card.cardId),
+    revlog: fromLegacyRevlog(result.log, card),
   }
 }
 
@@ -124,23 +112,11 @@ export function legacyNext(
   )
 }
 
-export function legacyRollback(
-  options: DefaultSchedulerOptions,
-  result: ReviewResult
-): Card {
-  return new FSRS(toLegacyParameters(options)).rollback(
-    toLegacyCard(result.card),
-    toLegacyRevlog(result.revlog)
-  )
-}
-
 export function expectRollbackParity(
   actual: DefaultSchedulerCard,
-  expected: Card | DefaultSchedulerCard
+  expected: DefaultSchedulerCard
 ): void {
-  const expectedCard =
-    'cardId' in expected ? expected : fromLegacyCard(expected, actual.cardId)
-  expect(actual).toEqual(expectedCard)
+  expect(actual).toEqual(expected)
 }
 
 export function expectRevlogParity(

--- a/packages/fsrs/src/scheduler/default-scheduler.spec.ts
+++ b/packages/fsrs/src/scheduler/default-scheduler.spec.ts
@@ -18,6 +18,147 @@ import {
 import { createStateCard, DAY, NOW } from './default-scheduler.test-utils.js'
 
 describe('DefaultScheduler', () => {
+  it.each([
+    false,
+    true,
+  ])('restores persisted reviews with fuzz and short term %s', async (enableShortTerm) => {
+    const options = { enableShortTerm, enableFuzz: true }
+    const scheduler = await DefaultScheduler(options)
+    const reloaded = await DefaultScheduler(options)
+    let card = scheduler.newCard({
+      now: new Date('2026-01-01T00:00:00Z'),
+      cardId: 'persisted-rollback',
+    })
+    let seed = 12345
+    const grades = [
+      Rating.Again,
+      Rating.Hard,
+      Rating.Good,
+      Rating.Easy,
+    ] as const
+
+    for (let index = 0; index < 200; index += 1) {
+      seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0
+      const now = new Date(card.dueAt.getTime() + (seed % 240) * 3_600_000)
+      const result = scheduler.review({
+        card,
+        grade: grades[(seed >>> 24) % grades.length],
+        now,
+      })
+      const saved: typeof result = JSON.parse(
+        JSON.stringify(result),
+        (key, value: unknown) =>
+          ['dueAt', 'lastReviewAt', 'reviewTime'].includes(key) &&
+          typeof value === 'string'
+            ? new Date(value)
+            : value
+      )
+      expect(reloaded.rollback(saved)).toEqual(card)
+      card = result.card
+    }
+  })
+
+  it.each([
+    false,
+    true,
+  ])('unwinds a persisted history back to the new card with short term %s', async (enableShortTerm) => {
+    const options = { enableShortTerm, enableFuzz: true }
+    const scheduler = await DefaultScheduler(options)
+    const reloaded = await DefaultScheduler(options)
+    const initialCard = scheduler.newCard({
+      now: new Date('2026-01-01T00:00:00Z'),
+      cardId: 'unwind-rollback',
+    })
+    const grades = [
+      Rating.Again,
+      Rating.Hard,
+      Rating.Good,
+      Rating.Easy,
+    ] as const
+    const cardsBefore = [initialCard]
+    const results = []
+    let card = initialCard
+    let seed = 987_654_321
+
+    for (let index = 0; index < 50; index += 1) {
+      seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0
+      const result = scheduler.review({
+        card,
+        grade: grades[(seed >>> 24) % grades.length],
+        now: new Date(card.dueAt.getTime() + (seed % 240) * 3_600_000),
+      })
+
+      results.push(result)
+      card = result.card
+      cardsBefore.push(card)
+    }
+
+    const saved: typeof results = JSON.parse(
+      JSON.stringify(results),
+      (key, value: unknown) =>
+        ['dueAt', 'lastReviewAt', 'reviewTime'].includes(key) &&
+        typeof value === 'string'
+          ? new Date(value)
+          : value
+    )
+    let restored = reloaded.rollback(saved[saved.length - 1])
+
+    for (let index = saved.length - 1; index >= 0; index -= 1) {
+      expect(restored, `rollback #${index + 1}`).toEqual(cardsBefore[index])
+      if (index === 0) break
+      restored = reloaded.rollback({
+        card: restored,
+        revlog: saved[index - 1].revlog,
+      })
+    }
+
+    expect(restored).toEqual(initialCard)
+    expect(restored.lastReviewAt).toBeNull()
+    expect(restored.state).toBe(State.New)
+  })
+
+  it('distinguishes review histories with identical due dates and memory states', async () => {
+    const weights = Array.from(FSRS6_DEFAULT_WEIGHTS)
+    weights[0] = weights[1] = weights[4] = weights[5] = 1
+    const scheduler = await DefaultScheduler({
+      weights,
+      enableShortTerm: true,
+      enableFuzz: false,
+    })
+    const original = scheduler.newCard({
+      now: new Date('2026-01-01T00:00:00Z'),
+      cardId: 'same-due',
+    })
+    const firstA = scheduler.review({
+      card: original,
+      grade: Rating.Again,
+      now: new Date('2026-01-02T12:04:30Z'),
+    })
+    const firstB = scheduler.review({
+      card: original,
+      grade: Rating.Hard,
+      now: new Date('2026-01-02T12:00:00Z'),
+    })
+    const now = new Date('2026-01-03T12:00:00Z')
+    const secondA = scheduler.review({
+      card: firstA.card,
+      grade: Rating.Good,
+      now,
+    })
+    const secondB = scheduler.review({
+      card: firstB.card,
+      grade: Rating.Good,
+      now,
+    })
+
+    expect(firstA.card.dueAt).toEqual(firstB.card.dueAt)
+    expect(firstA.card.stability).toBe(firstB.card.stability)
+    expect(firstA.card.difficulty).toBe(firstB.card.difficulty)
+    expect(secondA.revlog.lastReviewAt).not.toEqual(secondB.revlog.lastReviewAt)
+    expect(scheduler.rollback(secondA)).toEqual(firstA.card)
+    expect(scheduler.rollback(secondB)).toEqual(firstB.card)
+  })
+
   describe('validation', () => {
     it('delegates review input validation to the scheduler core', async () => {
       const scheduler = await DefaultScheduler()

--- a/packages/fsrs/src/scheduler/public-types.spec.ts
+++ b/packages/fsrs/src/scheduler/public-types.spec.ts
@@ -83,6 +83,7 @@ describe('public scheduler types', () => {
         scheduleStatus: 'new' | 'learning' | 'review' | 'suspended'
         rating: Grade
         dueAt: Date
+        lastReviewAt: Date | null
         reviewTime: Date
         stability: number
         difficulty: number

--- a/packages/srs-kit/bench/chrono.bench.ts
+++ b/packages/srs-kit/bench/chrono.bench.ts
@@ -94,7 +94,7 @@ describe('dateChrono preset', () => {
   bench('default card', () => {
     dateChrono.defaultValue.card?.({
       config: { fractionalDays: false },
-      previous,
+      previous: later,
       time: now,
     })
   })
@@ -162,7 +162,7 @@ function describeTemporalInstant(
     bench('default card', () => {
       temporalInstantChrono.defaultValue.card?.({
         config,
-        previous,
+        previous: later,
         time: now,
       })
     })

--- a/packages/srs-kit/src/chrono/chrono.ts
+++ b/packages/srs-kit/src/chrono/chrono.ts
@@ -76,7 +76,9 @@ type ChronoSchemaFields<Env extends BlankChronoEnv> = ChronoPart<
 // Chrono Projection
 // ==========
 export interface ChronoTimeProjection<Time> {
-  readonly previous: Time
+  /** Previous event time, or null when no previous event exists. */
+  readonly previous: Time | null
+  /** Current entity time; Date/Temporal cards and revlogs project their due date. */
   readonly current: Time
 }
 
@@ -136,14 +138,22 @@ export type ChronoProjectionRuntimeSchema =
 // ==========
 // Chrono
 // ==========
-export interface ChronoDefaultCtx<Config, Value> {
+export interface ChronoDefaultCtx<
+  Config,
+  Value,
+  Key extends 'card' | 'revlog' = 'revlog',
+> {
   readonly config: Readonly<Config>
+  /** Due time being written: the next one for cards, the pre-review one for revlogs. */
   readonly time: Value
-  readonly previous?: Readonly<ChronoTimeProjection<Value>>
+  /** Cards receive one event time; revlogs receive a projection whose `current` is that event time. */
+  readonly previous?: Key extends 'card'
+    ? Value | null
+    : Readonly<ChronoTimeProjection<Value>>
 }
 
 export type ChronoDefaultRuntimeFn = (
-  ctx: ChronoDefaultCtx<unknown, unknown>
+  ctx: ChronoDefaultCtx<unknown, unknown, 'card'>
 ) => object
 
 export type AnyChronoSchema = {
@@ -169,7 +179,7 @@ type ChronoDefaultPart<
   : {
       readonly [K in Key]?: FieldDefault<
         ChronoFieldSchema<Env, Key>,
-        ChronoDefaultCtx<ChronoConfig<Env>, SchemaOutput<Env['time']>>
+        ChronoDefaultCtx<ChronoConfig<Env>, SchemaOutput<Env['time']>, Key>
       >
     }
 

--- a/packages/srs-kit/src/chrono/chrono.ts
+++ b/packages/srs-kit/src/chrono/chrono.ts
@@ -146,7 +146,7 @@ export interface ChronoDefaultCtx<
   readonly config: Readonly<Config>
   /** Due time being written: the next one for cards, the pre-review one for revlogs. */
   readonly time: Value
-  /** Cards receive one event time; revlogs receive a projection whose `current` is that event time. */
+  /** Cards receive one event time, null when none precedes; revlogs receive a projection whose `current` is that event time. */
   readonly previous?: Key extends 'card'
     ? Value | null
     : Readonly<ChronoTimeProjection<Value>>

--- a/packages/srs-kit/src/chrono/define-chrono.spec.ts
+++ b/packages/srs-kit/src/chrono/define-chrono.spec.ts
@@ -93,21 +93,22 @@ describe('defineChrono', () => {
       defaultValue: {
         card({ config, previous, time }) {
           expectTypeOf(config).toEqualTypeOf<Readonly<Record<string, never>>>()
-          expectTypeOf(previous).toEqualTypeOf<
-            | Readonly<{
-                readonly previous: number
-                readonly current: number
-              }>
-            | undefined
-          >()
+          expectTypeOf(previous).toEqualTypeOf<number | null | undefined>()
           expectTypeOf(time).toEqualTypeOf<number>()
 
           return {
-            previous: previous?.current ?? null,
+            previous: previous ?? null,
             current: time,
           }
         },
         revlog({ previous, time }) {
+          expectTypeOf(previous).toEqualTypeOf<
+            | Readonly<{
+                readonly previous: number | null
+                readonly current: number
+              }>
+            | undefined
+          >()
           return {
             elapsedDays: previous ? time - previous.current : 0,
           }

--- a/packages/srs-kit/src/chrono/define-chrono.type-display.spec.ts
+++ b/packages/srs-kit/src/chrono/define-chrono.type-display.spec.ts
@@ -58,10 +58,12 @@ describe('defineChrono type display', () => {
         readonly revlog: SRSSchema<{
             input: {
                 dueAt: Date;
+                lastReviewAt?: (Date | null) | undefined;
                 reviewTime: Date;
             };
             output: {
                 dueAt: Date;
+                lastReviewAt: Date | null;
                 reviewTime: Date;
             };
         }>;
@@ -96,10 +98,12 @@ describe('defineChrono type display', () => {
         readonly revlog: SRSSchema<{
             input: {
                 dueAt: Temporal.Instant;
+                lastReviewAt?: (Temporal.Instant | null) | undefined;
                 reviewTime: Temporal.Instant;
             };
             output: {
                 dueAt: Temporal.Instant;
+                lastReviewAt: Temporal.Instant | null;
                 reviewTime: Temporal.Instant;
             };
         }>;

--- a/packages/srs-kit/src/chrono/presets/date/chrono.spec.ts
+++ b/packages/srs-kit/src/chrono/presets/date/chrono.spec.ts
@@ -59,6 +59,7 @@ describe('dateChrono', () => {
     }>()
     expectTypeOf<ChronoRevlogOf<typeof dateChrono>>().toEqualTypeOf<{
       dueAt: Date
+      lastReviewAt: Date | null
       reviewTime: Date
     }>()
 
@@ -106,7 +107,7 @@ describe('dateChrono', () => {
         dueAt: now,
         reviewTime: later,
       })
-    ).toEqual({ dueAt: now, reviewTime: later })
+    ).toEqual({ dueAt: now, lastReviewAt: null, reviewTime: later })
     expect(() =>
       parse(dateChrono.schema.revlog, {
         dueAt: null,
@@ -127,10 +128,10 @@ describe('dateChrono', () => {
     expect(
       parse(dateChrono.projection, {
         card: {
-          dueAt: now,
+          dueAt: later,
           lastReviewAt: now,
         },
-        time: later,
+        time: new Date('2026-06-25T00:00:00.000Z'),
       })
     ).toEqual({ previous: now, current: later })
     expect(
@@ -141,7 +142,7 @@ describe('dateChrono', () => {
         },
         time: later,
       })
-    ).toEqual({ previous: now, current: later })
+    ).toEqual({ previous: null, current: now })
     expect(
       parse(dateChrono.projection, {
         card: parse(dateChrono.schema.card, {
@@ -150,7 +151,7 @@ describe('dateChrono', () => {
         }),
         time: later,
       })
-    ).toEqual({ previous: now, current: later })
+    ).toEqual({ previous: null, current: now })
     expect(
       parse(dateChrono.projection, {
         card: parse(dateChrono.schema.card, {
@@ -158,12 +159,13 @@ describe('dateChrono', () => {
         }),
         time: later,
       })
-    ).toEqual({ previous: now, current: later })
+    ).toEqual({ previous: null, current: now })
     expect(
       parse(dateChrono.projection, {
         revlog: {
-          dueAt: now,
-          reviewTime: later,
+          dueAt: later,
+          lastReviewAt: now,
+          reviewTime: new Date('2026-06-25T00:00:00.000Z'),
         },
       })
     ).toEqual({ previous: now, current: later })
@@ -196,6 +198,21 @@ describe('dateChrono', () => {
       })
     ).toThrow('Expected valid Date')
     expect(() => parse(dateChrono.schema.card, null)).toThrow()
+    expect(() => parse(dateChrono.schema.revlog, null)).toThrow()
+    expect(() =>
+      parse(dateChrono.schema.revlog, {
+        dueAt: now,
+        lastReviewAt: 'never',
+        reviewTime: later,
+      })
+    ).toThrow('Expected valid Date fields')
+    expect(() =>
+      parse(dateChrono.schema.revlog, {
+        dueAt: now,
+        lastReviewAt: now,
+        reviewTime: 'never',
+      })
+    ).toThrow('Expected valid Date fields')
     expect(() =>
       parse(dateChrono.schema.card, {
         dueAt: new Date(Number.NaN),
@@ -248,10 +265,7 @@ describe('dateChrono', () => {
       dateChrono.defaultValue.card!({
         config: { fractionalDays: false },
         time: now,
-        previous: {
-          previous: now,
-          current: later,
-        },
+        previous: later,
       })
     ).toEqual({ dueAt: now, lastReviewAt: later })
     expect(
@@ -260,22 +274,23 @@ describe('dateChrono', () => {
         time: now,
       })
     ).toEqual({ dueAt: now, lastReviewAt: null })
+    const dueAt = new Date('2026-06-19T00:00:00.000Z')
     expect(
       dateChrono.defaultValue.revlog!({
         config: { fractionalDays: false },
-        time: now,
+        time: dueAt,
         previous: {
           previous: now,
           current: later,
         },
       })
-    ).toEqual({ dueAt: now, reviewTime: later })
+    ).toEqual({ dueAt, lastReviewAt: now, reviewTime: later })
     expect(
       dateChrono.defaultValue.revlog!({
         config: { fractionalDays: false },
         time: now,
       })
-    ).toEqual({ dueAt: now, reviewTime: now })
+    ).toEqual({ dueAt: now, lastReviewAt: null, reviewTime: now })
   })
 
   it('compares only UTC calendar dates', () => {

--- a/packages/srs-kit/src/chrono/presets/date/chrono.ts
+++ b/packages/srs-kit/src/chrono/presets/date/chrono.ts
@@ -38,8 +38,8 @@ export const dateChrono = defineChrono({
 
       return {
         value: {
-          previous: card.value.lastReviewAt ?? card.value.dueAt,
-          current: time.value,
+          previous: card.value.lastReviewAt,
+          current: card.value.dueAt,
         },
       }
     }
@@ -51,8 +51,8 @@ export const dateChrono = defineChrono({
 
     return {
       value: {
-        previous: revlog.value.dueAt,
-        current: revlog.value.reviewTime,
+        previous: revlog.value.lastReviewAt,
+        current: revlog.value.dueAt,
       },
     }
   },
@@ -60,12 +60,13 @@ export const dateChrono = defineChrono({
     card({ previous, time }) {
       return {
         dueAt: time,
-        lastReviewAt: previous?.current ?? null,
+        lastReviewAt: previous ?? null,
       }
     },
     revlog({ time, previous }) {
       return {
-        dueAt: previous?.previous ?? time,
+        dueAt: time,
+        lastReviewAt: previous?.previous ?? null,
         reviewTime: previous?.current ?? time,
       }
     },

--- a/packages/srs-kit/src/chrono/presets/date/schema.ts
+++ b/packages/srs-kit/src/chrono/presets/date/schema.ts
@@ -13,8 +13,16 @@ export type DateCardOutputFields = {
   lastReviewAt: Date | null
 }
 
+export type DateRevlogInputFields = {
+  dueAt: Date
+  lastReviewAt?: Date | null
+  reviewTime: Date
+}
+
+/** Pre-review card timestamps plus the time of the recorded review. */
 export type DateRevlogFields = {
   dueAt: Date
+  lastReviewAt: Date | null
   reviewTime: Date
 }
 
@@ -54,17 +62,23 @@ export const dateCardFieldsSchema = defineSchema<
   }
 })
 
-export const dateRevlogFieldsSchema = defineSchema<DateRevlogFields>(
-  (value: unknown) => {
-    if (!isObject(value) || !('dueAt' in value) || !('reviewTime' in value)) {
-      return invalidDateFields()
-    }
-
-    const { dueAt, reviewTime } = value
-    if (!isValidDate(dueAt) || !isValidDate(reviewTime)) {
-      return invalidDateFields()
-    }
-
-    return { value: { dueAt, reviewTime } }
+export const dateRevlogFieldsSchema = defineSchema<
+  DateRevlogInputFields,
+  DateRevlogFields
+>((value) => {
+  if (!isObject(value) || !('reviewTime' in value)) {
+    return invalidDateFields()
   }
-)
+
+  const card = dateCardFieldsSchema['~standard'].validate(value)
+  if (card.issues) return card
+
+  const { reviewTime } = value
+  if (!isValidDate(reviewTime)) {
+    return invalidDateFields()
+  }
+
+  const revlog = card.value as DateRevlogFields
+  revlog.reviewTime = reviewTime
+  return { value: revlog }
+})

--- a/packages/srs-kit/src/chrono/presets/numeric/chrono.spec.ts
+++ b/packages/srs-kit/src/chrono/presets/numeric/chrono.spec.ts
@@ -56,7 +56,7 @@ describe('numericChrono', () => {
     })
     expect(projectionValue).toEqual({ previous: 0, current: 4.5 })
     const elapsed = difference(
-      projectionValue.previous,
+      projectionValue.previous ?? 0,
       projectionValue.current
     )
     expect(elapsed).toBe(4.5)

--- a/packages/srs-kit/src/chrono/presets/temporal-instant/chrono.spec.ts
+++ b/packages/srs-kit/src/chrono/presets/temporal-instant/chrono.spec.ts
@@ -58,6 +58,7 @@ describe('temporalInstantChrono', () => {
     }>()
     expectTypeOf<ChronoRevlogOf<typeof temporalInstantChrono>>().toEqualTypeOf<{
       dueAt: Temporal.Instant
+      lastReviewAt: Temporal.Instant | null
       reviewTime: Temporal.Instant
     }>()
 
@@ -143,7 +144,7 @@ describe('temporalInstantChrono', () => {
         dueAt: now,
         reviewTime: later,
       })
-    ).toEqual({ dueAt: now, reviewTime: later })
+    ).toEqual({ dueAt: now, lastReviewAt: null, reviewTime: later })
     expect(() =>
       parse(temporalInstantChrono.schema.revlog, {
         dueAt: null,
@@ -161,15 +162,12 @@ describe('temporalInstantChrono', () => {
         reviewTime: {},
       })
     ).toThrow('Expected Temporal.Instant fields')
-    expect(
-      parse(temporalInstantChrono.projection, {
-        card: {
-          dueAt: now,
-          lastReviewAt: now,
-        },
-        time: later,
-      })
-    ).toEqual({ previous: now, current: later })
+    const projection = parse(temporalInstantChrono.projection, {
+      card: { dueAt: later, lastReviewAt: now },
+      time: createInstant(NS_PER_DAY * 2n),
+    })
+    expect(projection.previous).toBe(now)
+    expect(projection.current).toBe(later)
     expect(
       parse(temporalInstantChrono.projection, {
         card: {
@@ -178,7 +176,7 @@ describe('temporalInstantChrono', () => {
         },
         time: later,
       })
-    ).toEqual({ previous: now, current: later })
+    ).toEqual({ previous: null, current: now })
     expect(
       parse(temporalInstantChrono.projection, {
         card: parse(temporalInstantChrono.schema.card, {
@@ -187,7 +185,7 @@ describe('temporalInstantChrono', () => {
         }),
         time: later,
       })
-    ).toEqual({ previous: now, current: later })
+    ).toEqual({ previous: null, current: now })
     expect(
       parse(temporalInstantChrono.projection, {
         card: parse(temporalInstantChrono.schema.card, {
@@ -195,12 +193,13 @@ describe('temporalInstantChrono', () => {
         }),
         time: later,
       })
-    ).toEqual({ previous: now, current: later })
+    ).toEqual({ previous: null, current: now })
     expect(
       parse(temporalInstantChrono.projection, {
         revlog: {
-          dueAt: now,
-          reviewTime: later,
+          dueAt: later,
+          lastReviewAt: now,
+          reviewTime: createInstant(NS_PER_DAY * 2n),
         },
       })
     ).toEqual({ previous: now, current: later })
@@ -235,6 +234,14 @@ describe('temporalInstantChrono', () => {
       })
     ).toThrow('Expected Temporal.Instant')
     expect(() => parse(temporalInstantChrono.schema.card, null)).toThrow()
+    expect(() => parse(temporalInstantChrono.schema.revlog, null)).toThrow()
+    expect(() =>
+      parse(temporalInstantChrono.schema.revlog, {
+        dueAt: now,
+        lastReviewAt: {},
+        reviewTime: later,
+      })
+    ).toThrow('Expected Temporal.Instant fields')
     expect(() =>
       parse(temporalInstantChrono.schema.card, {
         dueAt: {},
@@ -284,10 +291,7 @@ describe('temporalInstantChrono', () => {
       temporalInstantChrono.defaultValue.card!({
         config: temporalConfig,
         time: now,
-        previous: {
-          previous: now,
-          current: later,
-        },
+        previous: later,
       })
     ).toEqual({ dueAt: now, lastReviewAt: later })
     expect(
@@ -300,17 +304,16 @@ describe('temporalInstantChrono', () => {
       temporalInstantChrono.defaultValue.revlog!({
         config: temporalConfig,
         time: now,
-        previous: {
-          previous: now,
-          current: later,
-        },
       })
-    ).toEqual({ dueAt: now, reviewTime: later })
-    expect(
-      temporalInstantChrono.defaultValue.revlog!({
-        config: temporalConfig,
-        time: now,
-      })
-    ).toEqual({ dueAt: now, reviewTime: now })
+    ).toEqual({ dueAt: now, lastReviewAt: null, reviewTime: now })
+    const dueAt = createInstant(NS_PER_DAY / 2n)
+    const revlog = temporalInstantChrono.defaultValue.revlog!({
+      config: temporalConfig,
+      time: dueAt,
+      previous: { previous: now, current: later },
+    })
+    expect(revlog.dueAt).toBe(dueAt)
+    expect(revlog.lastReviewAt).toBe(now)
+    expect(revlog.reviewTime).toBe(later)
   })
 })

--- a/packages/srs-kit/src/chrono/presets/temporal-instant/chrono.ts
+++ b/packages/srs-kit/src/chrono/presets/temporal-instant/chrono.ts
@@ -68,8 +68,8 @@ export const temporalInstantChrono = defineChrono({
 
       return {
         value: {
-          previous: card.value.lastReviewAt ?? card.value.dueAt,
-          current: time.value,
+          previous: card.value.lastReviewAt,
+          current: card.value.dueAt,
         },
       }
     }
@@ -83,8 +83,8 @@ export const temporalInstantChrono = defineChrono({
 
     return {
       value: {
-        previous: revlog.value.dueAt,
-        current: revlog.value.reviewTime,
+        previous: revlog.value.lastReviewAt,
+        current: revlog.value.dueAt,
       },
     }
   },
@@ -92,12 +92,13 @@ export const temporalInstantChrono = defineChrono({
     card({ previous, time }) {
       return {
         dueAt: time,
-        lastReviewAt: previous?.current ?? null,
+        lastReviewAt: previous ?? null,
       }
     },
     revlog({ time, previous }) {
       return {
-        dueAt: previous?.previous ?? time,
+        dueAt: time,
+        lastReviewAt: previous?.previous ?? null,
         reviewTime: previous?.current ?? time,
       }
     },

--- a/packages/srs-kit/src/chrono/presets/temporal-instant/schema.ts
+++ b/packages/srs-kit/src/chrono/presets/temporal-instant/schema.ts
@@ -16,8 +16,16 @@ export type TemporalInstantCardOutputFields = {
   lastReviewAt: Temporal.Instant | null
 }
 
+export type TemporalInstantRevlogInputFields = {
+  dueAt: Temporal.Instant
+  lastReviewAt?: Temporal.Instant | null
+  reviewTime: Temporal.Instant
+}
+
+/** Pre-review card timestamps plus the time of the recorded review. */
 export type TemporalInstantRevlogFields = {
   dueAt: Temporal.Instant
+  lastReviewAt: Temporal.Instant | null
   reviewTime: Temporal.Instant
 }
 
@@ -118,23 +126,23 @@ export const temporalInstantCardFieldsSchema = defineSchema<
   return { value: { dueAt: dueAt.data, lastReviewAt: lastReviewAt.data } }
 })
 
-export const temporalInstantRevlogFieldsSchema =
-  defineSchema<TemporalInstantRevlogFields>((value) => {
-    if (!isObject(value) || !('dueAt' in value) || !('reviewTime' in value)) {
-      return invalidInstantFields()
-    }
+export const temporalInstantRevlogFieldsSchema = defineSchema<
+  TemporalInstantRevlogInputFields,
+  TemporalInstantRevlogFields
+>((value) => {
+  if (!isObject(value) || !('reviewTime' in value)) {
+    return invalidInstantFields()
+  }
 
-    const dueAt = temporalInstantSchema.safeParse(value.dueAt)
-    if (!dueAt.success) {
-      return invalidInstantFields()
-    }
+  const card = temporalInstantCardFieldsSchema['~standard'].validate(value)
+  if (card.issues) return card
 
-    const reviewTime = temporalInstantSchema.safeParse(value.reviewTime)
-    if (!reviewTime.success) {
-      return invalidInstantFields()
-    }
+  const reviewTime = temporalInstantSchema.safeParse(value.reviewTime)
+  if (!reviewTime.success) {
+    return invalidInstantFields()
+  }
 
-    return {
-      value: { dueAt: dueAt.data, reviewTime: reviewTime.data },
-    }
-  })
+  const revlog = card.value as TemporalInstantRevlogFields
+  revlog.reviewTime = reviewTime.data
+  return { value: revlog }
+})

--- a/packages/srs-kit/src/scheduler/base.spec.ts
+++ b/packages/srs-kit/src/scheduler/base.spec.ts
@@ -1716,6 +1716,38 @@ describe('SchedulerCore.rollback', () => {
     expect(restored.lastReviewAt).toBe(null)
   })
 
+  it('supplies the same missing-previous context on newCard and on new-card rollback', () => {
+    const seen: { readonly present: boolean; readonly value: unknown }[] = []
+    const cardDefault = dateChrono.defaultValue.card!
+    const spiedChrono = {
+      ...dateChrono,
+      defaultValue: {
+        ...dateChrono.defaultValue,
+        card(ctx: Parameters<typeof cardDefault>[0]) {
+          seen.push({ present: 'previous' in ctx, value: ctx.previous })
+          return cardDefault(ctx)
+        },
+      },
+    } as typeof dateChrono
+    const spiedCore = defineScheduler({
+      model: SM2Model,
+      chrono: spiedChrono,
+    }).create({ config })
+    const card = spiedCore.newCard({ now: new Date('2026-06-28T00:00:00Z') })
+    const reviewed = spiedCore.review({
+      card,
+      grade: Rating.Good,
+      now: new Date('2026-06-30T00:00:00Z'),
+    })
+
+    const restored = spiedCore.rollback(reviewed)
+
+    expect(reviewed.revlog.state).toBe(State.New)
+    expect(seen).toHaveLength(3)
+    expect(seen[2]).toEqual(seen[0])
+    expect(restored).toEqual(card)
+  })
+
   it('restores non-new chrono card fields from revlog projection', () => {
     const dateCore = defineScheduler({
       model: SM2Model,

--- a/packages/srs-kit/src/scheduler/base.spec.ts
+++ b/packages/srs-kit/src/scheduler/base.spec.ts
@@ -752,6 +752,45 @@ describe('SchedulerCore.review', () => {
 })
 
 describe('SchedulerCore middleware handlers', () => {
+  it('records projected due dates without changing elapsed days in review, preview, and forward', () => {
+    const elapsedDays: number[] = []
+    const elapsedMiddleware = defineMiddleware({
+      name: Symbol('capture-elapsed-days'),
+      handlers: {
+        review(ctx, next) {
+          elapsedDays.push(ctx.elapsedDays)
+          next()
+        },
+      },
+    })
+    const dateCore = defineScheduler({ model: SM2Model, chrono: dateChrono })
+      .use(elapsedMiddleware)
+      .create({ config })
+    const createdAt = new Date('2026-01-01T00:00:00Z')
+    const reviewedAt = new Date('2026-01-02T00:00:00Z')
+    const now = new Date('2026-01-10T00:00:00Z')
+    const card = dateCore.newCard({ now: createdAt })
+    expect(card.lastReviewAt).toBeNull()
+    const first = dateCore.review({ card, grade: Rating.Good, now: reviewedAt })
+    const records = [
+      dateCore.review({ card: first.card, grade: Rating.Good, now }),
+      ...dateCore.preview({ card: first.card, now }),
+      ...dateCore.forward({
+        initialCard: first.card,
+        history: [{ rating: Rating.Good, reviewTime: now }],
+      }),
+    ]
+
+    expect(elapsedDays).toEqual([0, 8, 8, 8, 8, 8, 8])
+    for (const result of records) {
+      expect(result.revlog.dueAt).toEqual(first.card.dueAt)
+      expect(result.revlog.lastReviewAt).toEqual(first.card.lastReviewAt)
+      expect(result.revlog.reviewTime).toEqual(now)
+      expect(result.card.lastReviewAt).toEqual(now)
+      expect(dateCore.rollback(result)).toEqual(first.card)
+    }
+  })
+
   it('applies review and preview chrono defaults after middleware unwinds', () => {
     const seen: unknown[] = []
     const middleware = defineMiddleware({
@@ -1707,8 +1746,8 @@ describe('SchedulerCore.rollback', () => {
     })
 
     expect(restored.scheduleStatus).toBe('review')
-    expect(restored.dueAt).toEqual(revlog.reviewTime)
-    expect(restored.lastReviewAt).toEqual(revlog.dueAt)
+    expect(restored.dueAt).toEqual(revlog.dueAt)
+    expect(restored.lastReviewAt).toEqual(revlog.lastReviewAt)
   })
 
   it('allows rollback when chrono card defaults are absent', () => {

--- a/packages/srs-kit/src/scheduler/base.ts
+++ b/packages/srs-kit/src/scheduler/base.ts
@@ -47,7 +47,7 @@ export interface BaseSchedulerContext<
 interface PreparedReview<Env extends BlankSchedulerEnv> {
   readonly card: Readonly<SchedulerCoreEnv<Env>['card']['output']>
   readonly time: {
-    readonly previous: SchedulerCoreEnv<Env>['chrono']
+    readonly previous: SchedulerCoreEnv<Env>['chrono'] | null
     readonly current: SchedulerCoreEnv<Env>['chrono']
   }
   readonly elapsedDays: number
@@ -416,7 +416,7 @@ export class BaseScheduler<
     const elapsedDays =
       card.state === State.New
         ? 0
-        : this.chrono.difference(time.previous, time.current)
+        : this.chrono.difference(time.previous ?? time.current, now)
 
     const retrievability = this.model.forgettingCurve(memoryState, elapsedDays)
     const memoryStateByGrade = new Map<Grade, Record<string, unknown>>()
@@ -560,25 +560,22 @@ export class BaseScheduler<
     prepared: PreparedReview<Env>,
     ctx: ReviewMiddlewareOperationContext<Env>
   ): void {
-    if (ctx.scheduledDays === undefined) {
+    const {
+      result,
+      scheduledDays,
+      input: { now },
+    } = ctx
+    if (scheduledDays === undefined) {
       throw new Error('Expected scheduledDays after review middleware')
     }
-    this.applyChronoDefaults(ctx.result, prepared, ctx.scheduledDays)
-  }
-
-  private applyChronoDefaults(
-    result: ReviewResultDraft<Env>,
-    prepared: PreparedReview<Env>,
-    scheduledDays: number
-  ): void {
     const chronoCardDefault = this.schedulerDefinition.chrono.defaultValue?.card
     if (chronoCardDefault) {
       Object.assign(
         result.card,
         chronoCardDefault({
           config: this.config,
-          time: this.chrono.add(prepared.time.current, scheduledDays),
-          previous: prepared.time,
+          time: this.chrono.add(now, scheduledDays),
+          previous: now,
         })
       )
     }
@@ -591,7 +588,7 @@ export class BaseScheduler<
         chronoRevlogDefault({
           config: this.config,
           time: prepared.time.current,
-          previous: prepared.time,
+          previous: { previous: prepared.time.previous, current: now },
         })
       )
     }
@@ -614,13 +611,8 @@ export class BaseScheduler<
     const isNew = revlog.state === State.New
     const cardFields = this.schedulerDefinition.chrono.defaultValue?.card?.({
       config: this.config,
-      previous: isNew
-        ? undefined
-        : {
-            previous: 0,
-            current: projection.previous,
-          },
-      time: isNew ? projection.previous : projection.current,
+      previous: isNew ? null : projection.previous,
+      time: projection.current,
     })
     if (cardFields) {
       Object.assign(result.card, cardFields)

--- a/packages/srs-kit/src/scheduler/default-value.ts
+++ b/packages/srs-kit/src/scheduler/default-value.ts
@@ -40,7 +40,7 @@ function applyNewCardDefaults(ctx: {
   readonly defaultValue: DefaultValueContext
   readonly middlewares: readonly AnyMiddleware[]
   readonly chronoDefault?: ChronoDefaultRuntimeFn
-  readonly time: ChronoDefaultCtx<unknown, unknown>['time']
+  readonly time: ChronoDefaultCtx<unknown, unknown, 'card'>['time']
 }) {
   const { target, defaultValue, middlewares, chronoDefault, time } = ctx
 

--- a/packages/srs-kit/src/scheduler/default-value.ts
+++ b/packages/srs-kit/src/scheduler/default-value.ts
@@ -50,6 +50,7 @@ function applyNewCardDefaults(ctx: {
       chronoDefault({
         config: defaultValue.config,
         time,
+        previous: null,
       })
     )
   }

--- a/packages/srs-kit/src/scheduler/rollback-due-at.spec.ts
+++ b/packages/srs-kit/src/scheduler/rollback-due-at.spec.ts
@@ -1,0 +1,299 @@
+import { describe, expect, it } from 'vitest'
+import { dateChrono } from '@/chrono/presets/date/chrono.js'
+import { temporalInstantChrono } from '@/chrono/presets/temporal-instant/chrono.js'
+import { SM2Model } from '@/model/sm2.test.js'
+import { Rating } from '@/primitives/index.js'
+import { defineScheduler } from './define-scheduler.js'
+import { config } from './scheduler.test.js'
+
+const dateDefinition = defineScheduler({
+  model: SM2Model,
+  chrono: dateChrono,
+})
+const dateCore = dateDefinition.create({ config })
+
+const CREATED_AT = new Date('2026-01-01T00:00:00.000Z')
+const FIRST_REVIEW = new Date('2026-01-02T00:00:00.000Z')
+const SECOND_REVIEW = new Date('2026-01-10T00:00:00.000Z')
+
+describe('rollback restores dueAt', () => {
+  it('after the first review of a new card', () => {
+    const card = dateCore.newCard({ now: CREATED_AT })
+    const reviewed = dateCore.review({
+      card,
+      grade: Rating.Good,
+      now: FIRST_REVIEW,
+    })
+
+    const restored = dateCore.rollback(reviewed)
+
+    expect(reviewed.revlog.lastReviewAt).toBeNull()
+    expect(restored.dueAt).toEqual(card.dueAt)
+    expect(restored.lastReviewAt).toBe(null)
+  })
+
+  it('after a second review, when the card carries lastReviewAt', () => {
+    const card = dateCore.newCard({ now: CREATED_AT })
+    const first = dateCore.review({
+      card,
+      grade: Rating.Good,
+      now: FIRST_REVIEW,
+    })
+    expect(first.card.lastReviewAt).toEqual(FIRST_REVIEW)
+
+    const second = dateCore.review({
+      card: first.card,
+      grade: Rating.Good,
+      now: SECOND_REVIEW,
+    })
+
+    expect(second.revlog.dueAt).toEqual(first.card.dueAt)
+    expect(second.revlog.lastReviewAt).toEqual(first.card.lastReviewAt)
+    expect(second.revlog.reviewTime).toEqual(SECOND_REVIEW)
+
+    const restored = dateCore.rollback(second)
+
+    expect(restored.dueAt).toEqual(first.card.dueAt)
+    expect(restored.lastReviewAt).toEqual(first.card.lastReviewAt)
+  })
+
+  it('for an overdue card, without pulling dueAt forward to the review time', () => {
+    const card = dateCore.newCard({ now: CREATED_AT })
+    const first = dateCore.review({
+      card,
+      grade: Rating.Good,
+      now: FIRST_REVIEW,
+    })
+    const dueBefore = first.card.dueAt
+    expect(dueBefore.getTime()).toBeLessThan(SECOND_REVIEW.getTime())
+
+    const second = dateCore.review({
+      card: first.card,
+      grade: Rating.Good,
+      now: SECOND_REVIEW,
+    })
+    const restored = dateCore.rollback(second)
+
+    expect(restored.dueAt).toEqual(dueBefore)
+    expect(restored.dueAt.getTime()).toBeLessThan(SECOND_REVIEW.getTime())
+  })
+
+  it('round-trips dueAt across a review/rollback cycle for any review count', () => {
+    let card = dateCore.newCard({ now: CREATED_AT })
+    let now = FIRST_REVIEW
+
+    for (let index = 0; index < 4; index += 1) {
+      const dueBefore = card.dueAt
+      const lastReviewBefore = card.lastReviewAt
+      const reviewed = dateCore.review({ card, grade: Rating.Good, now })
+
+      const restored = dateCore.rollback(reviewed)
+      expect(restored.dueAt, `review #${index + 1} dueAt`).toEqual(dueBefore)
+      expect(
+        restored.lastReviewAt,
+        `review #${index + 1} lastReviewAt`
+      ).toEqual(lastReviewBefore)
+
+      card = reviewed.card
+      now = new Date(now.getTime() + 5 * 24 * 60 * 60 * 1000)
+    }
+  })
+
+  it('rolls back both persisted reviews using a fresh scheduler', () => {
+    const card = dateCore.newCard({ now: CREATED_AT })
+    const first = dateCore.review({
+      card,
+      grade: Rating.Good,
+      now: FIRST_REVIEW,
+    })
+    const second = dateCore.review({
+      card: first.card,
+      grade: Rating.Good,
+      now: SECOND_REVIEW,
+    })
+    const saved: [typeof first, typeof second] = JSON.parse(
+      JSON.stringify([first, second]),
+      (key, value: unknown) =>
+        ['dueAt', 'lastReviewAt', 'reviewTime'].includes(key) &&
+        typeof value === 'string'
+          ? new Date(value)
+          : value
+    )
+    const reloaded = dateDefinition.create({ config })
+    const restored2 = reloaded.rollback(saved[1])
+    const restored1 = reloaded.rollback({
+      card: restored2,
+      revlog: saved[0].revlog,
+    })
+
+    expect(restored2).toEqual(first.card)
+    expect(restored1).toEqual(card)
+  })
+
+  it('unwinds a long review history back to the new card', () => {
+    const grades = [Rating.Again, Rating.Hard, Rating.Good, Rating.Easy]
+    const initialCard = dateCore.newCard({ now: CREATED_AT })
+    const cardsBefore = [initialCard]
+    const results = []
+    let card = initialCard
+    let now = FIRST_REVIEW
+
+    for (let index = 0; index < 20; index += 1) {
+      const grade = grades[index % grades.length]
+      const result = dateCore.review({ card, grade, now })
+
+      results.push(result)
+      card = result.card
+      cardsBefore.push(card)
+      now = new Date(card.dueAt.getTime() + (index % 5) * 3 * 60 * 60 * 1000)
+    }
+
+    const saved: typeof results = JSON.parse(
+      JSON.stringify(results),
+      (key, value: unknown) =>
+        ['dueAt', 'lastReviewAt', 'reviewTime'].includes(key) &&
+        typeof value === 'string'
+          ? new Date(value)
+          : value
+    )
+    const reloaded = dateDefinition.create({ config })
+    let restored = reloaded.rollback(saved[saved.length - 1])
+
+    for (let index = saved.length - 1; index >= 0; index -= 1) {
+      expect(restored, `rollback #${index + 1}`).toEqual(cardsBefore[index])
+      if (index === 0) break
+      restored = reloaded.rollback({
+        card: restored,
+        revlog: saved[index - 1].revlog,
+      })
+    }
+
+    expect(restored).toEqual(initialCard)
+  })
+
+  it('unwinds a long Temporal review history back to the new card', () => {
+    const definition = defineScheduler({
+      model: SM2Model,
+      chrono: temporalInstantChrono,
+    })
+    const settings = {
+      ...config,
+      timezone: 'America/New_York',
+      fractionalDays: false,
+    }
+    const core = definition.create({ config: settings })
+    const grades = [Rating.Good, Rating.Again, Rating.Easy, Rating.Hard]
+    const initialCard = core.newCard({
+      now: Temporal.Instant.from('2026-03-06T07:30:00.123456789Z'),
+    })
+    const cardsBefore = [initialCard]
+    const results = []
+    let card = initialCard
+    let now = Temporal.Instant.from('2026-03-07T07:30:00.234567891Z')
+
+    for (let index = 0; index < 20; index += 1) {
+      const result = core.review({
+        card,
+        grade: grades[index % grades.length],
+        now,
+      })
+
+      results.push(result)
+      card = result.card
+      cardsBefore.push(card)
+      now = card.dueAt.add({ hours: index % 7, nanoseconds: index + 1 })
+    }
+
+    const saved: typeof results = JSON.parse(
+      JSON.stringify(results),
+      (key, value: unknown) =>
+        ['dueAt', 'lastReviewAt', 'reviewTime'].includes(key) &&
+        typeof value === 'string'
+          ? Temporal.Instant.from(value)
+          : value
+    )
+    const reloaded = definition.create({ config: settings })
+    let restored = reloaded.rollback(saved[saved.length - 1])
+
+    for (let index = saved.length - 1; index >= 0; index -= 1) {
+      const expected = cardsBefore[index]
+      expect(restored.dueAt.epochNanoseconds, `rollback #${index + 1}`).toBe(
+        expected.dueAt.epochNanoseconds
+      )
+      expect(
+        restored.lastReviewAt?.epochNanoseconds ?? null,
+        `rollback #${index + 1} lastReviewAt`
+      ).toBe(expected.lastReviewAt?.epochNanoseconds ?? null)
+      expect(restored).toEqual(expected)
+      if (index === 0) break
+      restored = reloaded.rollback({
+        card: restored,
+        revlog: saved[index - 1].revlog,
+      })
+    }
+
+    expect(restored.lastReviewAt).toBeNull()
+  })
+
+  it('preserves an explicitly null previous review time on a non-new card', () => {
+    const first = dateCore.review({
+      card: dateCore.newCard({ now: CREATED_AT }),
+      grade: Rating.Good,
+      now: FIRST_REVIEW,
+    })
+    const card = { ...first.card, lastReviewAt: null }
+    const second = dateCore.review({
+      card,
+      grade: Rating.Good,
+      now: SECOND_REVIEW,
+    })
+
+    expect(second.revlog.lastReviewAt).toBeNull()
+    expect(dateCore.rollback(second)).toEqual(card)
+  })
+
+  it('restores persisted Temporal timestamps without losing nanoseconds', () => {
+    const definition = defineScheduler({
+      model: SM2Model,
+      chrono: temporalInstantChrono,
+    })
+    const settings = {
+      ...config,
+      timezone: 'America/New_York',
+      fractionalDays: false,
+    }
+    const core = definition.create({ config: settings })
+    const card = core.newCard({
+      now: Temporal.Instant.from('2026-03-06T07:30:00.123456789Z'),
+    })
+    const firstTime = Temporal.Instant.from('2026-03-07T07:30:00.234567891Z')
+    const first = core.review({ card, grade: Rating.Good, now: firstTime })
+    const second = core.review({
+      card: first.card,
+      grade: Rating.Good,
+      now: Temporal.Instant.from('2026-03-10T12:00:00.345678912Z'),
+    })
+    const saved: [typeof first, typeof second] = JSON.parse(
+      JSON.stringify([first, second]),
+      (key, value: unknown) =>
+        ['dueAt', 'lastReviewAt', 'reviewTime'].includes(key) &&
+        typeof value === 'string'
+          ? Temporal.Instant.from(value)
+          : value
+    )
+    const reloaded = definition.create({ config: settings })
+    const restored2 = reloaded.rollback(saved[1])
+    expect(restored2.dueAt.epochNanoseconds).toBe(
+      first.card.dueAt.epochNanoseconds
+    )
+    expect(restored2.lastReviewAt?.epochNanoseconds).toBe(
+      firstTime.epochNanoseconds
+    )
+    const restored1 = reloaded.rollback({
+      card: restored2,
+      revlog: saved[0].revlog,
+    })
+    expect(restored1.dueAt.epochNanoseconds).toBe(card.dueAt.epochNanoseconds)
+    expect(restored1.lastReviewAt).toBeNull()
+  })
+})


### PR DESCRIPTION
## Why

`scheduler.rollback(result)` could not restore a card's pre-review state. For a card that came due days ago and is reviewed today, rollback derived `dueAt` from `reviewTime` and pushed the due time forward to the moment of the review being undone — a due-ordered queue then drops the card to the very end. The pre-review due time was never recorded on the revlog, so no amount of replay could recover it (verified: fixing weights and re-running the full middleware chain does not reproduce the pre-review schedule).

The classic `FSRS` class has the same defect; its existing tests hid it by reviewing exactly at `card.due`.

## What changed

- Card and revlog chrono projections now return the same pair, `{ previous: lastReviewAt, current: dueAt }`. `ChronoTimeProjection.previous` is `Time | null`.
- The Date and Temporal.Instant presets persist `lastReviewAt` on the revlog. `revlog.dueAt` is now the card's due time **before** the review; `reviewTime` is the review instant.
- `ChronoDefaultCtx` gained a `Key extends 'card' | 'revlog'` generic: card defaults receive a single event time (or `null`), revlog defaults receive a projection whose `current` is the event time being recorded.
- `BaseScheduler` feeds those defaults accordingly on review/preview/forward and on rollback.
- `elapsedDays` is unchanged: `difference(previous ?? current, now)` still resolves to `lastReviewAt ?? dueAt` measured against the review time.

Chronologies still read only their own time fields — no `state` or middleware inspection, no new `chronoCard`, and `rollback()`'s public input is unchanged.

## Compatibility

Revlogs written before this change lack `lastReviewAt` and stored the previous `lastReviewAt` in `dueAt`. They parse with `lastReviewAt: null` and will not roll back exactly; the historical due time cannot be recovered because it was never persisted. Accepted for v6.

## Test plan

- New `packages/srs-kit/src/scheduler/rollback-due-at.spec.ts`: first/second review, overdue undo, N-cycle round trip, full unwind of a 20-review history back to the new card (Date and Temporal), all through JSON serialization and a fresh scheduler instance, with nanosecond checks for Temporal.
- New `packages/fsrs`: 200-round persisted rollback with fuzz for both short-term settings; 50-review full unwind back to the new card; a case where two histories share `dueAt`, stability and difficulty but differ in `lastReviewAt`, proving rollback discriminates them.
- Legacy parity tests now assert `rollback(review(card)) === card` instead of matching the classic implementation's incorrect result; `legacyRollback`/`toLegacyRevlog` removed.
- srs-kit: 238 passing, 100% statement/branch/function/line coverage. fsrs: 578 passing, 1 skipped. `tsc --noEmit` and `biome check` clean in both packages.
- Reverting the three source files under test makes all 9 new srs-kit cases fail, and swapping the `dueAt`/`lastReviewAt` mapping fails the Date preset spec.