### PR TITLE
fix: exclude website from changeset releases

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -27,5 +27,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@open-spaced-repetition/binding-test"]
+  "ignore": ["@open-spaced-repetition/binding-test", "@ts-fsrs/website"]
 }


### PR DESCRIPTION
Exclude `@ts-fsrs/website` from Changesets versioning by adding it to the existing ignore list. This prevents dependency updates from adding the private docs website to the release PR, as seen in #494.

Validation: compared Changesets status before and after the change. The website changes from `0.0.1-beta.0` to no version bump (`type: none`, `0.0.0`), while all other release entries remain unchanged. `git diff --check` passes.
